### PR TITLE
Fix .Language.Params deprecation

### DIFF
--- a/layouts/_default/index.json
+++ b/layouts/_default/index.json
@@ -2,7 +2,7 @@
 {{- range .Site.Pages -}}
   {{- $section := .Site.GetPage "section" .Section -}}
   {{- $index = $index | append (dict
-    "date" (.Date | time.Format (.Site.Language.Params.dateFormat | default ":date_long")) 
+    "date" (.Date | time.Format (.Site.Params.dateFormat | default ":date_long")) 
     "title" (.Title | emojify | safeJS)
     "section" ($section.Title | emojify | safeJS)
     "summary" (.Summary | emojify | safeJS)

--- a/layouts/partials/functions/date.html
+++ b/layouts/partials/functions/date.html
@@ -1,1 +1,1 @@
-{{ return time.Format (site.Language.Params.dateFormat | default ":date_long") . }}
+{{ return time.Format (site.Params.dateFormat | default ":date_long") . }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,6 +1,6 @@
 <head>
   <meta charset="utf-8" />
-  {{ with .Site.Language.Params.htmlCode | default .Site.LanguageCode }}
+  {{ with .Site.Params.htmlCode | default .Site.LanguageCode }}
   <meta http-equiv="content-language" content="{{ . }}" />
   {{ end }}
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/layouts/partials/translations.html
+++ b/layouts/partials/translations.html
@@ -11,7 +11,7 @@
         {{ range .AllTranslations }}
         <a href="{{ .RelPermalink }}" class="flex items-center">
           <p class="text-sm font-sm text-gray-500 hover:text-gray-900" title="{{ .Title }}">
-            {{ .Language.Params.displayName | emojify }}
+            {{ .Site.Params.displayName | emojify }}
           </p>
         </a>
         {{ end }}


### PR DESCRIPTION
Since Hugo v0.112, `.Language.Params` has been deprecated in favor of `.Site.Params`.  Running with `--panicOnWarning` displays the following warning:
```
.Language.Params is deprecated and will be removed in a future release. .Language.Params
is deprecated and will be removed in a future release. Use site.Params instead.

- For all but custom parameters, you need to use the built in Hugo variables, e.g. site.Title, 
  site.LanguageCode; site.Language.Params.Title will not work.
- All custom parameters needs to be placed below params, e.g. [languages.en.params] in TOML.

See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
```

The consequence of this PR would be to raise the minimum version of Hugo to v0.112, so it is probably too early to merge it. It will become necessary once the deprecation turns into removal.