### PR TITLE
♻️ Add i18n for article series

### DIFF
--- a/i18n/bn.yaml
+++ b/i18n/bn.yaml
@@ -18,6 +18,9 @@ article:
   likes:
     one: "{{ .Count }} বার পছন্দ করা হয়েছে"
     other: "{{ .Count }} বার পছন্দ করা হয়েছে"
+  part_of_series: "This article is part of a series."
+  part: "Part"
+  this_article: "This Article"
 
 author:
   byline_title: "লেখক"

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -12,6 +12,9 @@ article:
   word_count:
    one: "{{ .Count }} Wort"
    other: "{{ .Count }} Wörter"
+  part_of_series: "This article is part of a series."
+  part: "Part"
+  this_article: "This Article"
 
 author:
   byline_title: "Autor"

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -18,6 +18,9 @@ article:
   likes:
     one: "{{ .Count }} like"
     other: "{{ .Count }} likes"
+  part_of_series: "This article is part of a series."
+  part: "Part"
+  this_article: "This Article"
 
 author:
   byline_title: "Author"

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -12,6 +12,9 @@ article:
   word_count:
     one: "{{ .Count }} palabra"
     other: "{{ .Count }} palabras"
+  part_of_series: "Este artículo es parte de una serie."
+  part: "Parte"
+  this_article: "Este artículo"
 
 author:
   byline_title: "Autor"

--- a/i18n/fi.yaml
+++ b/i18n/fi.yaml
@@ -12,6 +12,9 @@ article:
   word_count:
     one: "{{ .Count }} sana"
     other: "{{ .Count }} sanaa"
+  part_of_series: "This article is part of a series."
+  part: "Part"
+  this_article: "This Article"
 
 author:
   byline_title: "Kirjoittaja"

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -12,6 +12,9 @@ article:
   word_count:
     one: "{{ .Count }} mot"
     other: "{{ .Count }} mots"
+  part_of_series: "This article is part of a series."
+  part: "Part"
+  this_article: "This Article"
 
 author:
   byline_title: "Auteur"

--- a/i18n/he.yaml
+++ b/i18n/he.yaml
@@ -12,6 +12,9 @@ article:
   word_count:
     one: "{{ .Count }} מילה"
     other: "{{ .Count }} מילים"
+  part_of_series: "This article is part of a series."
+  part: "Part"
+  this_article: "This Article"
 
 author:
   byline_title: "מחבר"

--- a/i18n/hr.yaml
+++ b/i18n/hr.yaml
@@ -18,6 +18,9 @@ article:
   likes:
     one: "{{ .Count }} sviđa se"
     other: "{{ .Count }} sviđa se"
+  part_of_series: "This article is part of a series."
+  part: "Part"
+  this_article: "This Article"
 
 author:
   byline_title: "Autor"

--- a/i18n/hu.yaml
+++ b/i18n/hu.yaml
@@ -12,6 +12,9 @@ article:
   word_count:
     one: "{{ .Count }} szó"
     other: "{{ .Count }} szó"
+  part_of_series: "This article is part of a series."
+  part: "Part"
+  this_article: "This Article"
 
 author:
   byline_title: "Szerző"

--- a/i18n/id.yaml
+++ b/i18n/id.yaml
@@ -18,6 +18,9 @@ article:
   likes:
     one: "{{ .Count }} disukai"
     other: "{{ .Count }} disukai"
+  part_of_series: "This article is part of a series."
+  part: "Part"
+  this_article: "This Article"
 
 author:
   byline_title: "Penulis"

--- a/i18n/it.yaml
+++ b/i18n/it.yaml
@@ -12,6 +12,9 @@ article:
   word_count:
     one: "{{ .Count }} parola"
     other: "{{ .Count }} parole"
+  part_of_series: "This article is part of a series."
+  part: "Part"
+  this_article: "This Article"
 
 author:
   byline_title: "Autore"

