### PR TITLE
fix GitLab shortcode link url

### DIFF
--- a/layouts/shortcodes/gitlab.html
+++ b/layouts/shortcodes/gitlab.html
@@ -4,7 +4,7 @@
 {{- $gitLabData := getJSON ($gitlabURL) -}}
 {{- with $gitLabData -}}
 
-<a target="_blank" href="{{ .html_url }}" class="cursor-pointer">
+<a id="{{ $id }}" target="_blank" href="{{ .web_url }}" class="cursor-pointer">
   <div class="w-full md:w-auto pt-3 p-5 border border-neutral-200 dark:border-neutral-700 border rounded-md shadow-2xl">
 
     <div class="flex items-center">


### PR DESCRIPTION
The property `.html_url` is no longer present in `https://gitlab.com/api/v4/projects/<projectID>` endpoint. That renders an empty `href`. Instead, the endpoint returns the property `.web_url`