### PR TITLE
Ugly hotfix for iOS notch color

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -8,6 +8,9 @@
 colorScheme = "blowfish"
 defaultAppearance = "light" # valid options: light or dark
 autoSwitchAppearance = true
+# expose theme colors for iOS notch coloring (barring better options)
+iosLightOverride = "ffffff"
+iosDarkOverride = "1e313b"
 
 enableSearch = false
 enableCodeCopy = false

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -4,6 +4,8 @@
   <meta http-equiv="content-language" content="{{ . }}" />
   {{ end }}
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="theme-color" content="#{{ .Site.Params.iosLightOverride | default "ffffff" }}" media="(prefers-color-scheme: light)" />
+  <meta name="theme-color" content="#{{ .Site.Params.iosDarkOverride | default "000000" }}" media="(prefers-color-scheme: dark)" />
   <meta http-equiv="X-UA-Compatible" content="ie=edge" />
   {{/* Title */}}
   {{ if .IsHome -}}


### PR DESCRIPTION
Technically addresses #519 but fails to consider background images and theme switch button.