--- a/i18n/ja.yaml
+++ b/i18n/ja.yaml
@@ -12,7 +12,10 @@ article:
   word_count:
     one: "{{ .Count }} 文字"
     other: "{{ .Count }} 文字"
-  
+  part_of_series: "This article is part of a series."
+  part: "Part"
+  this_article: "This Article"
+
 author:
   byline_title: "著者"
 

--- a/i18n/pl.yaml
+++ b/i18n/pl.yaml
@@ -18,6 +18,9 @@ article:
   likes:
     one: "{{ .Count }} polubienie"
     other: "{{ .Count }} polubień"
+  part_of_series: "This article is part of a series."
+  part: "Part"
+  this_article: "This Article"
 
 author:
   byline_title: "Autor"

--- a/i18n/pt-BR.yaml
+++ b/i18n/pt-BR.yaml
@@ -15,6 +15,9 @@ article:
   views:
     one: "{{ .Count }} visualização"
     other: "{{ .Count }} visualizaçōes"
+  part_of_series: "This article is part of a series."
+  part: "Part"
+  this_article: "This Article"
 
 author:
   byline_title: "Autor"

--- a/i18n/pt-PT.yaml
+++ b/i18n/pt-PT.yaml
@@ -15,6 +15,9 @@ article:
   views:
     one: "{{ .Count }} visualização"
     other: "{{ .Count }} visualizaçōes"
+  part_of_series: "This article is part of a series."
+  part: "Part"
+  this_article: "This Article"
 
 author:
   byline_title: "Autor"

--- a/i18n/ro.yaml
+++ b/i18n/ro.yaml
@@ -12,6 +12,9 @@ article:
   word_count:
     one: "{{ .Count }} cuvânt"
     other: "{{ .Count }} cuvinte"
+  part_of_series: "This article is part of a series."
+  part: "Part"
+  this_article: "This Article"
 
 author:
   byline_title: "Autor"

--- a/i18n/ru.yaml
+++ b/i18n/ru.yaml
@@ -18,6 +18,9 @@ article:
   likes:
     one: "{{ .Count }} нравится"
     other: "{{ .Count }} нравится"
+  part_of_series: "This article is part of a series."
+  part: "Part"
+  this_article: "This Article"
 
 author:
   byline_title: "Автор"

--- a/i18n/tr.yaml
+++ b/i18n/tr.yaml
@@ -11,6 +11,9 @@ article:
   word_count:
     one: "{{ .Count }} kelime"
     other: "{{ .Count }} kelime"
+  part_of_series: "This article is part of a series."
+  part: "Part"
+  this_article: "This Article"
 
 author:
   byline_title: "Yazar"

--- a/i18n/zh-CN.yaml
+++ b/i18n/zh-CN.yaml
@@ -11,6 +11,9 @@ article:
   word_count:
     one: "{{ .Count }} 字"
     other: "{{ .Count }} 字"
+  part_of_series: "This article is part of a series."
+  part: "Part"
+  this_article: "This Article"
 
 author:
   byline_title: "作者"

--- a/i18n/zh-TW.yaml
+++ b/i18n/zh-TW.yaml
@@ -11,6 +11,9 @@ article:
   word_count:
     one: "{{ .Count }} 字"
     other: "{{ .Count }} 字"
+  part_of_series: "This article is part of a series."
+  part: "Part"
+  this_article: "This Article"
 
 author:
   byline_title: "作者"

--- a/layouts/partials/series-closed.html
+++ b/layouts/partials/series-closed.html
@@ -2,19 +2,19 @@
 <details style="margin-left:0px" class="mt-2 mb-5 overflow-hidden rounded-lg ltr:-ml-5 ltr:pl-5 rtl:-mr-5 rtl:pr-5">
     <summary
         class="py-1 text-lg font-semibold cursor-pointer bg-primary-200 text-neutral-800 ltr:-ml-5 ltr:pl-5 rtl:-mr-5 rtl:pr-5 dark:bg-primary-800 dark:text-neutral-100">
