### PR TITLE
:adhesive_bandage: :wheelchair: Fix missing title attribute from search button

### DIFF
--- a/layouts/partials/header/basic.html
+++ b/layouts/partials/header/basic.html
@@ -38,7 +38,7 @@
 
             {{ if .Site.Params.enableSearch | default false }}
             <button id="search-button" class="text-base hover:text-primary-600 dark:hover:text-primary-400"
-                title="{{ i18n " search.open_button_title" }}">
+                title="{{ i18n "search.open_button_title" }}">
                 {{ partial "icon.html" "search" }}
             </button>
             {{ end }}
@@ -68,7 +68,7 @@
 
             {{ if .Site.Params.enableSearch | default false }}
             <button id="search-button-mobile" class="text-base hover:text-primary-600 dark:hover:text-primary-400"
-                title="{{ i18n " search.open_button_title" }}">
+                title="{{ i18n "search.open_button_title" }}">
                 {{ partial "icon.html" "search" }}
             </button>
             {{ end }}


### PR DESCRIPTION
This was caused by an extra space before an enquoted identifier, causing the i18n lookup to fail.