### PR TITLE
:globe_with_meridians: Add Catalan translation

### DIFF
--- a/exampleSite/content/docs/configuration/index.md
+++ b/exampleSite/content/docs/configuration/index.md
@@ -67,6 +67,7 @@ The theme currently supports the following languages by default:
 | 🇦🇪 Arabic                       | `ar`    |
 | 🇧🇬 Bulgarian                    | `bg`    |
 | 🇧🇩 Bengali                      | `bn`    |
+| 🇪🇸 Catalan                      | `ca`    |
 | 🇨🇿 Czech                        | `cs`    |
 | 🇩🇪 German                       | `de`    |
 | 🇬🇧 English                      | `en`    |

--- a/exampleSite/content/docs/welcome/index.md
+++ b/exampleSite/content/docs/welcome/index.md
@@ -26,7 +26,7 @@ A highly requested feature, Blowfish is now multilingual! If you publish your co
 
 <div class="text-2xl text-center" style="font-size: 2.8rem">:gb: :de: :fr: :es: :cn: :brazil: :tr: :bangladesh:</div>
 
-Thanks to submissions from the community, Blowfish has already been translated into [eight languages](https://github.com/nunocoracao/blowfish/tree/main/i18n) with more to be added over time. By the way, [pull requests](https://github.com/nunocoracao/blowfish/pulls) for new languages are always welcome!
+Thanks to submissions from the community, Blowfish has already been translated into [twenty-six languages](https://github.com/nunocoracao/blowfish/tree/main/i18n) with more to be added over time. By the way, [pull requests](https://github.com/nunocoracao/blowfish/pulls) for new languages are always welcome!
 
 ## RTL language support
 

--- a/i18n/ca.yaml
+++ b/i18n/ca.yaml
@@ -1,0 +1,74 @@
+global:
+  language: "CA"
+
+article:
+  anchor_label: "Àncora"
+  date: "{{ .Date }}"
+  date_updated: "Actualitzat: {{ .Date }}"
+  draft: "Esborrany"
+  edit_title: "Editar contingut"
+  reading_time:
+    one: "{{ .Count }} min"
+    other: "{{ .Count }} mins"
+  reading_time_title: "Temps de lectura"
+  table_of_contents: "Taula de contingut"
+  word_count:
+    one: "{{ .Count }} paraula"
+    other: "{{ .Count }} paraules"
+  views:
+    one: "{{ .Count }} visualització"
+    other: "{{ .Count }} visualitzacions"
+  likes:
+    one: "{{ .Count }} m'agrada"
+    other: "{{ .Count }} m'agrades"
+  part_of_series: "Aquest article pertany a una sèrie."
+  part: "Part"
+  this_article: "Aquest article"
+  related_articles: "Relacionats"
+  zen_mode_title:
+    enable: "Activar mode zen"
+    disable: "Desactivar mode zen"
+
+author:
+  byline_title: "Autor"
+
+code:
+  copy: "Copiar"
+  copied: "Copiat"
+
+error:
+  404_title: "Pàgina no trobada :confused:"
+  404_error: "Error 404"
+  404_description: "Sembla que la pàgina sol·licitada no existeix."
+
+footer:
+  dark_appearance: "Canviar a mode fosc"
+  light_appearance: "Canviar a mode clar"
+  powered_by: "Desenvolupat amb {{ .Hugo }} &amp; {{ .Theme }}"
+
+list:
+  externalurl_title: "Enllaç a pàgina externa"
+  no_articles: "Encara no hi ha cap article per a mostrar."
+
+nav:
+  scroll_to_top_title: "Tornar a l'inici"
+  skip_to_main: "Anar al contingut"
+
+search:
+  open_button_title: "Cercar (/)"
+  close_button_title: "Tancar (Esc)"
+  input_placeholder: "Cercar"
+
+sharing:
+  email: "Enviar per correu electrònic"
+  facebook: "Compartir amb Facebook"
+  linkedin: "Compartir amb LinkedIn"
+  pinterest: "Compartir amb Pinterest"
+  reddit: "Publicar a Reddit"
+  twitter: "Tuitejar a Twitter"
+
+shortcode:
+  recent_articles: "Recent"
+
+recent:
+  show_more: "Mostrar més"


### PR DESCRIPTION
I added the Catalan translation for the default i18n strings. I didn't add the language to the list in the [Configuration page of the documentation](https://blowfish.page/docs/installation/), because it is unclear what flag should be used (if any). For that same reason, I chose to apply the `CA` tag in the YAML file. Any suggestions on how to resolve this would be appreciated.

