### PR TITLE
Set maximum-supported Hugo version to 0.118.2

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,4 +2,4 @@
   [module.hugoVersion]
     extended = true
     min = "0.87.0"
-    max = "0.117.0"
+    max = "0.118.2"


### PR DESCRIPTION
Set maximum-supported Hugo version to 0.118.2: https://github.com/gohugoio/hugo/releases/tag/v0.118.2.