### PR TITLE
🐛 Icon not centered in alert shortcode

### DIFF
--- a/layouts/shortcodes/alert.html
+++ b/layouts/shortcodes/alert.html
@@ -1,5 +1,5 @@
 <div class="flex px-4 py-3 rounded-md bg-primary-100 dark:bg-primary-900">
-  <span class="text-primary-400 ltr:pr-3 rtl:pl-3">
+  <span class="text-primary-400 ltr:pr-3 rtl:pl-3 flex items-center">
     {{ partial "icon.html" (.Get 0 | default "triangle-exclamation") }}
   </span>
   <span class="dark:text-neutral-300">


### PR DESCRIPTION
Fixes #452 

## Example:

Before:

![image](https://user-images.githubusercontent.com/28601784/212733951-dfefd85f-54b5-42df-9c15-d175168302f3.png)


After:

![image](https://user-images.githubusercontent.com/28601784/212733984-f70932a9-065e-4247-9fd5-33f272746e4d.png)
