### PR TITLE
:bug: Fix header with disabled logo on mobile

### DIFF
--- a/layouts/partials/header/fixed.html
+++ b/layouts/partials/header/fixed.html
@@ -1,7 +1,7 @@
 <div class="min-h-[148px]"></div>
-<div class="fixed inset-x-0 h-[120px] pl-[24px] pr-[24px] sbackdrop-blur-xl sshadown-2xl" style="z-index:100">
+<div class="fixed inset-x-0 pl-[24px] pr-[24px] sbackdrop-blur-xl sshadown-2xl" style="z-index:100">
   <div id="menu-blur" class="absolute opacity-0 inset-x-0 top-0 h-full single_hero_background nozoom backdrop-blur-2xl shadow-2xl"></div>
-  <div class="relative max-w-[64rem] h-[100px] ml-auto mr-auto">
+  <div class="relative max-w-[64rem] ml-auto mr-auto">
     {{ partial "partials/header/basic.html" . }}
   </div>
 </div>


### PR DESCRIPTION
closes #363 

i just changed the height of the header to be automatic

how it was before my change:
![image](https://user-images.githubusercontent.com/44976946/210178268-29add82a-03bd-4907-8bed-a8676ea6680a.png)

how it is after my change:
![image](https://user-images.githubusercontent.com/44976946/210178281-ac03bad4-7e02-4b2e-9537-155b206ce047.png)