### PR TITLE
🐛 Fix TOC scroll indicator with CJK characters

### DIFF
--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -33,7 +33,7 @@
         h.each(function (i, e) {
           e = $(e);
           if (e.offset().top - $(window).height()/3 <= currentScroll) {
-            id = e.attr('id');
+            id = decodeURIComponent(e.attr('id'));
           }
         });
         var active = $toc.find('a.active');      


### PR DESCRIPTION
If a header text contains CJK characters, the anchor id of it will be encoded.

For example, the id of [`Icon 图标`](https://blowfish.page/zh-cn/docs/partials/#icon-%E5%9B%BE%E6%A0%87) is `icon-%E5%9B%BE%E6%A0%87`. 

So the set active actions for TOC with `('a[href="#' + id + '"]').addClass('active')` will be impossible to set to the right TOC element, since the id equals `icon-%E5%9B%BE%E6%A0%87` and the href in TOC is `#icon-图标`.

A simple conversion with decodeURIComponent() will fix this well.