### PR TITLE
✨ Shortcode `carousel`: add optional parameter for scroll duration

### DIFF
--- a/exampleSite/content/docs/shortcodes/index.md
+++ b/exampleSite/content/docs/shortcodes/index.md
@@ -106,7 +106,7 @@ Call to action
 | ------------- | ----------------------------------------------------------------------------------------------------------------- |
 | `images`      | **Required.** A regex string to match image names.                                                                |
 | `aspectRatio` | **Optional.** The aspect ratio for the carousel. Either `16-9`, `21-9` or `32-9`. It is set to `16-9` by default. |
-| `duration`    | **Optional.** The duration for the auto-scrooling, specified in milliseconds. Defaults to `2000` (2s)             |
+| `interval`    | **Optional.** The interval for the auto-scrooling, specified in milliseconds. Defaults to `2000` (2s)             |
 <!-- prettier-ignore-end -->
 
 **Example 1:** 16:9 aspect ratio and verbose list of images
@@ -120,10 +120,10 @@ Call to action
 **Example 2:** 21:9 aspect ratio and regex-ed list of images
 
 ```md
-{{</* carousel images="gallery/*" aspectRatio="21-9" duration="2500" */>}}
+{{</* carousel images="gallery/*" aspectRatio="21-9" interval="2500" */>}}
 ```
 
-{{< carousel images="gallery/*" aspectRatio="21-9" duration="2500" >}}
+{{< carousel images="gallery/*" aspectRatio="21-9" interval="2500" >}}
 
 <br/><br/><br/>
 

--- a/exampleSite/content/docs/shortcodes/index.md
+++ b/exampleSite/content/docs/shortcodes/index.md
@@ -101,12 +101,12 @@ Call to action
 
 `carousel` is used to showcase multiple images in an interactive and visually appealing way. This allows a user to slide through multiple images while only taking up the vertical space of a single one. All images are displayed using the full width of the parent component and using one of the predefined aspect ratios of `16:9`, `21:9` or `32:9`.
 
-
 <!-- prettier-ignore-start -->
 | Parameter     | Description                                                                                                       |
 | ------------- | ----------------------------------------------------------------------------------------------------------------- |
 | `images`      | **Required.** A regex string to match image names.                                                                |
 | `aspectRatio` | **Optional.** The aspect ratio for the carousel. Either `16-9`, `21-9` or `32-9`. It is set to `16-9` by default. |
+| `duration`    | **Optional.** The duration for the auto-scrooling, specified in milliseconds. Defaults to `2000` (2s)             |
 <!-- prettier-ignore-end -->
 
 **Example 1:** 16:9 aspect ratio and verbose list of images
@@ -120,10 +120,10 @@ Call to action
 **Example 2:** 21:9 aspect ratio and regex-ed list of images
 
 ```md
-{{</* carousel images="gallery/*" aspectRatio="21-9" */>}}
+{{</* carousel images="gallery/*" aspectRatio="21-9" duration="2500" */>}}
 ```
 
-{{< carousel images="gallery/*" aspectRatio="21-9" >}}
+{{< carousel images="gallery/*" aspectRatio="21-9" duration="2500" >}}
 
 <br/><br/><br/>
 

--- a/layouts/shortcodes/carousel.html
+++ b/layouts/shortcodes/carousel.html
@@ -2,7 +2,7 @@
 {{ $id := delimit (slice "gallery" $time) "-" }}
 {{ $aspect := default "16-9" (.Get "aspectRatio") }}
 {{ $images := .Page.Resources.Match (.Get "images") }}
-{{ $durationMillis := default "2000" (.Get "durationMillis") }}
+{{ $duration := default "2000" (.Get "duration") }}
 
 <div id="{{ $id }}" class="carousel slide relative" data-bs-ride="carousel">
     <div class="carousel-indicators absolute right-0 bottom-0 left-0 flex justify-center p-0 mb-2">
@@ -24,7 +24,7 @@
 
         <div class="carousel-item {{ if eq $num 0 }} active {{ end }} relative float-left w-full ratio-{{ $aspect }} single_hero_background"
             style="background-image:url({{ . }})"
