### PR TITLE
fix: broken link and add: user website

### DIFF
--- a/exampleSite/content/users.md
+++ b/exampleSite/content/users.md
@@ -42,6 +42,7 @@ Real websites that are built with Blowfish.
 | [tabletopflore.com](https://www.tabletopflore.com)                    | Personal site                |
 | [omarohn.de](https://omarohn.de)                                      | Personal site                |
 | [spelucin.me](https://spelucin.me)                                    | Personal site                |
+| [insidemordecai.com](https://insidemordecai.com)                      | Personal site                |
 
 {{< alert >}}
 

--- a/exampleSite/content/users.md
+++ b/exampleSite/content/users.md
@@ -45,6 +45,6 @@ Real websites that are built with Blowfish.
 
 {{< alert >}}
 
-**Blowfish user?** To add your site to this list, [submit a pull request](https://github.com/nunocoracao/blowfish/blob/dev/exampleSite/content/users.md).
+**Blowfish user?** To add your site to this list, [submit a pull request](https://github.com/nunocoracao/blowfish/blob/main/exampleSite/content/users.md).
 
 {{</ alert >}}


### PR DESCRIPTION
Small change, the link under the Users page redirects to what I believe was a previous branch that is now non-existent

Also, added my personal site to the list. 