### PR TITLE
✏️ Fix folder structure example on Thumbnails page

### DIFF
--- a/exampleSite/content/docs/thumbnails/index.md
+++ b/exampleSite/content/docs/thumbnails/index.md
@@ -31,13 +31,14 @@ content
 └── awesome_article.md
 ```
 
-You need to change it from a single markdown file into a folder. Create a directory with the same name of the article, inside create a `index.md` file. You'll get a structure similar to what's below. 
+You need to change it from a single Markdown file into a folder. Create a directory with the same name of the article, inside create a `index.md` file. You'll get a structure similar to what's below. 
 
 ```shell
 content
 └── awesome_article
-    └── featured.png
+    └── index.md
 ```
+
 Then you just need to add an image like explained earlier. If you want to see a sample of this, you can consult [this sample]({{< ref "thumbnail_sample" >}}).
 
 ## Hero Images


### PR DESCRIPTION
Current example looks a little bit confusing because the description in the text and the folder structure in the example don't match. The fix makes it more clear to what the user should have and see after making the changes according to the description.