-            data-bs-interval="{{ $durationMillis }}"
+            data-bs-interval="{{ $duration }}"
         ></div>
         {{ $num = add $num 1 }}
         {{ end }}

--- a/layouts/shortcodes/carousel.html
+++ b/layouts/shortcodes/carousel.html
@@ -2,7 +2,7 @@
 {{ $id := delimit (slice "gallery" $time) "-" }}
 {{ $aspect := default "16-9" (.Get "aspectRatio") }}
 {{ $images := .Page.Resources.Match (.Get "images") }}
-{{ $randomDuration := add (mod (add (mul 13 $time) 97) 1000) 2000 }}
+{{ $durationMillis := default "2000" (.Get "durationMillis") }}
 
 <div id="{{ $id }}" class="carousel slide relative" data-bs-ride="carousel">
     <div class="carousel-indicators absolute right-0 bottom-0 left-0 flex justify-center p-0 mb-2">
@@ -24,7 +24,7 @@
 
         <div class="carousel-item {{ if eq $num 0 }} active {{ end }} relative float-left w-full ratio-{{ $aspect }} single_hero_background"
             style="background-image:url({{ . }})"
-            data-bs-interval="{{ $randomDuration }}"
+            data-bs-interval="{{ $durationMillis }}"
         ></div>
         {{ $num = add $num 1 }}
         {{ end }}

--- a/layouts/shortcodes/carousel.html
+++ b/layouts/shortcodes/carousel.html
@@ -2,6 +2,7 @@
 {{ $id := delimit (slice "gallery" $time) "-" }}
 {{ $aspect := default "16-9" (.Get "aspectRatio") }}
 {{ $images := .Page.Resources.Match (.Get "images") }}
+{{ $randomDuration := add (mod (add (mul 13 $time) 97) 1000) 2000 }}
 
 <div id="{{ $id }}" class="carousel slide relative" data-bs-ride="carousel">
     <div class="carousel-indicators absolute right-0 bottom-0 left-0 flex justify-center p-0 mb-2">
@@ -23,6 +24,7 @@
 
         <div class="carousel-item {{ if eq $num 0 }} active {{ end }} relative float-left w-full ratio-{{ $aspect }} single_hero_background"
             style="background-image:url({{ . }})"
+            data-bs-interval="{{ $randomDuration }}"
         ></div>
         {{ $num = add $num 1 }}
         {{ end }}

--- a/layouts/shortcodes/carousel.html
+++ b/layouts/shortcodes/carousel.html
@@ -2,7 +2,7 @@
 {{ $id := delimit (slice "gallery" $time) "-" }}
 {{ $aspect := default "16-9" (.Get "aspectRatio") }}
 {{ $images := .Page.Resources.Match (.Get "images") }}
-{{ $duration := default "2000" (.Get "duration") }}
+{{ $interval := default "2000" (.Get "interval") }}
 
 <div id="{{ $id }}" class="carousel slide relative" data-bs-ride="carousel">
     <div class="carousel-indicators absolute right-0 bottom-0 left-0 flex justify-center p-0 mb-2">
@@ -24,7 +24,7 @@
 
         <div class="carousel-item {{ if eq $num 0 }} active {{ end }} relative float-left w-full ratio-{{ $aspect }} single_hero_background"
             style="background-image:url({{ . }})"
-            data-bs-interval="{{ $duration }}"
+            data-bs-interval="{{ $interval }}"
         ></div>
         {{ $num = add $num 1 }}
         {{ end }}


### PR DESCRIPTION
Currently, if I have multiple `carousel` elements in the same page, they scroll more or less at the same time, which looks kind of bad.

This PR solves the problem by adding a pseudo-random time to each carousel to stagger them a bit, making the page look more "dynamic".

The base duration for scrolling is set to 2000 millis. On top of that, a pseudo-random number from `0` to `999` millis is added, to have random values in the `[2000, 2999]` range.