### PR TITLE
❇️ Use article/page configured summary ahead of default

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -17,8 +17,8 @@
   {{ with .Params.Summary | default .Site.Params.description -}}
   <meta name="description" content="{{ . }}" />
   {{- end }}
-  {{ with .Site.Params.keywords -}}
-  <meta name="keywords" content="{{ . }}" />
+  {{ with  .Params.Tags | default .Site.Params.keywords -}}
+  <meta name="keywords" content="{{ range . }}{{ . }}, {{ end -}}" />
   {{- end }}
   {{ with .Site.Params.robots }}
   <meta name="robots" content="{{ . }}" />

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -14,7 +14,7 @@
   <meta name="title" content="{{ .Title | emojify }} &middot; {{ .Site.Title | emojify }}" />
   {{- end }}
   {{/* Metadata */}}
-  {{ with .Site.Params.description -}}
+  {{ with .Params.Summary | default .Site.Params.description -}}
   <meta name="description" content="{{ . }}" />
   {{- end }}
   {{ with .Site.Params.keywords -}}


### PR DESCRIPTION
This PR is a potential small seo improvement. If there is a configured `summary` in the page frontmatter, it will be used in the `<meta name="description">` tag instead. If this isn't configured, then it defaults to `Site.Params.description`