### PR TITLE
Improve hero image visuals

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -348,9 +348,8 @@ body:has(#menu-controller:checked) {
 }
 
 .single_hero {
-  background-repeat:no-repeat;
-  background-size:cover; 
-  background-position:center;
+  max-height: 50vh;
+  object-fit: cover;
 }
 
 .thumbnailshadow {

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -6,8 +6,8 @@
   {{- $featured := $images.GetMatch "*feature*" -}}
   {{- if not $featured }}{{ $featured = $images.GetMatch "{*cover*,*thumbnail*}" }}{{ end -}}
   {{- with $featured -}}
-    {{ with .Resize "600x" }}
-      <div class="w-full h-36 md:h-56 lg:h-72 single_hero nozoom" style="background-image:url({{ .RelPermalink }});"></div>
+    {{ with .Resize "1200x" }}
+      <img class="w-full rounded-lg single_hero nozoom" src="{{ .RelPermalink }}">
     {{ end }}
   {{- end -}}
   {{- end -}}


### PR DESCRIPTION
- Increase resized image. 600px was too low for a full width hero
- Added rounded corners
- Increased the height, by allowing the img to wrap it's contents (up until 50% viewport height)