### PR TITLE
👤 Add website to users.json

### DIFF
--- a/exampleSite/content/users/users.json
+++ b/exampleSite/content/users/users.json
@@ -519,5 +519,13 @@
     "tags": [
       "Personal site"
     ]
+  },
+  {
+    "title": "alxhslm.github.io",
+    "url": "https://alxhslm.github.io/",
+    "tags": [
+      "Personal Site",
+      "Blog"
+    ]
   }
 ]


### PR DESCRIPTION
Adds my [personal website](https://alxhslm.github.io/) to users.json so it appears on the "Users" page.