### PR TITLE
Allow overwriting of sharing links

### DIFF
--- a/data/sharing.json
+++ b/data/sharing.json
@@ -1,32 +1,34 @@
 {
-  "email": {
-    "icon": "email",
-    "title": "sharing.email",
-    "url": "mailto:?body=%s&subject=%s"
-  },
-  "facebook": {
-    "icon": "facebook",
-    "title": "sharing.facebook",
-    "url": "https://www.facebook.com/sharer/sharer.php?u=%s&quote=%s"
-  },
-  "linkedin": {
-    "icon": "linkedin",
-    "title": "sharing.linkedin",
-    "url": "https://www.linkedin.com/shareArticle?mini=true&url=%s&title=%s"
-  },
-  "pinterest": {
-    "icon": "pinterest",
-    "title": "sharing.pinterest",
-    "url": "https://pinterest.com/pin/create/bookmarklet/?url=%s&description=%s"
-  },
-  "reddit": {
-    "icon": "reddit",
-    "title": "sharing.reddit",
-    "url": "https://reddit.com/submit/?url=%s&resubmit=true&title=%s"
-  },
-  "twitter": {
-    "icon": "twitter",
-    "title": "sharing.twitter",
-    "url": "https://twitter.com/intent/tweet/?url=%s&text=%s"
+  "links": {
+    "email": {
+      "icon": "email",
+      "title": "sharing.email",
+      "url": "mailto:?body=%s&subject=%s"
+    },
+    "facebook": {
+      "icon": "facebook",
+      "title": "sharing.facebook",
+      "url": "https://www.facebook.com/sharer/sharer.php?u=%s&quote=%s"
+    },
+    "linkedin": {
+      "icon": "linkedin",
+      "title": "sharing.linkedin",
+      "url": "https://www.linkedin.com/shareArticle?mini=true&url=%s&title=%s"
+    },
+    "pinterest": {
+      "icon": "pinterest",
+      "title": "sharing.pinterest",
+      "url": "https://pinterest.com/pin/create/bookmarklet/?url=%s&description=%s"
+    },
+    "reddit": {
+      "icon": "reddit",
+      "title": "sharing.reddit",
+      "url": "https://reddit.com/submit/?url=%s&resubmit=true&title=%s"
+    },
+    "twitter": {
+      "icon": "twitter",
+      "title": "sharing.twitter",
+      "url": "https://twitter.com/intent/tweet/?url=%s&text=%s"
+    }
   }
 }

--- a/layouts/partials/sharing-links.html
+++ b/layouts/partials/sharing-links.html
@@ -1,8 +1,7 @@
 {{ with .Params.sharingLinks | default (.Site.Params.article.sharingLinks | default false) }}
-  {{ $links := site.Data.sharing }}
   <section class="flex flex-row flex-wrap justify-center pt-4 text-xl">
-    {{ range . }}
-      {{ with index $links . }}
+    {{ range $.Site.Data.sharing.links }}
+      {{ with . }}
         <a
           class="m-1 inline-block min-w-[2.4rem] rounded bg-neutral-300 p-1 text-center text-neutral-700 hover:bg-primary-500 hover:text-neutral dark:bg-neutral-700 dark:text-neutral-300 dark:hover:bg-primary-400 dark:hover:text-neutral-800"
           href="{{ printf .url $.Permalink $.Title }}"


### PR DESCRIPTION
This PR changes this by grouping the links within an object key: `Site.Data.sharing.links`. This means that sites can provide their own `data/sharing.json` file and overwrite the `links` key, to provide links of their own links.

Without the key, any custom links in `data/sharing.json` are appended, due to Hugo de-duping keys (not files).