### PR TITLE
Fix annoying `.File.Path on zero object.` warning

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -19,10 +19,12 @@
   <div class="mt-1 mb-2 text-base text-neutral-500 dark:text-neutral-400 print:hidden">
     {{ partial "article-meta/list.html" (dict "context" . "scope" "single") }}
   </div>
+  {{ with .File }}
   <script>
-    var oid = "views_{{ .File.Path }}"
-    var oid_likes = "likes_{{ .File.Path }}"
+    var oid = "views_{{ .Path }}"
+    var oid_likes = "likes_{{ .Path }}"
   </script>
+  {{ end }}
   {{ $jsPage := resources.Get "js/page.js" }}
   {{ $jsPage = $jsPage | resources.Minify | resources.Fingerprint "sha512" }}
   <script type="text/javascript" src="{{ $jsPage.RelPermalink }}" integrity="{{ $jsPage.Data.Integrity }}"></script>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -86,10 +86,12 @@
         {{ partial "related.html" . }}  
       </div>
      
+    {{ with .File }}
      <script>
-        var oid = "views_{{ .File.Path }}"
-        var oid_likes = "likes_{{ .File.Path }}"
+        var oid = "views_{{ .Path }}"
+        var oid_likes = "likes_{{ .Path }}"
       </script>
+      {{ end }}
       {{ $jsPage := resources.Get "js/page.js" }}
       {{ $jsPage = $jsPage | resources.Minify | resources.Fingerprint "sha512" }}
       <script type="text/javascript" src="{{ $jsPage.RelPermalink }}" integrity="{{ $jsPage.Data.Integrity }}"></script>


### PR DESCRIPTION
When I was creating a post, I was getting this warning:
```
WARN  .File.Path on zero object. Wrap it in if or with: {{ with .File }}{{ .Path }}{{ end }}
```
So I did as suggested and replaced the `.File.Path` using a `with` statement in the `list.html` and `single.html` files. So far, the warning hasn't popped up again.
I am not sure why this warning comes up, but I hope this will mitigate weird behavior in the future.

I noticed this warning in two issues #602 and #490 