### PR TITLE
Gallery fixes.

### DIFF
--- a/layouts/shortcodes/gallery.html
+++ b/layouts/shortcodes/gallery.html
@@ -1,12 +1,11 @@
-{{ $time := now.UnixNano }}
-{{ $id := delimit (slice "gallery" .Ordinal $time) "-" }}
+{{ $id := delimit (slice "gallery" .Ordinal) "-" }}
 
 <div id="{{ $id }}">
   {{ .Inner }}
 </div>
 
 <script>
-  $(document).ready(function () {
+  $(window).on("load", function () {
     $('#{{ $id }}').packery({
       percentPosition: true,
       gutter: 5,


### PR DESCRIPTION
- Removed `now.UnixNano` time from the IDs of the galleries so page generation is deterministic. This fixes generated pages with galleries always having differences after each build, even if the page hasn't changed. With `.Ordinal`, the galleries IDs should already be unique.
- Make sure that all images have finished loading before calling Packery, fixing some image overlapping problems.