### PR TITLE
Only send web request for zoom library if it is not disabled.

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -73,7 +73,9 @@
     integrity="{{ $bundleJS.Data.Integrity }}" data-copy="{{ i18n " code.copy" }}" data-copied="{{ i18n " code.copied"
     }}"></script>
   {{ end }}
+  {{ if not .Site.Params.disableImageZoom | default true }}
   <script src="{{ "js/zoom.min.js" | relURL }}"></script>
+  {{ end }}
   {{/* Icons */}}
   {{ if templates.Exists "partials/favicons.html" }}
   {{ partialCached "favicons.html" .Site }}


### PR DESCRIPTION
There is already [an if condition](https://github.com/nunocoracao/blowfish/blob/45d634f6ca698abdbfebf67e955211f090043e5b/layouts/partials/footer.html#L46) in `footer.html` that only runs the JS from the zoom library if it is enabled per-site.

This commit takes the same if condition and applies it in `head.html` as well to save a unnecessary web request to `zoom.min.js` if that is the case.