### PR TITLE
Feature/hero-image gradient parameter

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,4 +2,4 @@
   [module.hugoVersion]
     extended = true
     min = "0.87.0"
-    max = "0.120.3"
+    max = "0.120.4"

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -37,6 +37,7 @@ disableImageOptimization = true
 [homepage]
   layout = "profile" # valid options: page, profile, hero, card, background, custom
   #homepageImage = "IMAGE.jpg" # used in: hero, and card
+  homepageImageGradientOverlay = true # tastefully darken the hero-image via CSS
   showRecent = false
   showRecentItems = 5
   showMoreLink = false

--- a/layouts/partials/home/hero.html
+++ b/layouts/partials/home/hero.html
@@ -26,11 +26,11 @@
                         alt="{{ $.Site.Author.name | default " Author" }}" src="{{ $authorImage.RelPermalink }}" />
                     {{ end }}
                     {{ end }}
-                    <h1 class="mb-2 text-4xl font-extrabold text-neutral-200">
+                    <h1 class="mb-2 text-4xl font-extrabold text-neutral-200 drop-shadow-md">
                         {{ .Site.Author.name | default .Site.Title }}
                     </h1>
                     {{ with .Site.Author.headline }}
-                    <h2 class="mt-0 mb-0 text-xl text-neutral-300">
+                    <h2 class="mt-0 mb-0 text-xl text-neutral-300 drop-shadow-md">
                         {{ . | markdownify | emojify }}
                     </h2>
                     {{ end }}

--- a/layouts/partials/home/hero.html
+++ b/layouts/partials/home/hero.html
@@ -11,7 +11,7 @@
                     {{ if $homepageImage }}
                     <img class="h-full w-full object-cover m-0 nozoom" src="{{ $homepageImage.RelPermalink }}">
                     <div
-                        class="absolute inset-0 bg-gradient-to-r from-primary-500 to-secondary-700 dark:from-primary-600 dark:to-secondary-800 mix-blend-multiply">
+                        class="absolute inset-0 {{ if .Site.Params.homepage.homepageImageGradientOverlay }}bg-gradient-to-r{{ end }} from-primary-500 to-secondary-700 dark:from-primary-600 dark:to-secondary-800 mix-blend-multiply">
                     </div>
                     {{ end }}
                 </div>


### PR DESCRIPTION
This adds a boolean site-parameter to control the application of the `bg-gradient-to-r` darkening css on a Hero image.  For backwards compatibility/'principle-of-least-astonishment', this parameter is set to 'true' by default, maintaining the previous default behavior of darkening the hero image via CSS.  

This also applies the Tailwind CSS 'drop-shadow-md' property to the Author and Site Title sections.  This will be invisible over a dark image, but aids in readability over a light image (such as what may get displayed if homepageImageGradientOverlay is set to false).  

Please don't hesitate to suggest changes if there is a cleaner/better/less-hateful way to do this - I am not the strongest when it comes to FE HTML/CSS stuff, but I am always eager to learn and improve.  