### PR TITLE
Fix wide elements (equations, tables, and inline code) breaking site width and layout

### DIFF
--- a/assets/css/compiled/main.css
+++ b/assets/css/compiled/main.css
@@ -4586,6 +4586,28 @@ body:has(#menu-controller:checked) {
   opacity: 0.05;
 }
 
+/* Fix long KaTeX equations on mobile (see https://katex.org/docs/issues.html#css-customization) */
+
+.katex-display {
+  overflow: auto hidden
+}
+
+/* Fix long tables breaking out of article on mobile */
+
+table {
+  display: block;
+  overflow: auto;
+}
+
+/* Fix long inline code sections breaking out of article on mobile */
+
+code {
+  word-wrap: break-word;
+  /* All browsers since IE 5.5+ */
+  overflow-wrap: break-word;
+  /* Renamed property in CSS3 draft spec */
+}
+
 /* -- Chroma Highlight -- */
 
 /* Background */

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -111,6 +111,21 @@ body:has(#menu-controller:checked) {
   @apply absolute opacity-5 -z-10;
 }
 
+/* Fix long KaTeX equations on mobile (see https://katex.org/docs/issues.html#css-customization) */
+.katex-display { overflow: auto hidden }
+
+/* Fix long tables breaking out of article on mobile */
+table {
+    display: block;
+    overflow: auto;
+}
+
+/* Fix long inline code sections breaking out of article on mobile */
+code {
+    word-wrap: break-word;         /* All browsers since IE 5.5+ */
+    overflow-wrap: break-word;     /* Renamed property in CSS3 draft spec */
+}
+
 /* -- Chroma Highlight -- */
 /* Background */
 .prose .chroma {


### PR DESCRIPTION
This tweaks the CSS to fix https://github.com/nunocoracao/blowfish/issues/990 by adding scroll bars to long KaTeX equations, tables, and inline code sections. The corresponding edits to `assets/css/compiled/main.css` are from the Tailwind compiler.

In the past, such long elements used to break the site layout, render some elements off-screen with no way to view them, and cause menus to be unreachable or impossible to click, especially on mobile devices.

I tested it on an example post similar to the one in the original issue. The scroll bars on these elements will fade in and out as needed, depending on the default behavior of the user's browser.
![breaking-site-width-comparison](https://github.com/nunocoracao/blowfish/assets/14023456/aa4aa2a4-754a-4818-bfdd-e53ee06c6078)
