### PR TITLE
♿️ Alt text management

### DIFF
--- a/layouts/partials/hero/big.html
+++ b/layouts/partials/hero/big.html
@@ -6,11 +6,11 @@
 {{- with $featured -}}
     {{ if $disableImageOptimization }}
         {{ with . }}
-        <img class="w-full rounded-lg single_hero_round nozoom" src="{{ .RelPermalink }}">
+        <img class="w-full rounded-lg single_hero_round nozoom" width="{{ .Width }}" height="{{ .Height }}" src="{{ .RelPermalink }}">
         {{ end }}
     {{ else }}
         {{ with .Resize "1200x" }}
-        <img class="w-full rounded-lg single_hero_round nozoom" src="{{ .RelPermalink }}">
+        <img class="w-full rounded-lg single_hero_round nozoom" width="{{ .Width }}" height="{{ .Height }}" src="{{ .RelPermalink }}">
         {{ end }}
     {{ end }}
 {{- end -}}

--- a/layouts/partials/hero/big.html
+++ b/layouts/partials/hero/big.html
@@ -3,14 +3,16 @@
 {{- $images := .Resources.ByType "image" -}}
 {{- $featured := $images.GetMatch "*feature*" -}}
 {{- if not $featured }}{{ $featured = $images.GetMatch "{*cover*,*thumbnail*}" }}{{ end -}}
+{{- $alt := .Page.Title -}}
+{{- with .Page.Params.alt }}{{ $alt = . }}{{ end -}}
 {{- with $featured -}}
     {{ if $disableImageOptimization }}
         {{ with . }}
-        <img class="w-full rounded-lg single_hero_round nozoom" width="{{ .Width }}" height="{{ .Height }}" src="{{ .RelPermalink }}">
+        <img class="w-full rounded-lg single_hero_round nozoom" alt="{{ $alt }}" width="{{ .Width }}" height="{{ .Height }}" src="{{ .RelPermalink }}">
         {{ end }}
     {{ else }}
         {{ with .Resize "1200x" }}
-        <img class="w-full rounded-lg single_hero_round nozoom" width="{{ .Width }}" height="{{ .Height }}" src="{{ .RelPermalink }}">
+        <img class="w-full rounded-lg single_hero_round nozoom" alt="{{ $alt }}" width="{{ .Width }}" height="{{ .Height }}" src="{{ .RelPermalink }}">
         {{ end }}
     {{ end }}
 {{- end -}}

--- a/layouts/partials/home/background.html
+++ b/layouts/partials/home/background.html
@@ -8,7 +8,7 @@
                     {{ with .Site.Params.defaultBackgroundImage }}{{ $homepageImage = resources.Get . }}{{ end }}
                     {{ with .Site.Params.homepage.homepageImage }}{{ $homepageImage = resources.Get . }}{{ end }}
                     {{ if not (eq $homepageImage "") }}
-                    <img class="w-full h-[1000px] object-cover m-0 nozoom" src="{{ $homepageImage.RelPermalink }}">
+                    <img class="w-full h-[1000px] object-cover m-0 nozoom" src="{{ $homepageImage.RelPermalink }}" role="presentation">
                     <div
                         class="absolute inset-0 h-[1000px] bg-gradient-to-t from-neutral dark:from-neutral-800 to-transparent mix-blend-normal">
                     </div>


### PR DESCRIPTION
This change improve accessibility by:
- indicating that the background image is use for presentation only and then do not need an alt text
- add an alt text to the big hero image  defaulting to page title or to the specified "alt" param in the Page Bundle.

I've also set a fixed image ratio for the big hero image to improve performance (less page redraws).