### PR TITLE
Cursor adjustments to badges section in an article

### DIFF
--- a/layouts/partials/article-meta/basic.html
+++ b/layouts/partials/article-meta/basic.html
@@ -51,7 +51,7 @@
 {{ end }}
 
 
-<div style="cursor: default;" class="flex flex-row flex-wrap items-center">
+<div class="flex flex-row flex-wrap items-center">
   {{/* Output partials */}}
   {{ with ($meta.Get "partials") }}
   {{ delimit . "<span class=\"px-2 text-primary-500\">&middot;</span>" | safeHTML }}
@@ -64,7 +64,7 @@
 </div>
 
 {{ if .Params.showAuthorsBadges | default (.Site.Params.article.showAuthorsBadges | default false) }}
-<div style="cursor: pointer;" class="flex flex-row flex-wrap items-center">
+<div class="flex flex-row flex-wrap items-center">
   {{ range $taxonomy, $terms := .Site.Taxonomies }}
   {{ if (eq $taxonomy "authors")}}
   {{ if (gt (len ($context.GetTerms $taxonomy)) 0) }}
@@ -79,7 +79,7 @@
 
 {{/* Output taxonomies */}}
 {{ if .Params.showTaxonomies | default (.Site.Params.article.showTaxonomies | default false) }}
-<div style="cursor: pointer;" class="flex flex-row flex-wrap items-center">
+<div class="flex flex-row flex-wrap items-center">
   {{ range $taxonomy, $terms := .Site.Taxonomies }}
   {{ if and (not (eq $taxonomy "authors")) (not (eq $taxonomy "series"))}}
   {{ if (gt (len ($context.GetTerms $taxonomy)) 0) }}

--- a/layouts/partials/badge.html
+++ b/layouts/partials/badge.html
@@ -1,7 +1,5 @@
-<span class="flex">
-  <span
-    class="rounded-md border border-primary-400 px-1 py-[1px] text-xs font-normal text-primary-700 dark:border-primary-600 dark:text-primary-400"
-  >
+<span class="flex" style="cursor: pointer;">
+  <span class="rounded-md border border-primary-400 px-1 py-[1px] text-xs font-normal text-primary-700 dark:border-primary-600 dark:text-primary-400">
     {{ . }}
   </span>
 </span>


### PR DESCRIPTION
Previously the hand cursor was visible when hovering the whole line where both the badges and author badges are. That was confusing to know what parts were actually clickable.

Now the cursor appears specifically on each badge and author badge.

Also I removed the `cursor: default` from the date, as it was inconsistent with all the other non-clickable texts which show the text selection cursor. At the same time, this was added intentionally like a month ago, so if it's preferred to keep it this way I can just revert it back.