### PR TITLE
🐛 fix regression in fathom analytics

### DIFF
--- a/layouts/partials/analytics/fathom.html
+++ b/layouts/partials/analytics/fathom.html
@@ -1,5 +1,5 @@
 {{ if isset site.Params.fathomAnalytics "domain" }}
-<script defer src="https://{{ site.Params.fathomAnalytics.domain }}/script.js" data-site="{{ . }}"></script>
+<script defer src="https://{{ site.Params.fathomAnalytics.domain }}/script.js" data-site="{{ site.Params.fathomAnalytics.site }}"></script>
 {{ else }}
-<script defer src="https://cdn.usefathom.com/script.js" data-site="{{ . }}"></script>
+<script defer src="https://cdn.usefathom.com/script.js" data-site="{{ site.Params.fathomAnalytics.site }}"></script>
 {{ end }}


### PR DESCRIPTION
With the latest refactor, the site id for fathom analytics is not correctly set. This PR should fix it.