### PR TITLE
🔧 Fixed zoom.min.js library not being found if site is in a subfolder.

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -73,7 +73,7 @@
     integrity="{{ $bundleJS.Data.Integrity }}" data-copy="{{ i18n " code.copy" }}" data-copied="{{ i18n " code.copied"
     }}"></script>
   {{ end }}
-  <script src="/js/zoom.min.js"></script>
+  <script src="{{ "js/zoom.min.js" | relURL }}"></script>
   {{/* Icons */}}
   {{ if templates.Exists "partials/favicons.html" }}
   {{ partialCached "favicons.html" .Site }}


### PR DESCRIPTION
zoom.min.js is not found when site is not in the root and baseURL is set accordingly to something like `https://website.com/test/`. Other files in the static folder work fine. Only zoom.min.js has this issue.