### PR TITLE
translate hosting-deployment && 202310-blowfish-tutorial to zh-cn

### DIFF
--- a/exampleSite/content/docs/hosting-deployment/index.zh-cn.md
+++ b/exampleSite/content/docs/hosting-deployment/index.zh-cn.md
@@ -9,30 +9,30 @@ series: ["部署教程"]
 series_order: 14
 ---
 
-There are many ways to deploy your Hugo website built with Blowfish. The theme is designed to be flexible in almost any deployment scenario.
+有许多方法可以部署基于 Blowfish 主题的 Hugo 网站。这个主题几乎在任何部署场景中都很灵活。
 
-Blowfish is built using relative URLs throughout the theme. This enables sites to easily be deployed to sub-folders and hosts like GitHub Pages. There's usually no special configuration required for this to work as long as the `baseURL` parameter has been configured in the `config.toml` file.
+Blowfish 主题是通过将目录转换成相对 URL 路径来构建的。这让网站可以轻松地将子文件夹部署到类似 GitHub Pages 的托管服务中。只要在 `config.toml` 文件中配置了 `baseURL` 参数即可，通常不需要其他特殊的配置就能正常工作。
 
-The official Hugo [Hosting and Deployment](https://gohugo.io/hosting-and-deployment/) docs are the best place to learn how to deploy your site. The sections below contain some specific theme configuration details that can help you deploy smoothly with certain providers.
+Hugo 官方[托管与部署](https://gohugo.io/hosting-and-deployment/)文档是了解如何部署网站的最佳方案。下面会介绍详细介绍一些方案，希望能帮助你在以下平台顺利部署。
 
-**Choose your provider:**
+**选择你喜欢的服务商：**
 
 - [GitHub Pages](#github-pages)
 - [Netlify](#netlify)
 - [Render](#render)
 - [Cloudflare Pages](#cloudflare-pages)
-- [Shared hosting, VPS or private web server](#shared-hosting-vps-or-private-web-server)
+- [共享主机，VPS 或者 私有服务器](#shared-hosting-vps-or-private-web-server)
 
 ---
 
 ## GitHub Pages
 
-GitHub allows hosting on [GitHub Pages](https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages) using Actions. To enable this functionality, enable Pages on your repo and create a new Actions workflow to build and deploy your site.
+GitHub 允许你使用 Actions 在 [GitHub Pages](https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages) 上托管静态网站。如果想要启用此功能，需要你在代码库中启用 Pages 并创建一个新的 Actions 工作流，以此来构建和部署你的网站。
 
-The file needs to be in YAML format, placed within the `.github/workflows/` directory of your GitHub repository and named with a `.yml` extension.
+工作流文件需要是 YAML 格式，放置在 GitHub 仓库的 `.github/workflows/` 目录下，并以 `.yml` 后缀命名即可。
 
 {{< alert >}}
-**Important:** Ensure you set the correct branch name under `branches` and in the deploy step `if` parameter to the source branch used in your project.
+**重要：** 确保你需要部署的分支 `branches` 分支下和 YAML 的部署步骤中 `if` 参数一致，保证部署正确的分支。
 {{< /alert >}}
 
 ```yaml
@@ -74,19 +74,19 @@ jobs:
           publish_dir: ./public
 ```
 
-Push the config file to GitHub and the action should automatically run. It may fail the first time and you'll need to visit the **Settings > Pages** section of your GitHub repo to check the source is correct. It should be set to use the `gh-pages` branch.
+将配置文件推动到 Github，Github 会自动运行工作流。你需要访问 Github 代码库的 **Settings > Pages** 部分，检查 YAML 配置是否正确。它应该被设置为使用 `gh-pages` 分支。
 
 {{< screenshot src="github-pages-source.jpg" alt="Screen capture of GitHub Pages source" >}}
 
-Once the settings are configured, re-run the action and the site should build and deploy correctly. You can consult the actions log to check everything deployed successfully.
+一旦配置完成后，重新运行 Actions 工作流，网站会正确构建和部署，你就可以查看 Actions 的日志来检查是否部署成功。
 
 ## Netlify
 
-To deploy to [Netlify](https://www.netlify.com), create a new continuous deployment site and link it to your source code. The build settings can be left blank in the Netlify UI. You will only need to configure the domain you'll be using.
+想要部署 [Netlify](https://www.netlify.com)，需要创建一个新的 CI 并关联到你的源码。在 Netlify UI 中，构建的设置可以置空，你只需要配置你要绑定的域名。
 
 {{< screenshot src="netlify-build-settings.jpg" alt="Screen capture of Netlify build settings" >}}
 
-Then in the root of your site repository, create a `netlify.toml` file:
+然后在你的代码库根目录下创建一个 `netlify.toml` 文件，具体内容如下：
 
 ```toml
 # netlify.toml
@@ -108,41 +108,41 @@ Then in the root of your site repository, create a `netlify.toml` file:
   HUGO_VERSION = "0.104.1"
 ```
 
-This configuration assumes you are deploying Blowfish as a Hugo module. If you have installed the theme using another method, change the build command to simply `hugo --gc --minify -b $URL`.
+这个配置默认使用的是 Hugo module 的安装方式来加载 Blowfish 主题的。如果你是通过别的方式加载 Blowfish，请将构建命令改为 `hugo --gc --minify -b $URL`。
 
-When you push the config file to your repo, Netlify should automatically deploy your site. You can check the deploy logs in the Netlify UI to check for any errors.
+当你将配置文件推动到你的代码库时，Netlify 会自动触发并部署你的网站。你可以在 Netlify UI 中查看日志，以检查是否报错。
 
 ## Render
 
-Deploying to [Render](https://render.com) is very straightforward and all configuration is via the Render UI.
+部署到 [Render](https://render.com) 非常地简单易懂，所有的配置都可以通过 Render UI 来完成。
 
-Create a new **Static Site** and link it to your project's code repository. Then simply configure the build command to be `hugo --gc --minify` and publish directory to be `public`.
+创建一个 **静态网站** 并关联到你的代码库。然后只需要配置你的构建命令为 `hugo --gc --minify` 和发布目录为 `public` 即可。
 
 {{< screenshot src="render-settings.jpg" alt="Screen capture of Render settings" >}}
 
-The site will automatically build and deploy whenever you push a change to your repo.
+当你更新你的代码库时，[Render](https://render.com) 总会自动构建并重新部署。
 
 ## Cloudflare Pages
 
-Cloudflare offers the [Pages](https://pages.cloudflare.com/) service that can host Hugo blogs. It builds the site from a git repository and then hosts it on Cloudflare's CDN. Follow their [Hugo deployment guide](https://developers.cloudflare.com/pages/framework-guides/deploy-a-hugo-site) to get started.
+Cloudflare 提供了 [Pages](https://pages.cloudflare.com/) 服务来托管 Hugo 站点。只需要从 Git 仓库构建并托管到 Cloudflare 的 CDN 即可。这部分可以参考 [Hugo 部署指南](https://developers.cloudflare.com/pages/framework-guides/deploy-a-hugo-site)。
 
-The Rocket Loader™ feature offered by Cloudflare tries to speed up rendering of web pages with JavaScript, but it breaks the appearance switcher in the theme. It can also cause an annoying light/dark screen flash when browsing your site due to scripts loading in the wrong order.
+Cloudflare 提供的 Rocket Loader™ 可以通过 JavaScript 来加速网页渲染，但是会破坏 Blowfish 主题中的外观切换器，甚至还有可能因为错误的加载顺序导致网站出现或亮或暗的屏幕闪烁。
 
-This problem can be fixed by disabling it:
+可以通过禁用它来解决：
 
-- Go to the [Cloudflare dashboard](https://dash.cloudflare.com)
-- Click on your domain name in the list
-- Click _Optimization_ in the _Speed_ section
-- Scroll down to _Rocket Loader™_ and disable it
+- 点击 [Cloudflare 控制台](https://dash.cloudflare.com)
+- 点击你的域名
+- 点击 _Speed_ 中的 _Optimization_ 选项
+- 滚动到 _Rocket Loader™_ 并禁用它
 
-Hugo sites built with Blowfish still load very quickly, even with this feature disabled.
+即使不需要这个功能，基于 Blowfish 主题的 Hugo 站点本身加载就比较快。
 
-## Shared hosting, VPS or private web server
+## 共享主机，VPS 或者 私有服务器
 
-Using traditional web hosting, or deploying to your own web server, is as simple as building your Hugo site and transferring the files to your host.
+不论你是使用传统的网站托管，或是部署到你自己的服务器中，这和构建 Hugo 网站并传输文件到你的服务一样简单。
 
-Make sure that the `baseURL` parameter in `config.toml` is set to the full URL to the root of your website (including any sub domains or sub-folders).
+确保 `config.toml` 文件中的 `baseURL` 参数是你的网站根目录的完整 URL（包括任何子域名或子文件夹）。
 
-Then build your site using `hugo` and copy the contents of the output directory to the root of your web server and you will be ready to go. By default, the output directory is named `public`.
+然后使用 `hugo` 构建你的网站，并将输出目录复制到你的服务器根目录，至此你已经部署完毕了。需要注意的是，默认情况下构建好的网站目录是 `public`。
 
-_If you need a hosting provider, check out [Vultr](https://www.vultr.com/?ref=8957394-8H) or [DigitalOcean](https://m.do.co/c/36841235e565). Signing up using these affiliate links will give you up to $100 in free credit so you can try the service._
+_如果你需要一个托管提供商，你可以尝试 [Vultr](https://www.vultr.com/?ref=8957394-8H) 或者 [DigitalOcean](https://m.do.co/c/36841235e565)。注册这些产品默认会给你100美元的免费额度，以便你托管服务。_

--- a/exampleSite/content/guides/202310-blowfish-tutorial/index.zh-cn.md
+++ b/exampleSite/content/guides/202310-blowfish-tutorial/index.zh-cn.md
@@ -1,9 +1,9 @@
 ---
-title: "Build your homepage using Blowfish and Hugo"
-summary: "Just one year ago, I created Blowfish, a Hugo theme crafted to build my unique vision for my personal homepage. I also decided to make it an open-source project. Fast-forward to today, and Blowfish has transformed into a thriving open-source project with over 600 stars on GitHub and a user base of hundreds. In this tutorial, I’ll show you how to get started and have your website running in a couple of minutes."
-description: "Just one year ago, I created Blowfish, a Hugo theme crafted to build my unique vision for my personal homepage. I also decided to make it an open-source project. Fast-forward to today, and Blowfish has transformed into a thriving open-source project with over 600 stars on GitHub and a user base of hundreds. In this tutorial, I’ll show you how to get started and have your website running in a couple of minutes."
-categories: ["Open-Source", "Blowfish"]
-tags: ["tutorial", "blowfish", "hugo"]
+title: "使用 Blowfish和 Hugo 构建你的主页"
+summary: "一年前我创建了 Blowfish，这是一个为了打造我的个人主页而精心设计的 Hugo 主题。我决定将其作为一个开源项目。直到今天，Blowfish 已经变成了一个蓬勃发展的开源项目，在 GitHub 上拥有超过900个 star 和数百名用户。在本教程中，我将向你展示如何搭建并在几分钟内让你的网站运行起来。"
+description: "一年前我创建了 Blowfish，这是一个为了打造我的个人主页而精心设计的 Hugo 主题。我决定将其作为一个开源项目。直到今天，Blowfish 已经变成了一个蓬勃发展的开源项目，在 GitHub 上拥有超过900个 star 和数百名用户。在本教程中，我向像你展示如何搭建并在几分钟内让你的网站运行起来。"
+categories: ["开源", "Blowfish"]
+tags: ["指南", "blowfish", "hugo"]
 externalUrl: "https://nunocoracao.com/posts/202310-blowfish-tutorial/"
 date: 2023-10-04
 draft: false
@@ -12,59 +12,58 @@ authors:
   - nunocoracao
 ---
 
-Just one year ago, I created[Blowfish](https://blowfish.page/), a [Hugo](https://gohugo.io/) theme crafted to build my unique vision for my personal homepage. I also decided to make it an open-source project. Fast-forward to today, and Blowfish has transformed into a thriving open-source project with over 600 stars on GitHub and a user base of hundreds. In this tutorial, I’ll show you how to get started and have your website running in a couple of minutes.
+一年前我创建了 [Blowfish](https://blowfish.page/)，这是一个为了打造我的个人主页而精心设计的 [Hugo](https://gohugo.io/) 主题。我决定将其作为一个开源项目。直到今天，Blowfish 已经变成了一个蓬勃发展的开源项目，在 GitHub 上拥有超过900个 star 和数百名用户。在本教程中，我将向你展示如何搭建并在几分钟内让你的网站运行起来。
 
 {{< github repo="nunocoracao/blowfish" >}}
 
 ## TL;DR
 
-The goal of this guide is to walk a newcomer to Hugo on how to install, manage, and publish your own website. The final version of the code is available in this [repo](https://github.com/nunocoracao/blowfish-tutorial/tree/main) - for those that would like to jump to the end. 
+本指南的目标是指导新用户如何使用 Hugo 快速安装、管理和发布自己的网站。最终的版本可以看这个[代码库](https://github.com/nunocoracao/blowfish-tutorial/tree/main)——如果你想直接跳到结尾的话可以直接看这里。
 
-![Tutorial example](img/01.png)
+![指南示例](img/01.png)
 
-The visual style is just one of the many possibilities available in Blowfish. Users are encouraged to check the [documentation page](https://blowfish.page/) and learn how to customize the theme to their needs. Additionally, there are already [great examples](https://blowfish.page/users/) of the theme from other users available for inspiration. Blowfish also offers several extra features in the form of `shortcodes` available out of the box in the theme - check them out [here](https://blowfish.page/docs/shortcodes/) and get inspired. 
+视觉风格只是 Blowfish 提供的众多特性之一。想要了解更多，我们鼓励你浏览[文档](https://blowfish.page/)，学习如何根据自己的需求自定义主题。另外，已经有许多其他用户使用该主题并提供了十分优秀的[示例](https://blowfish.page/users/)，来为你提供灵感。Blowfish 还提供了一些额外的基于 `短代码` 的功能——你可以在[这里](https://blowfish.page/docs/shortcodes/)查看它们以获取更多灵感。
 
-## Setup your environment
+## 设置你的环境
 
-Let’s begin by installing all the tools you need. This guide will cover the steps for Mac so these instructions might not apply to your hardware and OS. If you are on Windows or Linux, please consult the guides on how to [install Hugo](https://gohugo.io/installation/), and [GitHub’s CLI](https://cli.github.com/) for your OS.
+让我们从安装工具开始。本指南涵盖了在 Mac 操作系统下的步骤，这些命令可能不适用于你的硬件和操作系统。如果你使用的是 Windows 或 Linux，请参考文档：[安装 Hugo](https://gohugo.io/installation/) 和[GitHub CLI](https://cli.github.com/)。
 
-Anyway, if you are using MacOS let’s install `brew` - a package manager for mac - as that will help installing and managing the other tools.
+无论如何，如果你使用的是 MacOS，那么首先需要安装 `brew` ——一个专为 MacOS 的包管理器，这将有助于安装和管理其他工具。
 
 ```bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
 
-Once `brew` is installed let’s install Git, Hugo and GitHub’s CLI.
+安装完成 `brew` 后，让我们安装 Git, Hugo 和 GitHub CLI。
 ```bash
 brew install git
 brew install hugo
 brew install gh
 ```
 
-Create a folder for your code and open a terminal session into it (I chose _blowfish-tutorial_ in the commands below, feel free to call the folder whatever you want).
+为你的网站代码创建一个文件夹，并在终端中打开（我在下面创建了 _blowfish-tutorial_ 文件夹，当然你可以将其重命名为任何名称）。
 ```bash
 mkdir blowfish-tutorial
 cd blowfish-tutorial
 ```
 
-Once inside the folder, the next step is to initialize your local `git`  repo.
+进入文件夹后的下一步，就是初始化你本地的 `git` 仓库。
 ```bash
 git init -b main
 ```
 
-Now, let’s create and sync the local repo to a GitHub repo so that your code is stored remotely.
+现在，让我们创建并同步本地仓库到 GitHub 仓库，这样你的代码就可以在远程存储。
 ```bash
 gh auth login
 gh repo create
 git push --set-upstream origin main
 ```
 
-Check the image below for the options I selected for this guide, again feel free to change names and description to your use-case.
+查看下面的图片，这是我的远程仓库的地址。同样地，你也可以随意更改以适应你自己的 GitHub 仓库。
 
-![gh repo create example](img/ghcreate.png)
+![gh repo 创建示例](img/ghcreate.png)
 
-
-Finally, create a **.gitignore** file which allows you to exclude certain files from your repo automatically. I would start with something like the example below.
+最后，创建一个 **.gitignore** 文件，它会自动排除某些文件，以防止这些文件传到远程仓库。下面的例子是我在 **.gitignore** 文件中添加的文件和文件夹。
 
 ```bash
 #others
@@ -82,6 +81,7 @@ node_modules
 public
 ```
 
+最后一步是保存所有更改，并推送到你的远程仓库中。
 The last step is to save all the changes to the repo.
 ```bash
 git add .
@@ -90,30 +90,30 @@ git push
 ```
 
 
-## Create site and configure it
+## 创建并配置站点
 
-With all the tools ready, creating and configuring your site will be easy. Still within the folder you created in the last section, let’s create an empty Hugo website (_with no theme_).
+所有的准备工作就绪后，创建和配置你的站点将会很容易。继续在上一部分你创建的文件夹内，让我们首先创建一个空的 Hugo 网站（_不关联任何主题_）。
 
 ```bash
 hugo new site --force .
 ```
 
-Once the scaffolding finishes, try the command below to run your page. Open a browser on _[https://localhost:1313](https://localhost:1313)_ to see your site…
+执行完成后，尝试用下面的命令来运行你的网站。打开浏览器并访问 _[https://localhost:1313](https://localhost:1313)_ 即可查看你的网站。
  
 ```bash
 hugo server
 ```
 
- Ups… Page not found – right? 
-This was expected, even though you created a website, Hugo doesn’t give any default experience – aka your site doesn’t have any page to show.  
+emmmm… 页面未找到404了，是吧？
+这是预期内的，你创建了一个空白网站，Hugo 不会添加任何默认的页面——换句话说，你的网站还没有任何页面可以显示。
 
-Next step, let's install Blowfish using `git submodules` which will make it easier to manage and upgrade to new versions in the future.
+下一步，让我门使用 `git submodules` 来安装 Blowfish。通过 `git submodules` 安装可以让以后管理和升级 Blowfish 主题更加方便。
  
 ```bash
 git submodule add -b main https://github.com/nunocoracao/blowfish.git themes/blowfish
 ```
 
-Next, create the following folder structure at the root of your code directory - `config/_default/`. Now you will need to download [these files](https://minhaskamal.github.io/DownGit/#/home?url=https:%2F%2Fgithub.com%2Fnunocoracao%2Fblowfish%2Ftree%2Fmain%2Fconfig%2F%5C_default) and place them in _\_default_ folder you just created. The final structure should look something like this.
+接下来，在你的代码根目录下创建 `config/_default/` 文件夹。现在你需要下载[这些文件](https://minhaskamal.github.io/DownGit/#/home?url=https:%2F%2Fgithub.com%2Fnunocoracao%2Fblowfish%2Ftree%2Fmain%2Fconfig%2F%5C_default)，并把它们放在刚刚创建的 _\_default_ 文件夹内。最终的文件结构看起来应该是这样的。
 
 ```md
 config/_default/
@@ -125,29 +125,28 @@ config/_default/
 `
 ```
 
-
-Open the **config.toml** and uncomment the line **theme = "blowfish”** and you are ready to go. Try the running the site again and check the result at _[https://localhost:1313](https://localhost:1313)_
+打开 **config.toml** 并把 **theme = "blowfish”** 这一样的注释取消掉，目前为止你已经准备好了。再次尝试运行网站，并打开浏览器在_[https://localhost:1313](https://localhost:1313)_查看效果。
 
 ```bash
 hugo server
 ```
 
-You should see something like the image below. Not much yet as we didn’t add any content, but the main skeleton for Blowfish is already in place - just requires configuration. 
+你应该能看到下面这样。目前我们还没有添加任何内容，所以还没有页面，但是 Blowfish 主题已经准备就绪，下面只需要配置。
 
-![blowfish empty site](img/blowfishempty.png)
+![blowfish 空站点](img/blowfishempty.png)
 
-Now let’s configure the theme. 
+现在我们来配置主题。
 
 {{< alert  d>}}
-**FYI** This guide will not cover in detail what each parameter available in Blowfish does – for everything available and how to use it, check [Blowfish documentation](https://blowfish.page/docs/configuration/#theme-parameters) for every option in every file.
+**仅供参考** 本指南不会详细介绍 Blowfish 中的所有特性和参数——如果想要了解所有的功能特性和参数，以及如何使用它们，请参考[Blowfish 文档](https://blowfish.page/docs/configuration/#theme-parameters)。
 {{< /alert >}}
 
 ### menus.en.toml
-This file defines your menu structure, for the top banner and the footer. For this guide, let’s create two menu sections: one for _Posts_ and one for _Tags_. 
-- **Posts** - will display the full list of entries
-- **Tags** - automatically generated based on tags placed on each article
+这个文件定义了你的顶部（banner）和底部（footer）的菜单结构。对于本指南，我们只使用菜单的这两部分：_Posts_ 和 _Tags_。
+- **Posts** - 用于展示网站中的所有内容条目的完整列表
+- **Tags** - 自动生成每篇文章的标签
 
-To achieve this, make sure the following entries exist in the **menus.en.toml** file. Once the changes are done, you should see the menus appearing by re-running **hugo server**.
+为了实现这一点，请确保 **menus.en.toml** 文件中设置了以下参数。完成修改后，重新运行**hugo server**，你将会看到顶部菜单。
 
 ```toml
 [[main]]
@@ -164,33 +163,35 @@ To achieve this, make sure the following entries exist in the **menus.en.toml** 
 
 ### languages.en.toml
 
-This file will configure your main details as the author of the website. Change the section below to reflect your details.
+这个文件配置了网站作者的详细信息。修改下面的内容来定义你自己的信息。
 
 ```bash
 [author]
-   name = "Your name here"
+   name = "名字在这"
    image = "profile.jpg"
-   headline = "I'm only human"
-   bio = "A little bit about you" # appears in author card for each article
+   headline = "我是个好人"
+   bio = "关于我的二三事" # 出现在每篇文章的作者卡片中
 ```
 
-The images for the website should be placed in the _assets_ folder. For this step, please add a profile picture to that folder named _profile.jpg_ or change the configuration above to the filename you chose. If you don’t have a profile image available, you can use the one below for the tutorial.
+网站的图片需要防止在 _assets_ 文件夹内。针对这一步，请将一张你的个人图片添加到这个文件夹，并命名为 _profile.jpg_。
+你可以修改这个文件名，确保文件名和上面个人信息中 `image` 的参数值对应就行。如果你没有个人图片可用，你可以使用下面的图片继续教程。
 
 ![profile](img/profile.jpg "assets/profile.jpg")
 
-The last step is configuring your links – social media, GitHub, etc. The file includes all the supported options, but they are commented. You are welcome to uncomment everything and delete the ones you would rather not use. Replace the right links on the ones you decided to keep. You can also change the order.
-
-
+最后一步是配置你的链接——社交媒体、GitHub 等等。该文件包含了所有支持的链接选项，不过他们被注释掉了。你可以将你希望展示的个人链接的配置项接触注释，也可以替换他们的展示顺序。
 
 ### params.toml
 
-This is the main configuration file for Blowfish. Most of the visual options or customization available can be configured using it, and it covers several areas of the theme. For this tutorial, I decided to use a **background** layout - [check other layouts for Blowfish’s landing page](https://blowfish.page/) - with the **Neon** color scheme - you can pick a different color scheme if you want to - check [this list](https://blowfish.page/docs/getting-started/#colour-schemes) or [create your own](https://blowfish.page/docs/advanced-customisation/#colour-schemes).
+这个文件是 Blowfish 的配置文件。大部分的视觉选项或自定义的选项可以通过它进行配置，它涵盖了 Blowfish 主题的多个功能特性。
+对于本指南，我决定使用 **background** 布局，你也可以[查看Blowfish主题其他的主页布局](https://blowfish.page/)；同时使用了 **Neon** 颜色方案，你可以查看[完整的颜色方案列表](https://blowfish.page/docs/getting-started/#colour-schemes)或者[创建自己的颜色方案](https://blowfish.page/docs/advanced-customisation/#colour-schemes)。
 
-Add an **image.jpg** to the assets folder which will be the background for the site. You can also download the examples I am using in this tutorial.
+将 **image.jpg** 文件添加到 assets 文件夹，它将会作为网站的背景。你可以挑选自己喜欢的，当然也可以用本指南中使用的这张图。
 
 ![background](img/background.jpg "assets/image.jpg")
 
-Now let’s jump into the _params.toml_ and start configuring the file. I will focus only on the values that need to be changed, don’t delete the rest of the file without reading the docs. Let’s begin by making sure that we have the right color scheme, that image optimization is on, and configure the default background image.
+现在让我们打开 _params.toml_ 并开始配置。在这里我只会关注需要修改的值，不要再没看文档的情况下，删除此文件的其余部分。
+
+首先让我们确保上面提到的正确的颜色方案，开启图片优化，并设置默认背景图片。
 
 ```bash
 colorScheme = "neon"
@@ -198,7 +199,7 @@ disableImageOptimization = false
 defaultBackgroundImage = "image.jpg" # used as default for background images 
 ```
 
-Next, let's configure our homepage. We’re going with the _background_ layout, configuring the homepage image and recent items. Furthermore, we are using the **card view** for items in the recent category. Finally, let’s configure the header to be fixed.
+接下来，让我们配置首页。我们选择了 _background_ 布局，配置首页图片和最近文章。此外，可以使用 **card view** 卡片展示的方式来展现最新文章。最后让我们配置头部固定。
 
 ```bash
 [homepage]
@@ -216,7 +217,7 @@ Next, let's configure our homepage. We’re going with the _background_ layout, 
   layout = "fixed"
 ```
 
-Now configure how the article and list pages will look. Here are the configurations for those. 
+现在配置文章和列表页面的展示。下面是他们的配置。
 
 ```bash
 [article]
@@ -233,33 +234,35 @@ Now configure how the article and list pages will look. Here are the configurati
   cardView = true
 ```
 
-
+如果你再次运行**hugo server**，你会看到类似下面这张图的效果。
 If you run **hugo server** again, you should see something like the image below.
 
 
-![blowfish no articles](img/blowfishnoarticles.png)
+![blowfish 没有文章](img/blowfishnoarticles.png)
 
 
 
-## Adding content to your site
+## 在你的网站中添加内容
 
-Create a folder to place your posts in  `/content/posts`. This was also the directory configured in your menu to list all the articles. Within that folder, let’s create a new directory and give it the name **myfirstpost**. Within it create an **index.md** file – your article and place a featured.jpg or .png for in the same directory as the thumbnail for the article. Use the example below to get started. The first lines in the file are the Front Matter, which tell Hugo what the look and experience of the article will be – different themes support different params for this. Check the [docs](https://blowfish.page/docs/front-matter/) for more info.
+创建一个文件夹`/content/posts`，在这个文件夹下添加你的帖子或文章。这也是你在菜单所配置的所有文章的根目录。在这个文件夹内，让我们创建一个新目录并命名为 **myfirstpost**。在这个目录中创建一个**index.md**文件作为你的文章，同样也在这个目录中添加**featured.jpg**或**featured.png**作为文章的缩略图。
+参考下面这个示例。文件中的前几行是扉页参数（Front Matter），它定义了 Hugo 如何展示文章，更多的参数可以参考[这里](https://blowfish.page/docs/front-matter/)。
 
 ```md
 ---
-title: "My first post"
+title: "我的第一篇帖子"
 date: 2023-08-14
 draft: false
-summary: "This is my first post on my site"
+summary: "这是网站的第一篇你帖子"
 tags: ["space"]
 ---
 
-## A sub-title
+## 一个副标题
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi nibh nisl, vulputate eu lacus vitae, maximus molestie libero. Vestibulum laoreet, odio et sollicitudin sollicitudin, quam ligula tempus urna, sed sagittis eros eros ac felis. In tristique tortor vitae lacinia commodo. Mauris venenatis ultrices purus nec fermentum. Nunc sit amet aliquet metus. Morbi nisl felis, gravida ac consequat vitae, blandit eu libero. Curabitur porta est in dui elementum porttitor. Maecenas fermentum, tortor ac feugiat fringilla, orci sem sagittis massa, a congue risus ipsum vel massa. Aliquam sit amet nunc vulputate, facilisis neque in, faucibus nisl.
 ```
 
-You can create additional articles to see what your site will look like once there is content in it. Your site should look like the images below. The main page shows the recent articles, each article is connected through others automatically via related section, you have tag aggregation, and full-text search. 
+你可以创建其他文章，来查看和验证站点的效果。你的网站应该像下面的图片一样。
+主页显示最近的文章，每篇文章通过相关部分自动关联其他文章，有标签聚合和全文搜索。
 
 {{< gallery >}}
   <img src="img/blowfishrecent.png" class="grid-w50" />
@@ -269,31 +272,31 @@ You can create additional articles to see what your site will look like once the
 {{< /gallery >}}
 
 
-## Ship it
+## 发布它
 
-The only thing missing is to ship your site. I will be using [Firebase](https://firebase.google.com/) for hosting - it’s a free alternative and provides more advanced features if you are creating something more complex. Go to firebase and create a new project. Once that is done, let’s switch to the CLI as it will make it easier to configure everything.
+现在只剩下发布你的网站了。我将会使用 [Firebase](https://firebase.google.com/) 作为托管服务——这是一个免费的替代方案，如果你创建了更复杂的东西，它提供了高级功能。前往 [Firebase](https://firebase.google.com/) 创建一个新项目，然后我们切换到 CLI 终端，这将是配置 [Firebase](https://firebase.google.com/) 更加简单。
 
-Let’s install firebase’s CLI - if not on Mac check [install instructions on Firebase](https://firebase.google.com/docs/cli).
+让我们安装 [Firebase](https://firebase.google.com/) CLI 工具 —— 如果你不是 MacOS，请查看 [Firebase安装指南](https://firebase.google.com/docs/cli)。
 ```bash
 brew install firebase
 ```
 
-Now log in and init firebase hosting for the project.
+现在登录并为你的项目初始化firebase托管服务。
 
 ```bash
 firebase login
 firebase init
 ```
 
-Select hosting and proceed.
+选择托管并继续。
 
-![firebase init](img/firebasecli.png)
+![firebase 初始化](img/firebasecli.png)
 
-Follow the image below for the options I recommend. Make sure to set up the workflow files for GitHub actions. These will guarantee that your code will be deployed once there is a change to the repo.
+按照下面的图片进行，这是我推荐的方式。确保设置了 GitHub actions 工作流文件。这将保证你的 GitHub 仓库一旦有变化，就会立刻同步部署。
 
-![firebase options](img/firebaseoptions.png)
+![firebase 选项](img/firebaseoptions.png)
 
-However, those files will not work out-of-box, as Hugo requires extra steps for the build to work. Please copy and paste the code blocks below to the respective files within the **.github** folder, but keep the original **projectId** in the files generated by firebase.
+然而，这些文件不会立刻开始运行，因为 Hugo 需要额外的步骤来提前构建。将下面的代码复制并粘贴到 **.github** 文件夹，同时保留文件中 firebase 生成的**projectId**。
 
 ### firebase-hosting-merge.yml
 ```yaml
@@ -378,8 +381,7 @@ jobs:
           projectId: blowfish-tutorial
 ```
 
-
-The last step is committing your code to GitHub and let the workflows you created take care of deploying your site. Since we configured GitHub actions, this will trigger a job that will configure and deploy your site automatically.
+最后一步是将你的代码提交到 GitHub，提交成功后 GitHub actions 工作流将会自动触发，并构建和部署你的网站。
 
 ```bash
 git add .
@@ -387,17 +389,20 @@ git commit -m "add github actions workflows"
 git push  
 ```
 
-If the actions tab for your repo, you should see something like this.
+你的 GitHub 仓库中的 actions 模块，将会显示类似下图的内容。
 
 ![gh actions](img/githubactions.png)
 
+当所有步骤完成之后，你的 Firebase 控制台将会显示类似下图的内容，包括一个可以查看网站的链接。我在[https://blowfish-tutorial.web.app/](https://blowfish-tutorial.web.app/)中运行了这个教程。
 Once all the steps finish, your Firebase console should show something like the image below - including the links to see your app – I got a version of this tutorial running on [https://blowfish-tutorial.web.app/](https://blowfish-tutorial.web.app/).
 
 ![firebase console](img/firebaseconsole.png)
 
 
-## Conclusion and Next Steps
+## 结论和下一步
 
+现在你有了主页的第一个版本。你可以在本地进行更改，只要你提交代码，将会自动展示在你的网站中。
+那么接下来要做什么呢？我给你留了一下链接，相信会对你有所帮你，其它这些链接会让你获得灵感并了解更多 Blowfish 和 Hugo 的内容。
 Now you have your first version of your homepage. You can make changes locally and once you commit your code they will automatically be reflected online. What shall you do next? I’ll leave you with some useful links to get you inspired and learn more about Blowfish and Hugo. 
 
 - https://blowfish.page/docs/


### PR DESCRIPTION
translate docs to zh-cn:

./exampleSite/content/docs/hosting-deployment/index.zh-cn.md
./exampleSite/content/guides/202310-blowfish-tutorial/index.zh-cn.md

Maybe
 ./exampleSite/content/samples/placeholder-text/index.zh-cn.md
does not need to be translated ?

https://github.com/nunocoracao/blowfish/issues/1358