### PR TITLE
Remove extraneous backdrop-blurs across partials

### DIFF
--- a/layouts/partials/article-link/card-related.html
+++ b/layouts/partials/article-link/card-related.html
@@ -4,7 +4,7 @@
   {{ else }}
   <a href="{{ .RelPermalink }}" class="min-w-full">
     {{ end }}
-    <div class="min-h-full border border-neutral-200 dark:border-neutral-700 border-2 rounded overflow-hidden shadow-2xl relative backdrop-blur">
+    <div class="min-h-full border border-neutral-200 dark:border-neutral-700 border-2 rounded overflow-hidden shadow-2xl relative">
 
       {{- with $.Params.images -}}
       {{- range first 6 . }}

--- a/layouts/partials/article-link/card.html
+++ b/layouts/partials/article-link/card.html
@@ -4,7 +4,7 @@
   {{ else }}
   <a href="{{ .RelPermalink }}" class="min-w-full">
     {{ end }}
-    <div class="min-h-full border border-neutral-200 dark:border-neutral-700 border-2 rounded overflow-hidden shadow-2xl relative backdrop-blur">
+    <div class="min-h-full border border-neutral-200 dark:border-neutral-700 border-2 rounded overflow-hidden shadow-2xl relative">
 
       {{- with $.Params.images -}}
       {{- range first 6 . }}

--- a/layouts/partials/article-link/simple.html
+++ b/layouts/partials/article-link/simple.html
@@ -2,7 +2,7 @@
 
 {{ $articleClasses := "flex flex-wrap article" }}
 {{ if .Site.Params.list.showCards }}
-{{ $articleClasses = delimit (slice $articleClasses "border border-neutral-200 dark:border-neutral-700 border-2 rounded-md backdrop-blur overflow-hidden") " " }}
+{{ $articleClasses = delimit (slice $articleClasses "border border-neutral-200 dark:border-neutral-700 border-2 rounded-md overflow-hidden") " " }}
 {{ else }}
 {{ $articleClasses = delimit (slice $articleClasses "") " " }}
 {{ end }}

--- a/layouts/partials/scroll-to-top.html
+++ b/layouts/partials/scroll-to-top.html
@@ -1,6 +1,6 @@
 <div id="top-scroller" class="pointer-events-none absolute top-[110vh] bottom-0 w-12 ltr:right-0 rtl:left-0">
   <a href="#the-top"
-    class="pointer-events-auto sticky top-[calc(100vh-5.5rem)] flex h-12 w-12 mb-16 items-center justify-center rounded-full bg-neutral/50 text-xl text-neutral-700 backdrop-blur hover:text-primary-600 dark:bg-neutral-800/50 dark:text-neutral dark:hover:text-primary-400"
+    class="pointer-events-auto sticky top-[calc(100vh-5.5rem)] flex h-12 w-12 mb-16 items-center justify-center rounded-full bg-neutral/50 text-xl text-neutral-700 hover:text-primary-600 dark:bg-neutral-800/50 dark:text-neutral dark:hover:text-primary-400"
     aria-label="{{ i18n "nav.scroll_to_top_title" }}" title="{{ i18n "nav.scroll_to_top_title" }}">
     &uarr;
   </a>

--- a/layouts/partials/term-link/card.html
+++ b/layouts/partials/term-link/card.html
@@ -1,6 +1,6 @@
 <a href="{{ .Page.RelPermalink }}" class="min-w-full">
   <div
-    class="border border-neutral-200 dark:border-neutral-700 border-2 rounded overflow-hidden shadow-2xl relative backdrop-blur">
+    class="border border-neutral-200 dark:border-neutral-700 border-2 rounded overflow-hidden shadow-2xl relative">
 
     {{ $disableImageOptimization := .Page.Site.Params.disableImageOptimization | default false }}
 
@@ -32,7 +32,7 @@
     <span class="absolute bottom-0 right-0 m-2">
       <span class="flex">
         <span
-          class="rounded-md border backdrop-blur border-primary-400 px-1 py-[1px] text-xl font-normal text-primary-700 dark:border-primary-600 dark:text-primary-400"
+          class="rounded-md border border-primary-400 px-1 py-[1px] text-xl font-normal text-primary-700 dark:border-primary-600 dark:text-primary-400"
         >
         {{ .Count }}
         </span>

