### PR TITLE
UTF-8 encoded series names support; small updates

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -6,6 +6,8 @@
 # baseURL = "https://your_domain.com/"
 defaultContentLanguage = "en"
 
+# pluralizeListTitles = "true"
+
 enableRobotsTXT = true
 paginate = 20
 summaryLength = 30

--- a/exampleSite/content/users/index.md
+++ b/exampleSite/content/users/index.md
@@ -53,6 +53,7 @@ Real websites that are built with Blowfish.
 | [sdehm.dev](https://sdehm.dev)                                        | Personal site                |
 | [dizzytech.de](https://dizzytech.de)                                  | Personal site                |
 | [blog.rotrixx.eu](https://blog.rotrixx.eu)                            | Personal site                |
+| [hexwiki.cz](https://hexwiki.cz/)                                     | Personal site                |
 
 
 

--- a/i18n/cs.yaml
+++ b/i18n/cs.yaml
@@ -18,7 +18,7 @@ article:
   likes:
     one: "{{ .Count }} líbí se mi"
     other: "{{ .Count }} líbí se mi"
-  part_of_series: "Tento článek patří do série."
+  part_of_series: "Tento článek patří do seriálu."
   part: "Část"
   this_article: "Tento článek"
 

--- a/layouts/partials/series-closed.html
+++ b/layouts/partials/series-closed.html
@@ -4,7 +4,9 @@
         class="py-1 text-lg font-semibold cursor-pointer bg-primary-200 text-neutral-800 ltr:-ml-5 ltr:pl-5 rtl:-mr-5 rtl:pr-5 dark:bg-primary-800 dark:text-neutral-100">
         {{ index .Params.series 0 }} - {{ i18n "article.part_of_series" }}
     </summary>
-    {{ range $post := sort (index .Site.Taxonomies.series (index .Params.series 0 | urlize)) "Params.series_order" }}
+    {{ $seriesName := strings.ToLower (index .Params.series 0) }}
+    {{ $seriesNameURL := strings.Replace $seriesName " " "-" }}
+    {{ range $post := sort (index .Site.Taxonomies.series $seriesNameURL) "Params.series_order" }}
     {{ if eq $post.Permalink $.Page.Permalink }}
     <div
         class="py-1 border-dotted border-neutral-300 ltr:-ml-5 ltr:border-l ltr:pl-5 rtl:-mr-5 rtl:border-r rtl:pr-5 dark:border-neutral-600">

--- a/layouts/partials/series.html
+++ b/layouts/partials/series.html
@@ -5,7 +5,9 @@
         class="py-1 text-lg font-semibold cursor-pointer bg-primary-200 text-neutral-800 ltr:-ml-5 ltr:pl-5 rtl:-mr-5 rtl:pr-5 dark:bg-primary-800 dark:text-neutral-100">
         {{ index .Params.series 0 }} - {{ i18n "article.part_of_series" }}
     </summary>
-    {{ range $post := sort (index .Site.Taxonomies.series (index .Params.series 0 | urlize)) "Params.series_order" }}
+    {{ $seriesName := strings.ToLower (index .Params.series 0) }}
+    {{ $seriesNameURL := strings.Replace $seriesName " " "-" }}
+    {{ range $post := sort (index .Site.Taxonomies.series $seriesNameURL) "Params.series_order" }}
     {{ if eq $post.Permalink $.Page.Permalink }}
     <div
         class="py-1 border-dotted border-neutral-300 ltr:-ml-5 ltr:border-l ltr:pl-5 rtl:-mr-5 rtl:border-r rtl:pr-5 dark:border-neutral-600">


### PR DESCRIPTION
As I write in czech I noticed that when I use a czech word for series name with special characters like ě,č,ř etc. there will be no posts associated with the series. The problem was the _urlize_ function in the _series.html_ and _series-closed.html_ files:

`{{ range $post := sort (index .Site.Taxonomies.series (index .Params.series 0 | urlize)) "Params.series_order" }}`

Beside making the name lowercase and replacing spaces with hyphens it also changes non ASCII characters to URL friendly format (Čeština -> %C4%8Ce%C5%A1tina) and so the next function `{{ if eq $post.Permalink $.Page.Permalink }}` fails to match article with the series name.

I changed the code so that now it only makes the name lowercase and replace spaces with hyphens.

Also default Hugo behavior of pluralizing list names isn't realy friendly to non-english languages, so I added the option to turn it of in _config.toml_