### PR TITLE
🖌️ attempt to address #716 - svgs support

### DIFF
--- a/layouts/partials/article-link/card.html
+++ b/layouts/partials/article-link/card.html
@@ -16,7 +16,7 @@
       {{- if not $featured }}{{ with .Site.Params.defaultFeaturedImage }}{{ $featured = resources.Get . }}{{ end }}{{ end -}}
       {{ if .Params.hideFeatureImage }}{{ $featured = false }}{{ end }}
       {{- with $featured -}}
-      {{ if $disableImageOptimization }}
+      {{ if or ( eq $featured.MediaType.SubType "svg") $disableImageOptimization }}
         {{ with . }}
         <div class="w-full thumbnail_card nozoom" style="background-image:url({{ .RelPermalink }});"></div>
         {{ end }}

--- a/layouts/partials/article-link/simple.html
+++ b/layouts/partials/article-link/simple.html
@@ -43,7 +43,7 @@
     {{- if not $featured }}{{ with .Site.Params.defaultFeaturedImage }}{{ $featured = resources.Get . }}{{ end }}{{ end -}}
     {{ if .Params.hideFeatureImage }}{{ $featured = false }}{{ end }}
     {{- with $featured -}}
-    {{ if $disableImageOptimization }}
+    {{ if or ( eq .MediaType.SubType "svg") $disableImageOptimization }}
         {{ with . }}
         <div class="{{ $articleImageClasses }}" style="background-image:url({{ .RelPermalink }});"></div>
         {{ end }}

--- a/layouts/partials/author-extra.html
+++ b/layouts/partials/author-extra.html
@@ -4,7 +4,9 @@
   {{ $authorImage := resources.Get . }}
   {{ if $authorImage }}
   {{ if not $disableImageOptimization }}
-  {{ $authorImage = $authorImage.Fill "192x192" }}
+  {{   if not (eq $authorImage.MediaType.SubType "svg") -}}
+  {{     $authorImage = $authorImage.Fill "192x192" }}
+  {{   end }}
   {{ end }}
   <img class="!mt-0 !mb-0 h-24 w-24 rounded-full ltr:mr-4 rtl:ml-4" width="96" height="96"
     src="{{ $authorImage.RelPermalink }}" />

--- a/layouts/partials/author.html
+++ b/layouts/partials/author.html
@@ -4,7 +4,9 @@
   {{ $authorImage := resources.Get . }}
   {{ if $authorImage }}
   {{ if not $disableImageOptimization }}
+  {{-   if not (eq $authorImage.MediaType.SubType "svg") -}}
   {{ $authorImage = $authorImage.Fill "192x192" }}
+  {{-   end -}}
   {{ end }}
   <img class="!mt-0 !mb-0 h-24 w-24 rounded-full ltr:mr-4 rtl:ml-4" width="96" height="96"
     alt="{{ $.Site.Author.name | default " Author" }}" src="{{ $authorImage.RelPermalink }}" />

--- a/layouts/partials/hero/background.html
+++ b/layouts/partials/hero/background.html
@@ -18,7 +18,7 @@
 {{ if $shouldAddHeaderSpace | default true}}
 <div id="hero" class="h-[150px] md:h-[200px]"></div>
 {{ end }}
-{{ if $disableImageOptimization }}
+{{ if or (eq .MediaType.SubType "svg" ) ($disableImageOptimization) }}
     {{ with . }}
     <div class="fixed inset-x-0 top-0 h-[800px] single_hero_background nozoom"
     style="background-image:url({{ .RelPermalink }});">

--- a/layouts/partials/hero/basic.html
+++ b/layouts/partials/hero/basic.html
@@ -4,7 +4,7 @@
 {{- $featured := $images.GetMatch "*feature*" -}}
 {{- if not $featured }}{{ $featured = $images.GetMatch "{*cover*,*thumbnail*}" }}{{ end -}}
 {{- with $featured -}}
-    {{ if $disableImageOptimization }}
+    {{ if or (eq .MediaType.SubType "svg" ) ($disableImageOptimization) }}
         {{ with . }}
             <div class="w-full h-36 md:h-56 lg:h-72 single_hero_basic nozoom" style="background-image:url({{ .RelPermalink }});"></div>
         {{ end }}

--- a/layouts/partials/hero/big.html
+++ b/layouts/partials/hero/big.html
@@ -6,7 +6,11 @@
 {{- $alt := .Page.Title -}}
 {{- with .Page.Params.alt }}{{ $alt = . }}{{ end -}}
 {{- with $featured -}}
