### PR TITLE
Use AutoOrient filter when resizing images

### DIFF
--- a/layouts/partials/article-link/card-related.html
+++ b/layouts/partials/article-link/card-related.html
@@ -24,7 +24,11 @@
         <div class="w-full thumbnail_card_related nozoom" style="background-image:url({{ .RelPermalink }});"></div>
         {{ end }}
       {{ else }}
-        {{ with .Resize "600x" }}
+      {{ $filters := slice
+        images.AutoOrient
+        (images.Process "resize 600x")
+      }}
+      {{ with images.Filter $filters . }}
         <div class="w-full thumbnail_card_related nozoom" style="background-image:url({{ .RelPermalink }});"></div>
         {{ end }}
       {{ end }}

--- a/layouts/partials/article-link/card.html
+++ b/layouts/partials/article-link/card.html
@@ -25,7 +25,11 @@
         <div class="w-full thumbnail_card nozoom" style="background-image:url({{ .RelPermalink }});"></div>
         {{ end }}
       {{ else }}
-        {{ with .Resize "600x" }}
+        {{ $filters := slice
+          images.AutoOrient
+          (images.Process "resize 600x")
+        }}
+        {{ with images.Filter $filters . }}
         <div class="w-full thumbnail_card nozoom" style="background-image:url({{ .RelPermalink }});"></div>
         {{ end }}
       {{ end }}

--- a/layouts/partials/article-link/simple.html
+++ b/layouts/partials/article-link/simple.html
@@ -52,7 +52,11 @@
         <div class="{{ $articleImageClasses }}" style="background-image:url({{ .RelPermalink }});"></div>
         {{ end }}
       {{ else }}
-        {{ with .Resize "600x"  }}
+        {{ $filters := slice
+          images.AutoOrient
+          (images.Process "resize 600x")
+        }}
+        {{ with images.Filter $filters . }}
         <div class="{{ $articleImageClasses }}" style="background-image:url({{ .RelPermalink }});"></div>
         {{ end }}
       {{ end }}

--- a/layouts/partials/hero/background.html
+++ b/layouts/partials/hero/background.html
@@ -41,7 +41,11 @@
     style="background-image:url({{ .RelPermalink }});">
     {{ end }}
 {{ else }}
-    {{ with .Resize "1200x" }}
+    {{ $filters := slice
+        images.AutoOrient
+        (images.Process "resize 1200x")
+    }}
+    {{ with images.Filter $filters . }}
     <div class="fixed inset-x-0 top-0 h-[800px] single_hero_background nozoom"
     style="background-image:url({{ .RelPermalink }});">
     {{ end }}

--- a/layouts/partials/hero/basic.html
+++ b/layouts/partials/hero/basic.html
@@ -26,7 +26,11 @@
             <div class="w-full h-36 md:h-56 lg:h-72 single_hero_basic nozoom" style="background-image:url({{ .RelPermalink }});"></div>
         {{ end }}
     {{ else }}
-        {{ with .Resize "1200x" }}
+        {{ $filters := slice
+            images.AutoOrient
+            (images.Process "resize 1200x")
+        }}
+        {{ with images.Filter $filters . }}
             <div class="w-full h-36 md:h-56 lg:h-72 single_hero_basic nozoom" style="background-image:url({{ .RelPermalink }});"></div>
         {{ end }}
     {{ end }}

--- a/layouts/partials/hero/big.html
+++ b/layouts/partials/hero/big.html
@@ -48,7 +48,11 @@
         </figure>
         {{ end }}
     {{ else }}
-        {{ with .Resize "1200x" }}
+        {{ $filters := slice
+            images.AutoOrient
+            (images.Process "resize 1200x")
+        }}
+        {{ with images.Filter $filters . }}
         <figure>
             <img class="w-full rounded-lg single_hero_round nozoom" alt="{{ $alt }}" width="{{ .Width }}" height="{{ .Height }}" src="{{ .RelPermalink }}">
             {{ if $caption }}

--- a/layouts/partials/hero/thumbAndBackground.html
+++ b/layouts/partials/hero/thumbAndBackground.html
@@ -25,7 +25,11 @@
 <div class="w-full rounded-md h-36 md:h-56 lg:h-72 single_hero_basic nozoom" style="background-image:url({{ .RelPermalink }});"></div>
 {{ end }}
 {{ else }}
-{{ with .Resize "1200x" }}
+{{ $filters := slice
+    images.AutoOrient
+    (images.Process "resize 1200x")
+}}
+{{ with images.Filter $filters . }}
 <div class="w-full rounded-md h-36 md:h-56 lg:h-72 single_hero_basic nozoom" style="background-image:url({{ .RelPermalink }});"></div>
 {{ end }}
 {{ end }}
@@ -44,7 +48,11 @@
     </div>
 </div>{{ end }}
 {{ else }}
-{{ with .Resize "1200x" }}
+{{ $filters := slice
+    images.AutoOrient
+    (images.Process "resize 1200x")
+}}
+{{ with images.Filter $filters . }}
 <div class="fixed inset-x-0 top-0 h-[800px] single_hero_background nozoom"
     style="background-image:url({{ .RelPermalink }});">
     <div class="absolute inset-0 bg-gradient-to-t from-neutral dark:from-neutral-800 to-transparent mix-blend-normal">

--- a/layouts/partials/term-link/card.html
+++ b/layouts/partials/term-link/card.html
@@ -17,7 +17,11 @@
         <div class="w-full thumbnail_card nozoom" style="background-image:url({{ .RelPermalink }});"></div>
         {{ end }}
       {{ else }}
-        {{ with .Resize "600x"  }}
+        {{ $filters := slice
+          images.AutoOrient
+          (images.Process "resize 600x")
+        }}
+        {{ with images.Filter $filters . }}
         <div class="w-full thumbnail_card nozoom" style="background-image:url({{ .RelPermalink }});"></div>
         {{ end }}
       {{ end }}


### PR DESCRIPTION
> Note - Haven't really developed for hugo, unsure if this has some unexpected consequences.

## What

Hugo, when resizing images, ignores EXIF data and suddenly some images (e.g. photos taken with a phone in portrait mode, I believe) end up rotated by 90 degrees.

## Why

I'd like to use images straight from my devices, without need to manually scrub EXIF data and then re-rotate each image.

## How

By adding Hugo's [auto orient](https://gohugo.io/functions/images/autoorient/) filter, wherever image is resized in layouts.