### PR TITLE
🎨 Fix that prevents the TOC from being covered by the main menu.

### DIFF
--- a/assets/css/compiled/main.css
+++ b/assets/css/compiled/main.css
@@ -6871,7 +6871,7 @@ body:has(#menu-controller:checked) {
   }
 
   .lg\:top-10 {
-    top: 2.5rem;
+    top: 6rem;
   }
 
   .lg\:top-\[140px\] {

--- a/assets/css/compiled/main.css
+++ b/assets/css/compiled/main.css
@@ -6871,7 +6871,7 @@ body:has(#menu-controller:checked) {
   }
 
   .lg\:top-10 {
-    top: 6rem;
+    top: 2.5rem;
   }
 
   .lg\:top-\[140px\] {

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -34,7 +34,8 @@
     {{- end }} prose flex max-w-full flex-col dark:prose-invert lg:flex-row">
     {{ if $toc }}
     <div class="order-first px-0 lg:order-last lg:max-w-xs ltr:lg:pl-8 rtl:lg:pr-8">
-      <div class="toc ltr:pl-5 rtl:pr-5 lg:sticky lg:top-10">
+      <div class="toc ltr:pl-5 rtl:pr-5 lg:sticky {{ if hasPrefix .Site.Params.header.layout "fixed" }}
+      lg:top-[140px] {{ else }} lg:top-10 {{ end }}">
         {{ partial "toc.html" . }}
       </div>
     </div>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -34,8 +34,8 @@
     {{- end }} prose flex max-w-full flex-col dark:prose-invert lg:flex-row">
     {{ if $toc }}
     <div class="order-first px-0 lg:order-last lg:max-w-xs ltr:lg:pl-8 rtl:lg:pr-8">
-      <div class="toc ltr:pl-5 rtl:pr-5 lg:sticky {{ if hasPrefix .Site.Params.header.layout "fixed" }}
-      lg:top-[140px] {{ else }} lg:top-10 {{ end }}">
+      <div class="toc ltr:pl-5 rtl:pr-5 lg:sticky {{ if hasPrefix .Site.Params.header.layout "fixed" -}}
+      lg:top-[140px]{{ else }}lg:top-10{{ end }}">
         {{ partial "toc.html" . }}
       </div>
     </div>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -62,8 +62,8 @@
     {{ if or (and (.Params.showTableOfContents | default (.Site.Params.article.showTableOfContents | default false)) (in
     .TableOfContents "<ul")) (.Site.Params.article.showRelatedPosts | default false) }} <div
       class="order-first sm:max-w-prose lg:ml-auto px-0 lg:order-last lg:max-w-xs ltr:lg:pl-8 rtl:lg:pr-8">
-      <div class="toc ltr:pl-5 rtl:pr-5 print:hidden lg:sticky {{ if hasPrefix .Site.Params.header.layout "fixed" }}
-        lg:top-[140px] {{ else }} lg:top-10 {{ end }}">
+      <div class="toc ltr:pl-5 rtl:pr-5 print:hidden lg:sticky {{ if hasPrefix .Site.Params.header.layout "fixed" -}}
+        lg:top-[140px]{{ else }}lg:top-10{{ end }}">
 
         {{ if and (.Params.showTableOfContents | default (.Site.Params.article.showTableOfContents | default false)) (in
         .TableOfContents "<ul") }} {{ partial "toc.html" . }} {{ end }} {{ if .Site.Params.article.showRelatedPosts |

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -62,7 +62,7 @@
     {{ if or (and (.Params.showTableOfContents | default (.Site.Params.article.showTableOfContents | default false)) (in
     .TableOfContents "<ul")) (.Site.Params.article.showRelatedPosts | default false) }} <div
       class="order-first sm:max-w-prose lg:ml-auto px-0 lg:order-last lg:max-w-xs ltr:lg:pl-8 rtl:lg:pr-8">
-      <div class="toc ltr:pl-5 rtl:pr-5 print:hidden lg:sticky {{ if eq .Site.Params.header.layout " fixed" }}
+      <div class="toc ltr:pl-5 rtl:pr-5 print:hidden lg:sticky {{ if hasPrefix .Site.Params.header.layout "fixed" }}
         lg:top-[140px] {{ else }} lg:top-10 {{ end }}">
 
         {{ if and (.Params.showTableOfContents | default (.Site.Params.article.showTableOfContents | default false)) (in


### PR DESCRIPTION
The TOC can be partially hidden by the main menu when scrolling down if that menu has a logo image. That's even visible in the Blowfish page. Just to test that it wasn't a Windows thing, I also checked on Ubuntu and same result.

![01](https://github.com/nunocoracao/blowfish/assets/7031754/2229c20f-93b4-4bd6-b84b-f47495045a7b)

I adjusted the top value so the TOC never goes that high in the page when scrolling down.

![02](https://github.com/nunocoracao/blowfish/assets/7031754/e38a742e-c7c9-4da1-bd53-c05877f1598e)
