### PR TITLE
🐛 Floating Position of TOC and Layout Setting for Article He…

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -62,7 +62,7 @@
     {{ if or (and (.Params.showTableOfContents | default (.Site.Params.article.showTableOfContents | default false)) (in
     .TableOfContents "<ul")) (.Site.Params.article.showRelatedPosts | default false) }} <div
       class="order-first sm:max-w-prose lg:ml-auto px-0 lg:order-last lg:max-w-xs ltr:lg:pl-8 rtl:lg:pr-8">
-      <div class="toc ltr:pl-5 rtl:pr-5 print:hidden lg:sticky {{ if eq .Site.Params.header.layout " fixed" }}
+      <div class="toc ltr:pl-5 rtl:pr-5 print:hidden lg:sticky {{ if eq .Site.Params.header.layout "fixed" }}
         lg:top-[140px] {{ else }} lg:top-10 {{ end }}">
 
         {{ if and (.Params.showTableOfContents | default (.Site.Params.article.showTableOfContents | default false)) (in


### PR DESCRIPTION
…ader

The extra space makes the TOC floating position wrong lg:top-10, rather than lg:top-[140px] for the 'fixed' header layout