-    {{ if or (eq .MediaType.SubType "svg" ) ($disableImageOptimization) }}
+    {{ if eq .MediaType.SubType "svg" }}
+        {{ with . }}
+        <img class="w-full rounded-lg single_hero_round nozoom" alt="{{ $alt }}" src="{{ .RelPermalink }}">
+        {{ end }}
+    {{ else if $disableImageOptimization }}
         {{ with . }}
         <img class="w-full rounded-lg single_hero_round nozoom" alt="{{ $alt }}" width="{{ .Width }}" height="{{ .Height }}" src="{{ .RelPermalink }}">
         {{ end }}

--- a/layouts/partials/hero/big.html
+++ b/layouts/partials/hero/big.html
@@ -6,7 +6,7 @@
 {{- $alt := .Page.Title -}}
 {{- with .Page.Params.alt }}{{ $alt = . }}{{ end -}}
 {{- with $featured -}}
-    {{ if $disableImageOptimization }}
+    {{ if or (eq .MediaType.SubType "svg" ) ($disableImageOptimization) }}
         {{ with . }}
         <img class="w-full rounded-lg single_hero_round nozoom" alt="{{ $alt }}" width="{{ .Width }}" height="{{ .Height }}" src="{{ .RelPermalink }}">
         {{ end }}

--- a/layouts/partials/hero/thumbAndBackground.html
+++ b/layouts/partials/hero/thumbAndBackground.html
@@ -16,7 +16,7 @@
     ) }}
 
 {{- with $featured -}}
-{{ if $disableImageOptimization }}
+{{ if or (eq $featured.MediaType.SubType "svg" ) ($disableImageOptimization) }}
 {{ with . }}
 <div class="w-full rounded-md h-36 md:h-56 lg:h-72 single_hero_basic nozoom" style="background-image:url({{ .RelPermalink }});"></div>
 {{ end }}
@@ -29,7 +29,7 @@
 
 {{- with $background -}}
 
-{{ if $disableImageOptimization }}
+{{ if or (eq  $background.MediaType.SubType "svg" ) ($disableImageOptimization) }}
 {{ with . }}
 <div class="fixed inset-x-0 top-0 h-[800px] single_hero_background nozoom"
     style="background-image:url({{ .RelPermalink }});">

--- a/layouts/partials/home/background.html
+++ b/layouts/partials/home/background.html
@@ -23,9 +23,11 @@
                     {{ $authorImage := resources.Get . }}
                     {{ if $authorImage }}
                     {{ if not $disableImageOptimization }}
-                    {{ $authorImage = $authorImage.Fill "288x288" }}
+                    {{-  if not (eq $authorImage.MediaType.SubType "svg") -}}
+                    {{     $authorImage = $authorImage.Fill "288x288" }}
+                    {{   end }}
                     {{ end }}
-                    <img class="mb-2 rounded-full h-36 w-36" width="144" height="144"
+                    <img class="mb-2 rounded-full h-36 w-36" {{-  if not (eq $authorImage.MediaType.SubType "svg") -}} width="144" height="144" {{- end -}}
                         alt="{{ $.Site.Author.name | default " Author" }}" src="{{ $authorImage.RelPermalink }}" />
                     {{ end }}
                     {{ end }}

--- a/layouts/partials/home/profile.html
+++ b/layouts/partials/home/profile.html
@@ -9,12 +9,16 @@
       {{ $authorImage := resources.Get . }}
       {{ if $authorImage }}
         {{ if not $disableImageOptimization }}
-        {{ $authorImage = $authorImage.Fill "288x288" }}
+        {{-   if not (eq $authorImage.MediaType.SubType "svg") -}}
+        {{     $authorImage = $authorImage.Fill "288x288" }}
+        {{-   end -}}
         {{ end }}
         <img
           class="mb-2 rounded-full h-36 w-36"
+{{        if not (eq $authorImage.MediaType.SubType "svg") }}     
           width="144"
           height="144"
+{{        end }}    
           alt="{{ $.Site.Author.name | default "Author" }}"
           src="{{ $authorImage.RelPermalink }}"
         />


### PR DESCRIPTION
I THINK This allows one to use SVGs as background, featured, or author images,  addressing #716 

Not sure if I missed anything, but this reflects the changes I made locally and it appears functional?
