### PR TITLE
footer menu supports "pre" icon parameter

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -6,8 +6,15 @@
       <ul class="flex flex-col list-none sm:flex-row">
         {{ range .Site.Menus.footer }}
         <li class="flex mb-1 ltr:text-right rtl:text-left sm:mb-0 ltr:sm:mr-7 ltr:sm:last:mr-0 rtl:sm:ml-7 rtl:sm:last:ml-0">
-          <a class="decoration-primary-500 hover:underline hover:decoration-2 hover:underline-offset-2" href="{{ .URL }}"
-            title="{{ .Title }}">{{ .Name | markdownify | emojify }}</a>
+          <a class="decoration-primary-500 hover:underline hover:decoration-2 hover:underline-offset-2 flex items-center" href="{{ .URL }}"
+            title="{{ .Title }}">
+            {{ if .Pre }}
+            <span {{ if and .Pre .Name}} class="mr-1" {{ end }}>
+                {{ partial "icon.html" .Pre }}
+            </span>
+            {{ end }}
+            {{ .Name | markdownify | emojify }}
+          </a>
         </li>
         {{ end }}
       </ul>


### PR DESCRIPTION
Fix https://github.com/nunocoracao/blowfish/issues/943

Support "pre" icon parameter for footer

```
[[footer]]
  identifier = "twitter"
  pre = "twitter"
  name = "Twitter"
  url = "https://twitter.com/xxx"
  weight = 200
```