--- a/layouts/partials/translations.html
+++ b/layouts/partials/translations.html
@@ -6,7 +6,7 @@
     </a>
   </div>
   <div class="absolute menuhide">
-    <div class="pt-2 p-5 mt-2 rounded-xl backdrop-blur shadow-2xl">
+    <div class="pt-2 p-5 mt-2 rounded-xl shadow-2xl">
       <div class="flex flex-col space-y-3">
         {{ range .AllTranslations }}
         <a href="{{ .RelPermalink }}" class="flex items-center">

--- a/layouts/shortcodes/github.html
+++ b/layouts/shortcodes/github.html
@@ -6,7 +6,7 @@
 
 <a id="{{ $id }}" target="_blank" href="{{ .html_url }}" class="cursor-pointer">
   <div
-    class="w-full md:w-auto pt-3 p-5 border border-neutral-200 dark:border-neutral-700 border rounded-md backdrop-blur shadow-2xl">
+    class="w-full md:w-auto pt-3 p-5 border border-neutral-200 dark:border-neutral-700 border rounded-md shadow-2xl">
 
     <div class="flex items-center">
       <span class="text-2xl text-neutral-800 dark:text-neutral" style="margin-right:10px;">

--- a/layouts/shortcodes/gitlab.html
+++ b/layouts/shortcodes/gitlab.html
@@ -5,7 +5,7 @@
 {{- with $gitLabData -}}
 
 <a target="_blank" href="{{ .html_url }}" class="cursor-pointer">
-  <div class="w-full md:w-auto pt-3 p-5 border border-neutral-200 dark:border-neutral-700 border rounded-md backdrop-blur shadow-2xl">
+  <div class="w-full md:w-auto pt-3 p-5 border border-neutral-200 dark:border-neutral-700 border rounded-md shadow-2xl">
 
     <div class="flex items-center">
       <span class="text-2xl text-neutral-800 dark:text-neutral" style="margin-right:10px;">

--- a/layouts/shortcodes/timelineItem.html
+++ b/layouts/shortcodes/timelineItem.html
@@ -8,7 +8,7 @@
     <div class="bg-primary-500 dark:bg-primary-300 text-neutral-50 dark:text-neutral-700 min-w-[30px] h-8 text-2xl flex items-center justify-center rounded-full -ml-12 mt-5">
       {{ partial "icon" $icon }}
     </div>
-    <div class="block p-6 rounded-lg shadow-2xl min-w-full ml-6 mb-10 backdrop-blur">
+    <div class="block p-6 rounded-lg shadow-2xl min-w-full ml-6 mb-10">
       <div class="flex justify-between">
         {{ if $header }}
         <h2 class="mt-0">


### PR DESCRIPTION
This should mostly fix https://github.com/nunocoracao/blowfish/issues/994 and partially address https://github.com/nunocoracao/blowfish/issues/907.
- Removes most of the extraneous usage of `backdrop-blur` with no apparent visual impact (I only kept it on menu-wrapper, menu-blur, nested-menu, background-blur, and search-wrapper)
- Improves number of draw calls in Firefox with `header = "fixed"` and `layoutBackgroundBlur = false` by **~200 times**, drastically improving scrolling performance
- Improves number of draw calls in Firefox with `header = "basic"` and `layoutBackgroundBlur = true` by ~50%

In my earlier testing, I had simply disabled `.backdrop-blur`, `.backdrop-blur-sm`, and `.backdrop-blur-2xl` on every element except for the search widget, but this is a more proper solution. The inclusion of the `backdrop-filter` on every article link was incredibly intensive and seemingly included as an oversight as it doesn't appear to have any visual effect. That said, please review and check if any of them were actually intended.

Probably more could be done with a better CSS implementation since I did find a lot of documentation saying to avoid these blur filters entirely as they are extremely intensive and often do not perform well on mobile.

The draw call statistics above are from a local build of your website, https://github.com/nunocoracao/n9o.xyz.
![n90_comparison](https://github.com/nunocoracao/blowfish/assets/14023456/3644d21c-4c7f-484b-b6a8-95ca11ae3834)
