### PR TITLE
Fixed having multiple galleries in the same page, only works the first one

### DIFF
--- a/layouts/shortcodes/gallery.html
+++ b/layouts/shortcodes/gallery.html
@@ -1,5 +1,5 @@
 {{ $time := now.UnixNano }}
-{{ $id := delimit (slice "gallery" $time) "-" }}
+{{ $id := delimit (slice "gallery" .Ordinal $time) "-" }}
 
 <div id="{{ $id }}">
   {{ .Inner }}


### PR DESCRIPTION
Having multiple galleries in the same page makes them have the same ID (as now.UnixNano can be the same), so only the javascript of the first gallery works. This adds a unique number to the ID of each gallery so it fixes the problem.