### PR TITLE
🐛 Fix tel:, ftp:, etc URLs For Author Links

### DIFF
--- a/layouts/partials/author-links.html
+++ b/layouts/partials/author-links.html
@@ -4,7 +4,7 @@
       {{ range $name, $url := $links }}
         <a
           class="px-1 hover:text-primary-700 dark:hover:text-primary-400"
-          href="{{ $url }}"
+          href="{{ $url | safeURL }}"
           target="_blank"
           aria-label="{{ $name | title }}"
           rel="me noopener noreferrer"


### PR DESCRIPTION
Added safeURL to author links so that ftp and phone links work correctly.
See Hugo documentation for more information:
https://gohugo.io/functions/safeurl/