### PR TITLE
Improve visuals of sharing links

### DIFF
--- a/assets/css/compiled/main.css
+++ b/assets/css/compiled/main.css
@@ -1866,8 +1866,8 @@ select {
   padding: 1rem;
 }
 
-.p-2 {
-  padding: 0.5rem;
+.p-1\.5 {
+  padding: 0.375rem;
 }
 
 .p-1 {

--- a/assets/css/compiled/main.css
+++ b/assets/css/compiled/main.css
@@ -1550,10 +1550,6 @@ select {
   min-width: 1.8rem;
 }
 
-.min-w-\[2\.4rem\] {
-  min-width: 2.4rem;
-}
-
 .min-w-\[220px\] {
   min-width: 220px;
 }
@@ -1868,6 +1864,10 @@ select {
 
 .p-4 {
   padding: 1rem;
+}
+
+.p-2 {
+  padding: 0.5rem;
 }
 
 .p-1 {

--- a/layouts/partials/icon.html
+++ b/layouts/partials/icon.html
@@ -1,6 +1,6 @@
 {{ $icon := resources.Get (print "icons/" . ".svg") }}
 {{ if $icon }}
-  <span class="relative inline-block align-text-bottom icon">
+  <span class="relative icon">
     {{ $icon.Content | safeHTML }}
   </span>
 {{ end }}

--- a/layouts/partials/icon.html
+++ b/layouts/partials/icon.html
@@ -1,6 +1,6 @@
 {{ $icon := resources.Get (print "icons/" . ".svg") }}
 {{ if $icon }}
-  <span class="relative icon p-2">
+  <span class="relative block icon p-1.5">
     {{ $icon.Content | safeHTML }}
   </span>
 {{ end }}

--- a/layouts/partials/icon.html
+++ b/layouts/partials/icon.html
@@ -1,6 +1,6 @@
 {{ $icon := resources.Get (print "icons/" . ".svg") }}
 {{ if $icon }}
-  <span class="relative icon">
+  <span class="relative icon p-2">
     {{ $icon.Content | safeHTML }}
   </span>
 {{ end }}

--- a/layouts/partials/sharing-links.html
+++ b/layouts/partials/sharing-links.html
@@ -4,7 +4,7 @@
       {{ with . }}
         <a
           target="_blank"
-          class="m-1 inline-block min-w-[2.4rem] rounded bg-neutral-300 p-1 text-center text-neutral-700 hover:bg-primary-500 hover:text-neutral dark:bg-neutral-700 dark:text-neutral-300 dark:hover:bg-primary-400 dark:hover:text-neutral-800"
+          class="m-1 rounded bg-neutral-300 p-1 text-neutral-700 hover:bg-primary-500 hover:text-neutral dark:bg-neutral-700 dark:text-neutral-300 dark:hover:bg-primary-400 dark:hover:text-neutral-800"
           href="{{ printf .url $.Permalink $.Title }}"
           title="{{ i18n .title }}"
           aria-label="{{ i18n .title }}"


### PR DESCRIPTION
The current sharing icons are currently anchored to the bottom with uneven visual padding around this. The PR changes them to be centred.

Current:
<img width="287" alt="Screenshot 2022-11-16 at 13 47 51" src="https://user-images.githubusercontent.com/227486/202197531-ec5274cc-eb49-4c8c-b213-019901a43489.png">

With PR:
<img width="282" alt="Screenshot 2022-11-17 at 10 15 30" src="https://user-images.githubusercontent.com/227486/202420480-32e45ff8-29b8-4e8d-aebd-b498e5bcae21.png">



