### PR TITLE
Hotfixed homepage card spillover on responsive displays

### DIFF
--- a/layouts/partials/home/card.html
+++ b/layouts/partials/home/card.html
@@ -12,8 +12,8 @@
                     <section>{{ .Content | emojify }}</section>
                   </article>
             </div>
-            <div class="mt-6 sm:mt-16 lg:mt-0">
-                <div class="-mr-48 pl-4 sm:pl-6 md:-mr-16 lg:relative lg:m-0 lg:h-full lg:px-0">
+            <div class="mt-6 sm:mt-16 lg:mt-0 mx-auto max-w-xl px-4 sm:px-6 lg:mx-0 lg:max-w-none lg:py-16 lg:px-0">
+                <div class="-mr-48 md:-mr-16 lg:relative lg:m-0 lg:h-full lg:px-0" style="width:100%">
                     {{ $homepageImage := "" }}
                     {{ with .Site.Params.defaultBackgroundImage }}{{ $homepageImage = resources.Get . }}{{ end }}
                     {{ with .Site.Params.homepage.homepageImage }}{{ $homepageImage = resources.Get . }}{{ end }}


### PR DESCRIPTION
This is my personal hotfix to #516 . It enforces width on the container for the image card, and replicates the content formatting for some amount of responsiveness. This is not intended as a true fix, but is potentially a start.

Remaining issue: scaling on iPad in the landscape view still spills over. Other views appear acceptable.