### PR TITLE
fix: add margin-bottom to 'the-top' element

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -28,7 +28,7 @@
       {{ if and (.Site.Params.footer.showScrollToTop | default true) (gt .WordCount 200) }}
       <div class="pointer-events-none absolute top-[100vh] bottom-0 w-12 ltr:right-0 rtl:left-0">
         <a href="#the-top"
-          class="pointer-events-auto sticky top-[calc(100vh-5.5rem)] flex h-12 w-12 items-center justify-center rounded-full bg-neutral/50 text-xl text-neutral-700 backdrop-blur hover:text-primary-600 dark:bg-neutral-800/50 dark:text-neutral dark:hover:text-primary-400"
+          class="pointer-events-auto sticky top-[calc(100vh-5.5rem)] flex h-12 w-12 mb-16 items-center justify-center rounded-full bg-neutral/50 text-xl text-neutral-700 backdrop-blur hover:text-primary-600 dark:bg-neutral-800/50 dark:text-neutral dark:hover:text-primary-400"
           aria-label="{{ i18n " nav.scroll_to_top_title" }}" title="{{ i18n " nav.scroll_to_top_title" }}">
           &uarr;
         </a>


### PR DESCRIPTION
Moved the scroll to top button to stop it from overlapping with footer text.
fixes #294 