### PR TITLE
Correct i18n strings

### DIFF
--- a/i18n/zh-CN.yaml
+++ b/i18n/zh-CN.yaml
@@ -14,10 +14,10 @@ article:
   word_count:
     one: "{{ .Count }} 字"
     other: "{{ .Count }} 字"
-  part_of_series: "This article is part of a series."
-  part: "Part"
-  this_article: "This Article"
-  related_articles: "Related"
+  part_of_series: "这篇文章属于一个选集。"
+  part: "§"
+  this_article: "本文"
+  related_articles: "相关文章"
 
 author:
   byline_title: "作者"


### PR DESCRIPTION
Translated items retained in English in `zh-CN.yaml`.