### PR TITLE
🐛 Anchors Not Functioning Correctly for CJK Headings

### DIFF
--- a/layouts/_default/_markup/render-heading.html
+++ b/layouts/_default/_markup/render-heading.html
@@ -1,10 +1,12 @@
+{{ $strAnchor := urlize .Anchor }}
+{{ $replacedAnchor := replaceRE "%25" "" $strAnchor }}
 <h{{ .Level }} class="relative group">{{ .Text | safeHTML }} 
-    <div id="{{ .Anchor | safeURL }}" class="anchor"></div>
+    <div id="{{ .Anchor | safeURL | urlize }}" class="anchor"></div>
     {{ if.Page.Params.showHeadingAnchors | default (.Page.Site.Params.article.showHeadingAnchors | default true) }}
     <span
         class="absolute top-0 w-6 transition-opacity opacity-0 ltr:-left-6 rtl:-right-6 not-prose group-hover:opacity-100">
         <a class="group-hover:text-primary-300 dark:group-hover:text-neutral-700"
-            style="text-decoration-line: none !important;" href="#{{ .Anchor | safeURL }}" aria-label="{{ i18n "article.anchor_label" }}">#</a>
+            style="text-decoration-line: none !important;" href="#{{ $replacedAnchor | safeURL }}" aria-label="{{ i18n "article.anchor_label" }}">#</a>
     </span>        
     {{ end }}
 </h{{ .Level }}>


### PR DESCRIPTION
## Issue
While utilizing the theme, it was observed that headings containing non-ASCII characters, such as those in Chinese text, were not positioned when clicked on either the Table of Contents (TOC) or the anchor mark (#) preceding the heading. This issue did not occur with headings in plain English.   
## Resolution  
The resolution involved updating the render-heading.html file to implement URL escaping for anchors, enabling accurate positioning for non-ASCII headings.