### PR TITLE
Fix background image mode in list view

### DIFF
--- a/layouts/partials/hero/background.html
+++ b/layouts/partials/hero/background.html
@@ -4,12 +4,17 @@
 {{- $featured := $images.GetMatch "*background*" -}}
 {{- if not $featured }}{{ $featured = $images.GetMatch "*feature*" }}{{ end -}}
 {{- if not $featured }}{{ $featured = $images.GetMatch "{*cover*,*thumbnail*}" }}{{ end -}}
-{{ if and .Params.featureimage (not $featured) }}
-{{- $url:= .Params.featureimage -}}
-{{ $featured = resources.GetRemote $url }}
-{{ end }}
-{{- if not $featured }}{{ with .Site.Params.defaultBackgroundImage }}{{ $featured = resources.Get . }}{{ end }}{{ end -}}
 {{ $isParentList := eq (.Scratch.Get "scope") "list"  }}
+{{- if not $featured }}
+{{ with .Site.Params.defaultBackgroundImage }}
+ {{ if or (strings.HasPrefix . "http:") (strings.HasPrefix . "https:") }}
+  {{ $featured = resources.GetRemote . }}
+ {{ else }}
+  {{ $featured = resources.Get . }}
+ {{ end }}
+{{ end }}
+{{ end -}}
+
 {{ $shouldBlur := $.Params.layoutBackgroundBlur | default (or 
         (and ($.Site.Params.article.layoutBackgroundBlur | default true) (not $isParentList)) 
         (and ($.Site.Params.list.layoutBackgroundBlur | default true) ($isParentList))


### PR DESCRIPTION
Fixes comment from

> This line was added to ensure that we fetched the background image using an external URL even in list, term, and taxonomy mode when showHero was set to true.
> 
> Currently, this is causing a bug. When hero mode is set to true, in the list view, it's not showing the background image.
> 
> I think we should keep the if condition. This condition checks if hero mode is set to true then it tries to fetch the image from the externalURL

https://github.com/nunocoracao/blowfish/commit/e87e066aa7250ac033ca01959639cbf795b14614#r138507821