### PR TITLE
Always generate appearance.js in js folder

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -50,7 +50,7 @@
   <link type="text/css" rel="stylesheet" href="{{ $bundleCSS.RelPermalink }}"
     integrity="{{ $bundleCSS.Data.Integrity }}" />
   {{ $jsAppearance := resources.Get "js/appearance.js" }}
-  {{ $jsAppearance = $jsAppearance | resources.ExecuteAsTemplate $jsAppearance.RelPermalink . | resources.Minify | resources.Fingerprint "sha512" }}
+  {{ $jsAppearance = $jsAppearance | resources.ExecuteAsTemplate "js/appearance.js" . | resources.Minify | resources.Fingerprint "sha512" }}
   <script type="text/javascript" src="{{ $jsAppearance.RelPermalink }}"
     integrity="{{ $jsAppearance.Data.Integrity }}"></script>
   {{ if .Site.Params.enableSearch | default false }}


### PR DESCRIPTION
depending on the basePath, the "appearance.js" was generated in an additional subfolder (Example: set the basePath to "https://example.com/foobar/", the file was generated into "/js/foobar/appearance...js" instead of "/js/appearance...js" ).

This fixes the behaviour, the javascript resource is always generated into the target "js" folder along with all the other js files.