### PR TITLE
Bump hugo max = 0.123.3

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,4 +2,4 @@
 [module.hugoVersion]
 extended = true
 min = "0.87.0"
-max = "0.123.1"
+max = "0.123.3"


### PR DESCRIPTION
Bumping hugo max version to `0.123.3` as it was breaking for me on latest hugo. :)