### PR TITLE
New way to generate UIDs.

### DIFF
--- a/layouts/partials/functions/uid.html
+++ b/layouts/partials/functions/uid.html
@@ -1,0 +1,13 @@
+{{ $uid := .Page.RelPermalink }}
+{{ $ctx := . }}
+
+{{ range seq 16 }}
+  {{ with $ctx }}
+    {{ $uid = printf "%s-%d" $uid .Ordinal }}
+    {{ $ctx = .Parent }}
+  {{ else }}
+    {{ break }}
+  {{ end }}
+{{ end }}
+
+{{ return md5 $uid }}

--- a/layouts/shortcodes/carousel.html
+++ b/layouts/shortcodes/carousel.html
@@ -1,4 +1,4 @@
-{{ $id := delimit (slice "carousel" .Ordinal now.UnixNano) "-" }}
+{{ $id := delimit (slice "carousel" (partial "functions/uid.html" .)) "-" }}
 {{ $aspect := default "16-9" (.Get "aspectRatio") }}
 {{ $images := .Page.Resources.Match (.Get "images") }}
 {{ $interval := default "2000" (.Get "interval") }}

--- a/layouts/shortcodes/chart.html
+++ b/layouts/shortcodes/chart.html
@@ -1,4 +1,4 @@
-{{ $id := delimit (slice "chart" .Ordinal now.UnixNano) "-" }}
+{{ $id := delimit (slice "chart" (partial "functions/uid.html" .)) "-" }}
 <div class="chart">
   <canvas id="{{ $id }}"></canvas>
   <script type="text/javascript">

--- a/layouts/shortcodes/gallery.html
+++ b/layouts/shortcodes/gallery.html
@@ -1,5 +1,4 @@
-{{ $random := delimit (shuffle (seq 1 9)) "" }}
-{{ $id := delimit (slice "gallery" $random now.UnixNano) "-" }}
+{{ $id := delimit (slice "gallery" (partial "functions/uid.html" .)) "-" }}
 
 <div id="{{ $id }}" class="gallery">
   {{ .Inner }}

--- a/layouts/shortcodes/github.html
+++ b/layouts/shortcodes/github.html
@@ -1,4 +1,4 @@
-{{ $id := delimit (slice "github" .Ordinal now.UnixNano) "-" }}
+{{ $id := delimit (slice "github" (partial "functions/uid.html" .)) "-" }}
 {{- $githubURL := print "https://api.github.com/repos/" (.Get "repo") -}}
 {{- $githubData := getJSON ($githubURL) -}}
 {{- $githubColors := .Site.Data.githubColors -}}

--- a/layouts/shortcodes/gitlab.html
+++ b/layouts/shortcodes/gitlab.html
@@ -1,4 +1,4 @@
-{{ $id := delimit (slice "gitlab" .Ordinal now.UnixNano) "-" }}
+{{ $id := delimit (slice "gitlab" (partial "functions/uid.html" .)) "-" }}
 {{- $gitlabURL := print (default "https://gitlab.com/" (.Get "baseURL")) "api/v4/projects/" (.Get "projectID") -}}
 
 {{- $gitLabData := getJSON ($gitlabURL) -}}

--- a/layouts/shortcodes/typeit.html
+++ b/layouts/shortcodes/typeit.html
@@ -13,7 +13,7 @@
 {{- end -}}
 {{- $tag := .Get "tag" | default "div" -}}
 
-{{ $id := delimit (slice "typeit" .Ordinal now.UnixNano) "-" }}
+{{ $id := delimit (slice "typeit" (partial "functions/uid.html" .)) "-" }}
 
 {{- $attrs := printf `id="%v"` $id -}}
 {{- with $classList -}}


### PR DESCRIPTION
I've experimented with a new way of generating unique IDs. These are used on some shortcodes like `gallery`.

There have been several iterations and all of them have had issues. I submitted a PR time ago (https://github.com/nunocoracao/blowfish/pull/738) that used `.Ordinal` to generate a unique number inside the page, to fix several galleries in the same page having the same ID. It was later discovered that this didn't work properly on nested shortcodes, like for example, inside a timeline (https://github.com/nunocoracao/blowfish/issues/1125#issuecomment-1859979392). The current solution generates an id with a random sequence  of numbers. Even if it would be very rare, it cannot be discarded the possibility of generating the same id twice in the same page. And it could go unnoticed by a developer that their site suddenly has some page with a broken gallery, since each build is a gamble.

My new approach consists on having a partial that can be reusable on everything that needs unique IDs, and this partial iterates through all the parents of the shortcode and gets `.Ordinal` on all of them, and generates an ID concatenating the `.RelPermalink` and all ordinals. Then returns the MD5 of the ID. This approach works on all known cases and is deterministic.

For example, in a page with a timeline with two galleries, and then another gallery outside the timeline, the sequence of ordinals for each gallery would be like this:

- 0-0
- 0-1
- 1

It currently supports up to 16 nested shortcodes, which probably is more than enough. But the amount can be increased easily.