### PR TITLE
Extract the "scroll to top" section as a partial

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -26,13 +26,7 @@
     <main id="main-content" class="grow">
       {{ block "main" . }}{{ end }}
       {{ if and (.Site.Params.footer.showScrollToTop | default true) (gt .WordCount 1) }}
-      <div class="pointer-events-none absolute top-[100vh] bottom-0 w-12 ltr:right-0 rtl:left-0">
-        <a href="#the-top"
-          class="pointer-events-auto sticky top-[calc(100vh-5.5rem)] flex h-12 w-12 mb-16 items-center justify-center rounded-full bg-neutral/50 text-xl text-neutral-700 backdrop-blur hover:text-primary-600 dark:bg-neutral-800/50 dark:text-neutral dark:hover:text-primary-400"
-          aria-label="{{ i18n " nav.scroll_to_top_title" }}" title="{{ i18n " nav.scroll_to_top_title" }}">
-          &uarr;
-        </a>
-      </div>
+      {{- partial "scroll-to-top.html" . -}}
       {{ end }}
     </main>
     {{- partial "footer.html" . -}}

--- a/layouts/partials/scroll-to-top.html
+++ b/layouts/partials/scroll-to-top.html
@@ -1,0 +1,7 @@
+<div class="pointer-events-none absolute top-[100vh] bottom-0 w-12 ltr:right-0 rtl:left-0">
+  <a href="#the-top"
+    class="pointer-events-auto sticky top-[calc(100vh-5.5rem)] flex h-12 w-12 mb-16 items-center justify-center rounded-full bg-neutral/50 text-xl text-neutral-700 backdrop-blur hover:text-primary-600 dark:bg-neutral-800/50 dark:text-neutral dark:hover:text-primary-400"
+    aria-label="{{ i18n " nav.scroll_to_top_title" }}" title="{{ i18n " nav.scroll_to_top_title" }}">
+    &uarr;
+  </a>
+</div>


### PR DESCRIPTION
This PR simply extracts the existing "scroll to top" section of code into a dedicated partial and then calls that in place.

The problem this solves is that it allows for easier customization of the icon. Personally, I don't like the plain arrow and on my website I implemented a circular button with an arrow up (like a fab). To do so, I had to override the `baseof` partial which is tricky as it can break with future updates. Extracting it as a partial makes it easy to just dump some new html code in the `layouts/partials/scroll-to-top.html` file in my repo to integrate more nicely with the theme.