### PR TITLE
:sparkles: Support for UTF-8 encoded series names; small updates

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -6,6 +6,8 @@
 # baseURL = "https://your_domain.com/"
 defaultContentLanguage = "en"
 
+# pluralizeListTitles = "true"
+
 enableRobotsTXT = true
 paginate = 20
 summaryLength = 30

--- a/exampleSite/content/users/index.md
+++ b/exampleSite/content/users/index.md
@@ -53,6 +53,7 @@ Real websites that are built with Blowfish.
 | [sdehm.dev](https://sdehm.dev)                                        | Personal site                |
 | [dizzytech.de](https://dizzytech.de)                                  | Personal site                |
 | [blog.rotrixx.eu](https://blog.rotrixx.eu)                            | Personal site                |
+| [hexwiki.cz](https://hexwiki.cz/)                                     | Personal site                |
 
 
 

--- a/i18n/cs.yaml
+++ b/i18n/cs.yaml
@@ -18,7 +18,7 @@ article:
   likes:
     one: "{{ .Count }} líbí se mi"
     other: "{{ .Count }} líbí se mi"
-  part_of_series: "Tento článek patří do seriálu."
+  part_of_series: "Tento článek patří do série."
   part: "Část"
   this_article: "Tento článek"
 

--- a/i18n/cs.yaml
+++ b/i18n/cs.yaml
@@ -18,7 +18,7 @@ article:
   likes:
     one: "{{ .Count }} líbí se mi"
     other: "{{ .Count }} líbí se mi"
-  part_of_series: "Tento článek patří do série."
+  part_of_series: "Tento článek patří do seriálu."
   part: "Část"
   this_article: "Tento článek"
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -25,7 +25,7 @@
   <div class="relative flex flex-col grow">
     <main id="main-content" class="grow">
       {{ block "main" . }}{{ end }}
-      {{ if and (.Site.Params.footer.showScrollToTop | default true) }}
+      {{ if and (.Site.Params.footer.showScrollToTop | default true) (gt .WordCount 1) }}
       <div class="pointer-events-none absolute top-[100vh] bottom-0 w-12 ltr:right-0 rtl:left-0">
         <a href="#the-top"
           class="pointer-events-auto sticky top-[calc(100vh-5.5rem)] flex h-12 w-12 mb-16 items-center justify-center rounded-full bg-neutral/50 text-xl text-neutral-700 backdrop-blur hover:text-primary-600 dark:bg-neutral-800/50 dark:text-neutral dark:hover:text-primary-400"

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -25,7 +25,7 @@
   <div class="relative flex flex-col grow">
     <main id="main-content" class="grow">
       {{ block "main" . }}{{ end }}
-      {{ if and (.Site.Params.footer.showScrollToTop | default true) (gt .WordCount 200) }}
+      {{ if and (.Site.Params.footer.showScrollToTop | default true) }}
       <div class="pointer-events-none absolute top-[100vh] bottom-0 w-12 ltr:right-0 rtl:left-0">
         <a href="#the-top"
           class="pointer-events-auto sticky top-[calc(100vh-5.5rem)] flex h-12 w-12 mb-16 items-center justify-center rounded-full bg-neutral/50 text-xl text-neutral-700 backdrop-blur hover:text-primary-600 dark:bg-neutral-800/50 dark:text-neutral dark:hover:text-primary-400"

--- a/layouts/partials/series-closed.html
+++ b/layouts/partials/series-closed.html
@@ -4,7 +4,9 @@
         class="py-1 text-lg font-semibold cursor-pointer bg-primary-200 text-neutral-800 ltr:-ml-5 ltr:pl-5 rtl:-mr-5 rtl:pr-5 dark:bg-primary-800 dark:text-neutral-100">
         {{ index .Params.series 0 }} - {{ i18n "article.part_of_series" }}
     </summary>
-    {{ range $post := sort (index .Site.Taxonomies.series (index .Params.series 0 | urlize)) "Params.series_order" }}
+    {{ $seriesName := strings.ToLower (index .Params.series 0) }}
+    {{ $seriesNameURL := strings.Replace $seriesName " " "-" }}
+    {{ range $post := sort (index .Site.Taxonomies.series $seriesNameURL) "Params.series_order" }}
     {{ if eq $post.Permalink $.Page.Permalink }}
     <div
         class="py-1 border-dotted border-neutral-300 ltr:-ml-5 ltr:border-l ltr:pl-5 rtl:-mr-5 rtl:border-r rtl:pr-5 dark:border-neutral-600">

--- a/layouts/partials/series.html
+++ b/layouts/partials/series.html
@@ -5,7 +5,9 @@
         class="py-1 text-lg font-semibold cursor-pointer bg-primary-200 text-neutral-800 ltr:-ml-5 ltr:pl-5 rtl:-mr-5 rtl:pr-5 dark:bg-primary-800 dark:text-neutral-100">
         {{ index .Params.series 0 }} - {{ i18n "article.part_of_series" }}
     </summary>
-    {{ range $post := sort (index .Site.Taxonomies.series (index .Params.series 0 | urlize)) "Params.series_order" }}
+    {{ $seriesName := strings.ToLower (index .Params.series 0) }}
+    {{ $seriesNameURL := strings.Replace $seriesName " " "-" }}
+    {{ range $post := sort (index .Site.Taxonomies.series $seriesNameURL) "Params.series_order" }}
     {{ if eq $post.Permalink $.Page.Permalink }}
     <div
         class="py-1 border-dotted border-neutral-300 ltr:-ml-5 ltr:border-l ltr:pl-5 rtl:-mr-5 rtl:border-r rtl:pr-5 dark:border-neutral-600">


### PR DESCRIPTION
As I write in czech, I noticed that when I use UTF-8 encoded characters (š,ř,ž etc.) in a series name, it won't associate it with any articles. The problem is in the _urlize_ function in the _series.html_ and _series-closed.html_ files.

`{{ range $post := sort (index .Site.Taxonomies.series (index .Params.series 0 | urlize)) "Params.series_order" }}`

Besides converting the name lowercase and replacing spaces with hyphens it also changes non ASCII characters to URL friendly format (Čeština -> %C4%8Ce%C5%A1tina). That leads to the inability of the next function: `{{ if eq $post.Permalink $.Page.Permalink }}` to match series names with corresponding posts.

So I changed the code so that now it only converts the name to lowercase and replaces spaces with hyphens.

I also added my personal website, changed one word in the czech translation and added an option to depluralize list names in _config.toml_ file. The last change is useful for non english languages because the pluralize funcition messes up names in other languages.