### PR TITLE
💄 Improve resizing for article thumbnails

### DIFF
--- a/layouts/partials/article-link-card.html
+++ b/layouts/partials/article-link-card.html
@@ -13,7 +13,7 @@
       {{- $featured := $images.GetMatch "*feature*" -}}
       {{- if not $featured }}{{ $featured = $images.GetMatch "{*cover*,*thumbnail*}" }}{{ end -}}
       {{- with $featured -}}
-      {{ with .Resize "600x" }}
+      {{ with .Fill "600x600" }}
       <div class="w-full thumbnail_card nozoom" style="background-image:url({{ .RelPermalink }});"></div>
       {{ end }}
       {{- else -}}

--- a/layouts/partials/article-link.html
+++ b/layouts/partials/article-link.html
@@ -32,7 +32,7 @@
     {{- $featured := $images.GetMatch "*feature*" -}}
     {{- if not $featured }}{{ $featured = $images.GetMatch "{*cover*,*thumbnail*}" }}{{ end -}}
     {{- with $featured -}}
-    {{ with .Resize "600x" }}
+    {{ with .Fill "600x400" }}
     <div class="{{ $articleImageClasses }}" style="background-image:url({{ .RelPermalink }});"></div>
     {{ end }}
     {{- else -}}


### PR DESCRIPTION
Currently, the image is resized to be 600px, which will work for most images, but causes issues for images which have very wide aspect ratios. This change updates the partials to use a `Fill` with an appropriate bounding box, rather than a simple resize. The bounding box chosen roughly matches what the displayed aspect ratio ends up at.

You can read more about Fill [here](https://gohugo.io/content-management/image-processing/#fill).

To show an example, here's the current behavior for a wide image:
<img width="1079" alt="Screenshot 2022-12-15 at 18 29 33" src="https://user-images.githubusercontent.com/227486/207939406-87afbfa7-5c0b-48e1-b678-17041a44506c.png">

...and with this PR:

<img width="1054" alt="Screenshot 2022-12-15 at 18 27 55" src="https://user-images.githubusercontent.com/227486/207939444-20c330a1-5c01-4eec-8e2d-785ce4272838.png">