### PR TITLE
Remove non-existant site (404)

### DIFF
--- a/exampleSite/content/users/users.json
+++ b/exampleSite/content/users/users.json
@@ -365,13 +365,6 @@
     ]
   },
   {
-    "title": "jahsehj.github.io",
-    "url": "https://jahsehj.github.io/",
-    "tags": [
-      "Personal site mainly in Chinese"
-    ]
-  },
-  {
     "title": "jundimubarok.com",
     "url": "https://jundimubarok.com/",
     "tags": [


### PR DESCRIPTION
After browsing some of the pages on the users page of the blowfish site, I have found that there was a site returning a 404. Due to this I decided to remove it to make sure that things work good.

:+1: