### PR TITLE
Fixed error getting views and likes on a Windows built site.

### DIFF
--- a/assets/js/process.js
+++ b/assets/js/process.js
@@ -7,22 +7,22 @@ if (typeof auth !== 'undefined') {
         return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
     }
 
-    var update_views = function (oid, id) {
+    var update_views = function (node, id) {
         viewsCollection.doc(id).onSnapshot(doc => {
             var data = doc.data();
             if (data) {
-                var label = document.querySelectorAll("span[id='" + oid + "']")[0].innerText.split(' ')[1]
-                document.querySelectorAll("span[id='" + oid + "']")[0].innerText = numberWithCommas(data.views)
+                //var label = node.innerText.split(' ')[1]
+                node.innerText = numberWithCommas(data.views)
             }
         })
     }
 
-    var update_likes = function (oid, id) {
+    var update_likes = function (node, id) {
         likesCollection.doc(id).onSnapshot(doc => {
             var data = doc.data();
             if (data) {
-                var label = document.querySelectorAll("span[id='" + oid + "']")[0].innerText.split(' ')[1]
-                document.querySelectorAll("span[id='" + oid + "']")[0].innerText = numberWithCommas(data.likes)
+                //var label = node.innerText.split(' ')[1]
+                node.innerText = numberWithCommas(data.likes)
             }
         })
     }
@@ -33,20 +33,20 @@ if (typeof auth !== 'undefined') {
             var views_nodes = document.querySelectorAll("span[id^='views_']")
 
             for (var i in views_nodes) {
-                var oid = views_nodes[i].id
-                var id = oid ? oid.replaceAll("/", "-") : oid
+                var node = views_nodes[i]
+                var id = node.id ? node.id.replaceAll("/", "-") : node.id
                 if (id) {
-                    update_views(oid, id)
+                    update_views(node, id)
                 }
             }
 
             var likes_nodes = document.querySelectorAll("span[id^='likes_']")
 
             for (var i in likes_nodes) {
-                var oid = likes_nodes[i].id
-                var id = oid ? oid.replaceAll("/", "-") : oid
+                var node = likes_nodes[i]
+                var id = node.id ? node.id.replaceAll("/", "-") : node.id
                 if (id) {
-                    update_likes(oid, id)
+                    update_likes(node, id)
                 }
             }
         })


### PR DESCRIPTION
Hi!

When building a site with Hugo on Windows, there are some differences in the results compared to other operating systems. The number of views and likes usually have a generated id like this: `<span id="views_posts/page.md" title="views">0</span>`, but due to using the `{{ .File.Path }}` variable, that generates `<span id="views_posts\page.md" title="views">0</span>` on Windows. This causes that `querySelectorAll` in `process.js` fails and returns undefined due to not being able to escape the `\` character.

The views and likes counts are successfully stored in the Firestore Database and then successfully retrieved. So this only affects to showing the data on the site.

The ideal fix would be to have a consistent span id no matter what operating system was built on, always with `/` instead of `\` on Windows. So instead of using `{{ .File.Path }}` to generate the id, it would be better something like `{{ replace .Page.Permalink .Site.BaseURL "" }}`. That is the best way I found for getting a consistent path that doesn't contain the `baseURL`. `.Page.RelPermalink` sounds like it would suffice, but it contains subfolders. For example, if `baseURL` is `https://website.com/test/`, `test/` would be contained in the `.Page.RelPermalink` variable. So moving the site to another folder would reset the number views and likes. Another thing that I consider an advantage of this approach is that this doesn't include the extension of the file. Changing the format of a page file shouldn't reset the views and likes count, as it is still the same page, at the same url, generated to an html file.

Another thing to mention is that due to IDs having `\` on Windows, the entry in the database preserves the `\` instead of being replaced with `-`. So a site generated on Windows, and the same generated on Linux would show different views and likes count, as there would be different entries in the database for each page. For example, the entry in the database can be `views_posts\page.md` or `views_posts-page.md` depending on the OS the site was built on.

Whatever the case, all of that would break the views and likes counts on all existing websites. So I just opted to do some changes in `process.js` so the `querySelectorAll` doesn't fail on Windows. Besides, it's a bit more efficient as it doesn't query stuff that many times.

Hopefully all that info helps in case a more consistent fix is desired.

Greetings!