### PR TITLE
fix: users.json listing

### DIFF
--- a/exampleSite/content/users/users.json
+++ b/exampleSite/content/users/users.json
@@ -521,6 +521,7 @@
     "title": "asterisk.lol",
     "url": "https://asterisk.lol",
     "tags": [
+      "Blog",
       "Personal Site"
     ]
   },


### PR DESCRIPTION
In my last PR the blog tag was missing from my listing, so I fixed that.