-        {{ index .Params.series 0 }} - This article is part of a series.
+        {{ index .Params.series 0 }} - {{ i18n "article.part_of_series" }}
     </summary>
     {{ range $post := sort (index .Site.Taxonomies.series (index .Params.series 0 | urlize)) "Params.series_order" }}
     {{ if eq $post.Permalink $.Page.Permalink }}
     <div
         class="py-1 border-dotted border-neutral-300 ltr:-ml-5 ltr:border-l ltr:pl-5 rtl:-mr-5 rtl:border-r rtl:pr-5 dark:border-neutral-600">
-        Part {{ $post.Params.series_order }}: This Article
+        {{ i18n "article.part" }} {{ $post.Params.series_order }}: {{ i18n "article.this_article" }}
     </div>
     {{ else }}
     <div
         class="py-1 border-dotted border-neutral-300 ltr:-ml-5 ltr:border-l ltr:pl-5 rtl:-mr-5 rtl:border-r rtl:pr-5 dark:border-neutral-600">
         <a href="{{$post.Permalink}}">
-            Part {{ $post.Params.series_order }}: {{ $post.Params.title}}
+            {{ i18n "article.part" }} {{ $post.Params.series_order }}: {{ $post.Params.title}}
         </a>
     </div>
     {{end}}

--- a/layouts/partials/series.html
+++ b/layouts/partials/series.html
@@ -1,20 +1,21 @@
 {{ if .Params.series }}
-<details style="margin-left:0px" class="mt-2 mb-5 overflow-hidden rounded-lg ltr:-ml-5 ltr:pl-5 rtl:-mr-5 rtl:pr-5" {{ if .Params.seriesOpened | default (.Site.Params.article.seriesOpened | default false) }} open {{ end }}>
+<details style="margin-left:0px" class="mt-2 mb-5 overflow-hidden rounded-lg ltr:-ml-5 ltr:pl-5 rtl:-mr-5 rtl:pr-5" {{
+    if .Params.seriesOpened | default (.Site.Params.article.seriesOpened | default false) }} open {{ end }}>
     <summary
         class="py-1 text-lg font-semibold cursor-pointer bg-primary-200 text-neutral-800 ltr:-ml-5 ltr:pl-5 rtl:-mr-5 rtl:pr-5 dark:bg-primary-800 dark:text-neutral-100">
-        {{ index .Params.series 0 }} - This article is part of a series.
+        {{ index .Params.series 0 }} - {{ i18n "article.part_of_series" }}
     </summary>
     {{ range $post := sort (index .Site.Taxonomies.series (index .Params.series 0 | urlize)) "Params.series_order" }}
     {{ if eq $post.Permalink $.Page.Permalink }}
     <div
         class="py-1 border-dotted border-neutral-300 ltr:-ml-5 ltr:border-l ltr:pl-5 rtl:-mr-5 rtl:border-r rtl:pr-5 dark:border-neutral-600">
-        Part {{ $post.Params.series_order }}: This Article
+        {{ i18n "article.part" }} {{ $post.Params.series_order }}: {{ i18n "article.this_article" }}
     </div>
     {{ else }}
     <div
         class="py-1 border-dotted border-neutral-300 ltr:-ml-5 ltr:border-l ltr:pl-5 rtl:-mr-5 rtl:border-r rtl:pr-5 dark:border-neutral-600">
         <a href="{{$post.Permalink}}">
-            Part {{ $post.Params.series_order }}: {{ $post.Params.title}}
+            {{ i18n "article.part" }} {{ $post.Params.series_order }}: {{ $post.Params.title}}
         </a>
     </div>
     {{end}}


### PR DESCRIPTION
Replacing static text for `articles series` with entries in i18n. 

I'm using English for all i18n resources except Spanish (the only other language I know), because I don't like automatic translations as I can't verify if it's a good one. I know is not ideal, but other languages will keep showing as they were before this change