### PR TITLE
:sparkles: Keyword shortcode

### DIFF
--- a/exampleSite/content/docs/shortcodes/index.md
+++ b/exampleSite/content/docs/shortcodes/index.md
@@ -399,13 +399,14 @@ The input is written in Markdown so you can format it however you please.
 {{</* keyword icon="github" */>}} Lorem ipsum dolor. {{</* /keyword */>}}
 {{</* keyword icon="code" */>}} **Important** skill {{</* /keyword */>}}
 {{</* /keywordList */>}}
+{{</* keyword */>}} *Standalone* skill {{</* /keyword */>}}
 ```
 
 {{< keywordList >}}
 {{< keyword icon="github" >}} Lorem ipsum dolor {{< /keyword >}}
 {{< keyword icon="code" >}} **Important** skill {{< /keyword >}}
 {{< /keywordList >}}
-
+{{< keyword >}} *Standalone* skill {{< /keyword >}}
 
 <br/><br/><br/>
 

--- a/exampleSite/content/docs/shortcodes/index.md
+++ b/exampleSite/content/docs/shortcodes/index.md
@@ -381,13 +381,13 @@ Check out the [mathematical notation samples]({{< ref "mathematical-notation" >}
 ## Keyword
 
 
-The `keyword` creates a visually distinguished keyword that can be used in different use-cases, e.g. professional skills etc. The `keyword` shortcode relies on the `keywordList` shortcode to group together keywords. Each item can have the following properties.
+The `keyword` component can be used to visually highlight certain important words or phrases, e.g. professional skills etc. The `keywordList` shortcode can be used to group together multiple `keyword` items. Each item can have the following properties.
 
 
 <!-- prettier-ignore-start -->
 | Parameter   | Description                                  |
 | ----------- | -------------------------------------------- |
-| `icon`      | the icon to be used in the keyword           |
+| `icon`      | Optional icon to be used in the keyword      |
 <!-- prettier-ignore-end -->
 
 The input is written in Markdown so you can format it however you please.

--- a/exampleSite/content/docs/shortcodes/index.md
+++ b/exampleSite/content/docs/shortcodes/index.md
@@ -377,6 +377,38 @@ Check out the [mathematical notation samples]({{< ref "mathematical-notation" >}
 
 <br/><br/><br/>
 
+
+## Keyword
+
+
+The `keyword` creates a visually distinguished keyword that can be used in different use-cases, e.g. professional skills etc. The `keyword` shortcode relies on the `keywordList` shortcode to group together keywords. Each item can have the following properties.
+
+
+<!-- prettier-ignore-start -->
+| Parameter   | Description                                  |
+| ----------- | -------------------------------------------- |
+| `icon`      | the icon to be used in the keyword           |
+<!-- prettier-ignore-end -->
+
+The input is written in Markdown so you can format it however you please.
+
+**Example:**
+
+```md
+{{</* keywordList */>}}
+{{</* keyword icon="github" */>}} Lorem ipsum dolor. {{</* /keyword */>}}
+{{</* keyword icon="code" */>}} **Important** skill {{</* /keyword */>}}
+{{</* /keywordList */>}}
+```
+
+{{< keywordList >}}
+{{< keyword icon="github" >}} Lorem ipsum dolor {{< /keyword >}}
+{{< keyword icon="code" >}} **Important** skill {{< /keyword >}}
+{{< /keywordList >}}
+
+
+<br/><br/><br/>
+
 ## Lead
 
 `lead` is used to bring emphasis to the start of an article. It can be used to style an introduction, or to call out an important piece of information. Simply wrap any Markdown content in the `lead` shortcode.
@@ -393,7 +425,7 @@ When life gives you lemons, make lemonade.
 When life gives you lemons, make lemonade.
 {{< /lead >}}
 
-<br/><br/><br/>
+<br/><br/><br/> 
 
 ## List
 

--- a/layouts/partials/keyword.html
+++ b/layouts/partials/keyword.html
@@ -1,0 +1,9 @@
+<span style="margin-top: 0.5rem" class="mr-2">
+  <span class="flex">
+    <span
+      class="rounded-full bg-primary-500 dark:bg-primary-300 text-neutral-50 dark:text-neutral-700 px-1 py-[1px] text-xs font-normal"
+    >
+      {{ . }}
+    </span>
+  </span>
+</span>

--- a/layouts/partials/keyword.html
+++ b/layouts/partials/keyword.html
@@ -1,9 +1,0 @@
-<span style="margin-top: 0.5rem" class="mr-2">
-  <span class="flex">
-    <span
-      class="rounded-full bg-primary-500 dark:bg-primary-300 text-neutral-50 dark:text-neutral-700 px-1 py-[1px] text-xs font-normal"
-    >
-      {{ . }}
-    </span>
-  </span>
-</span>

--- a/layouts/shortcodes/keyword.html
+++ b/layouts/shortcodes/keyword.html
@@ -1,0 +1,1 @@
+{{ partial "keyword.html" .Inner }}

--- a/layouts/shortcodes/keyword.html
+++ b/layouts/shortcodes/keyword.html
@@ -1,4 +1,5 @@
 {{ $icon := .Get "icon"}}
+<div class="flex mt-2">
 <span
   class="rounded-full bg-primary-500 dark:bg-primary-300 text-neutral-50 dark:text-neutral-700 px-1.5 py-[1px] text-xs font-normal"
 >
@@ -9,3 +10,4 @@
     <span> {{- .Inner | markdownify -}} </span>
   </span>
 </span>
+</div>

--- a/layouts/shortcodes/keyword.html
+++ b/layouts/shortcodes/keyword.html
@@ -2,9 +2,10 @@
 <span
   class="rounded-full bg-primary-500 dark:bg-primary-300 text-neutral-50 dark:text-neutral-700 px-1.5 py-[1px] text-xs font-normal"
 >
-  <span class="flex items-center">
+  <span class="flex flex-row items-center">
     {{if $icon}}
     <span class="mr-1">{{ partial "icon" $icon }}</span>
-    {{ end }} {{- .Inner | markdownify -}}
+    {{ end }}
+    <span> {{- .Inner | markdownify -}} </span>
   </span>
 </span>

--- a/layouts/shortcodes/keyword.html
+++ b/layouts/shortcodes/keyword.html
@@ -1,12 +1,10 @@
 {{ $icon := .Get "icon"}}
-<span style="margin-top: 0.5rem" class="flex mr-2">
-  <span
-    class="rounded-full bg-primary-500 dark:bg-primary-300 text-neutral-50 dark:text-neutral-700 px-1.5 py-[1px] text-xs font-normal"
-  >
-    <span class="flex items-center">
-      {{if $icon}}
-      <span class="mr-1">{{ partial "icon" $icon }}</span>
-      {{ end }} {{- .Inner | markdownify -}}
-    </span>
+<span
+  class="rounded-full bg-primary-500 dark:bg-primary-300 text-neutral-50 dark:text-neutral-700 px-1.5 py-[1px] text-xs font-normal"
+>
+  <span class="flex items-center">
+    {{if $icon}}
+    <span class="mr-1">{{ partial "icon" $icon }}</span>
+    {{ end }} {{- .Inner | markdownify -}}
   </span>
 </span>

--- a/layouts/shortcodes/keyword.html
+++ b/layouts/shortcodes/keyword.html
@@ -1,1 +1,12 @@
-{{ partial "keyword.html" .Inner }}
+{{ $icon := .Get "icon"}}
+<span style="margin-top: 0.5rem" class="flex mr-2">
+  <span
+    class="rounded-full bg-primary-500 dark:bg-primary-300 text-neutral-50 dark:text-neutral-700 px-1.5 py-[1px] text-xs font-normal"
+  >
+    <span class="flex items-center">
+      {{if $icon}}
+      <span class="mr-1">{{ partial "icon" $icon }}</span>
+      {{ end }} {{- .Inner | markdownify -}}
+    </span>
+  </span>
+</span>

--- a/layouts/shortcodes/keywordList.html
+++ b/layouts/shortcodes/keywordList.html
@@ -1,0 +1,1 @@
+<div class="flex flex-row flex-wrap items-center">{{- .Inner -}}</div>

--- a/layouts/shortcodes/keywordList.html
+++ b/layouts/shortcodes/keywordList.html
@@ -1,1 +1,1 @@
-<div class="flex flex-row flex-wrap items-center">{{- .Inner -}}</div>
+<div class="flex flex-row flex-wrap items-center space-x-2">{{- .Inner -}}</div>


### PR DESCRIPTION
This PR implements #1109, adding a keyword component. I'm a Python developer so all of this HTML is new to me, but I've got something that works. Feel free to make any changes or suggest any improvements.

<img width="653" alt="Screenshot 2023-12-20 at 16 17 43" src="https://github.com/nunocoracao/blowfish/assets/46283223/249ff38c-7317-4a2d-bb62-7249cc801365">

