### PR TITLE
✨ Use markdown emojify instead of dump emojify

### DIFF
--- a/exampleSite/layouts/partials/recent-articles-demo.html
+++ b/exampleSite/layouts/partials/recent-articles-demo.html
@@ -37,7 +37,7 @@
     <a href="{{ $showMoreLinkDest }}">
         <button
             class="bg-transparent hover:text-primary-500 prose dark:prose-invert font-semibold hover:text-white py-2 px-4 border border-primary-500 hover:border-transparent rounded">
-            {{ i18n "recent.show_more" | markdownify | emojify }}
+            {{ i18n "recent.show_more" | markdownify }}
             </button>
     </a>
 </div>

--- a/layouts/_default/index.json
+++ b/layouts/_default/index.json
@@ -9,8 +9,8 @@
     "date" (.Date | time.Format (.Site.Language.Params.dateFormat | default ":date_long")) 
     "title" (.Title | emojify | safeJS)
     "section" ($section.Title | emojify | safeJS)
-    "summary" (.Summary | emojify | safeJS)
-    "content" (.Plain | emojify | safeJS)
+    "summary" (.Summary | safeJS)
+    "content" (.Plain | safeJS)
     "permalink" .RelPermalink
     "externalUrl" .Params.externalUrl
     "type" .Type

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -49,7 +49,7 @@
     </div>
     {{ end }}
     <div class="min-w-0 min-h-0 max-w-prose">
-      {{ .Content | emojify }}
+      {{ .Content }}
     </div>
    
 

--- a/layouts/_default/simple.html
+++ b/layouts/_default/simple.html
@@ -9,7 +9,7 @@
       </h1>
     </header>
     <section class="max-w-full mt-6 prose dark:prose-invert">
-      {{ .Content | emojify }}
+      {{ .Content }}
     </section>
     <footer class="pt-8">
       {{ partial "sharing-links.html" . }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -80,7 +80,7 @@
         {{ partial "series/series.html" . }}
 
         <div class="article-content max-w-prose mb-20">
-          {{ .Content | emojify }}
+          {{ .Content }}
         </div>
         
         {{ if (.Params.showAuthorBottom | default ( .Site.Params.article.showAuthorBottom | default false)) }}

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -25,7 +25,7 @@
   {{ if .Content }}
     <section class="flex flex-col max-w-full mt-0 prose dark:prose-invert lg:flex-row">
       <div class="min-w-0 min-h-0 max-w-prose">
-        {{ .Content | emojify }}
+        {{ .Content }}
       </div>
     </section>
   {{ end }}

--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -24,7 +24,7 @@
   <section class="flex flex-col max-w-full mt-0 mb-5 prose dark:prose-invert lg:flex-row">
     {{ if .Content }}
     <div class="min-w-0 min-h-0 max-w-prose">
-      {{ .Content | emojify }}
+      {{ .Content }}
     </div>
     {{ end }}
     <script>

--- a/layouts/partials/article-link/card-related.html
+++ b/layouts/partials/article-link/card-related.html
@@ -65,7 +65,7 @@
 
         {{ if .Params.showSummary | default (.Site.Params.list.showSummary | default false) }}
         <div class="py-1 prose dark:prose-invert">
-          {{ .Summary | emojify }}
+          {{ .Summary }}
         </div>
         {{ end }}
       </div>

--- a/layouts/partials/article-link/card.html
+++ b/layouts/partials/article-link/card.html
@@ -66,7 +66,7 @@
 
         {{ if .Params.showSummary | default (.Site.Params.list.showSummary | default false) }}
         <div class="py-1 prose dark:prose-invert">
-          {{ .Summary | emojify }}
+          {{ .Summary }}
         </div>
         {{ end }}
       </div>

--- a/layouts/partials/article-link/simple.html
+++ b/layouts/partials/article-link/simple.html
@@ -94,7 +94,7 @@
       </div>
       {{ if .Params.showSummary | default (.Site.Params.list.showSummary | default false) }}
       <div class="py-1 max-w-fit prose dark:prose-invert">
-        {{ .Summary | emojify }}
+        {{ .Summary }}
       </div>
       {{ end }}
     </div>

--- a/layouts/partials/author-extra.html
+++ b/layouts/partials/author-extra.html
@@ -21,13 +21,13 @@
     {{ $link := .link}}
     {{ with .data.name | markdownify | emojify }}
     <div class="text-[0.6rem] uppercase leading-3 text-neutral-500 dark:text-neutral-400">
-      {{ i18n "author.byline_title" | markdownify | emojify }}
+      {{ i18n "author.byline_title" | markdownify }}
     </div>
     <a {{ if $link }} href="{{ $link }}" {{ end }} class="font-semibold leading-6 text-neutral-800 dark:text-neutral-300">
       {{ . }}
     </a>
     {{ end }}
-    {{ with .data.bio | markdownify | emojify }}
+    {{ with .data.bio | markdownify }}
     <div class="text-sm text-neutral-700 dark:text-neutral-400">{{ . }}</div>
     {{ end }}
     <div class="text-2xl sm:text-lg">

--- a/layouts/partials/author.html
+++ b/layouts/partials/author.html
@@ -23,15 +23,15 @@
     {{ end }}
   {{ end }}
   <div class="place-self-center">
-    {{ with .Site.Author.name | markdownify | emojify }}
+    {{ with .Site.Author.name | markdownify }}
     <div class="text-[0.6rem] uppercase leading-3 text-neutral-500 dark:text-neutral-400">
-      {{ i18n "author.byline_title" | markdownify | emojify }}
+      {{ i18n "author.byline_title" | markdownify }}
     </div>
     <div class="font-semibold leading-6 text-neutral-800 dark:text-neutral-300">
       {{ . }}
     </div>
     {{ end }}
-    {{ with .Site.Author.bio | markdownify | emojify }}
+    {{ with .Site.Author.bio | markdownify }}
     <div class="text-sm text-neutral-700 dark:text-neutral-400">{{ . }}</div>
     {{ end }}
     <div class="text-2xl sm:text-lg">{{ partialCached "author-links.html" . }}</div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -13,7 +13,7 @@
                 {{ partial "icon.html" .Pre }}
             </span>
             {{ end }}
-            {{ .Name | markdownify | emojify }}
+            {{ .Name | markdownify }}
           </a>
         </li>
         {{ end }}
@@ -27,11 +27,11 @@
     {{ if .Site.Params.footer.showCopyright | default true }}
     <p class="text-sm text-neutral-500 dark:text-neutral-400">
       {{- with replace .Site.Params.copyright "{ year }" now.Year  }}
-      {{ . | emojify | markdownify }}
+      {{ . | emojify }}
       {{- else }}
       &copy;
       {{ now.Format "2006" }}
-      {{ .Site.Author.name | markdownify | emojify }}
+      {{ .Site.Author.name | markdownify }}
       {{- end }}
     </p>
     {{ end }}

--- a/layouts/partials/header/basic.html
+++ b/layouts/partials/header/basic.html
@@ -5,7 +5,7 @@
     {{ if $logo }}
     <div>
         <a href="{{ "" | relLangURL }}" class="flex">
-            <span class="sr-only">{{ .Site.Title | markdownify | emojify }}</span>
+            <span class="sr-only">{{ .Site.Title | markdownify }}</span>
 
             <img src="{{ $logo.RelPermalink }}" width="{{ div $logo.Width 2 }}" height="{{ div $logo.Height 2 }}"
                 class="logo max-h-[5rem] max-w-[5rem] object-scale-down object-left nozoom" alt="{{ .Site.Title }}" />
@@ -20,7 +20,7 @@
             {{ if not .Site.Params.disableTextInHeader | default true }}
             <a href="{{ "" | relLangURL }}" class="text-base font-medium text-gray-500 hover:text-gray-900">{{
                 .Site.Title | markdownify
-                | emojify }}</a>
+                }}</a>
             {{ end }}
 
         </nav>
@@ -129,7 +129,7 @@
                             </span>
                             {{ end }}
                             <p class="text-sm font-sm text-gray-500 hover:text-gray-900" title="{{ .Title }}">
-                                {{ .Name | markdownify | emojify }}
+                                {{ .Name | markdownify }}
                             </p>
                         </a>
                     </li>
@@ -157,7 +157,7 @@
             </span>
             {{ end }}
             <p class="text-xs font-light text-gray-500 hover:text-gray-900" title="{{ .Title }}">
-                {{ .Name | markdownify | emojify }}
+                {{ .Name | markdownify }}
             </p>
         </a>
         {{ end }}

--- a/layouts/partials/header/header-mobile-option-nested.html
+++ b/layouts/partials/header/header-mobile-option-nested.html
@@ -6,7 +6,7 @@
         </span>
         {{ end }}
         <p class="text-bg font-bg" title="{{ .Title }}">
-            {{ .Name | markdownify | emojify }}
+            {{ .Name | markdownify }}
         </p>
         <span>
             {{ partial "icon.html" "chevron-down" }}
@@ -23,7 +23,7 @@
         </span>
         {{ end }}
         <p class="text-sm font-small" title="{{ .Title }}">
-            {{ .Name | markdownify | emojify }}
+            {{ .Name | markdownify }}
         </p>
     </a>
 </li>

--- a/layouts/partials/header/header-mobile-option-simple.html
+++ b/layouts/partials/header/header-mobile-option-simple.html
@@ -7,7 +7,7 @@
         </div>
         {{ end }}
         <p class="text-bg font-bg" title="{{ .Title }}">
-            {{ .Name | markdownify | emojify }}
+            {{ .Name | markdownify }}
         </p>
     </a>
 </li>

--- a/layouts/partials/header/header-option-nested.html
+++ b/layouts/partials/header/header-option-nested.html
@@ -7,7 +7,7 @@
     {{ end }}
     <a {{ if .URL }} href="{{ .URL }}" {{ if or (strings.HasPrefix .URL "http:" ) (strings.HasPrefix .URL "https:" ) }}
       target="_blank" {{ end }} {{ end }} class="text-base font-medium text-gray-500 hover:text-primary-600 dark:hover:text-primary-400" title="{{ .Title }}">
-      {{ .Name | markdownify | emojify }}
+      {{ .Name | markdownify }}
     </a>
     <span>
       {{ partial "icon.html" "chevron-down" }}
@@ -25,7 +25,7 @@
           </span>
           {{ end }}
           <p class="text-sm font-sm" title="{{ .Title }}">
-            {{ .Name | markdownify | emojify }}
+            {{ .Name | markdownify }}
           </p>
         </a>
         {{ end }}

--- a/layouts/partials/header/header-option-simple.html
+++ b/layouts/partials/header/header-option-simple.html
@@ -6,6 +6,6 @@
     </span>
     {{ end }}
     <p class="text-base font-medium" title="{{ .Title }}">
-        {{ .Name | markdownify | emojify }}
+        {{ .Name | markdownify }}
     </p>
 </a>

--- a/layouts/partials/home/background.html
+++ b/layouts/partials/home/background.html
@@ -51,7 +51,7 @@
                     </h1>
                     {{ with .Site.Author.headline }}
                     <h2 class="mt-0 mb-0 text-xl text-neutral-800 dark:text-neutral-300">
-                        {{ . | markdownify | emojify }}
+                        {{ . | markdownify }}
                     </h2>
                     {{ end }}
                     <div class="mt-3 mb-10 text-2xl">
@@ -67,7 +67,7 @@
                         </div>
                         {{ end }}
                     </div>
-                    <section class="prose dark:prose-invert">{{ .Content | emojify }}</section>
+                    <section class="prose dark:prose-invert">{{ .Content }}</section>
                 </div>
             </div>
         </div>

--- a/layouts/partials/home/card.html
+++ b/layouts/partials/home/card.html
@@ -9,7 +9,7 @@
                         <h1>{{ . | emojify }}</h1>
                       </header>
                     {{ end }}
-                    <section>{{ .Content | emojify }}</section>
+                    <section>{{ .Content }}</section>
                   </article>
             </div>
             <div class="mt-6 sm:mt-16 lg:mt-0 mx-auto max-w-xl px-4 sm:px-6 lg:mx-0 lg:max-w-none lg:py-16 lg:px-0">

--- a/layouts/partials/home/hero.html
+++ b/layouts/partials/home/hero.html
@@ -48,7 +48,7 @@
                     </h1>
                     {{ with .Site.Author.headline }}
                     <h2 class="mt-0 mb-0 text-xl text-neutral-300">
-                        {{ . | markdownify | emojify }}
+                        {{ . | markdownify }}
                     </h2>
                     {{ end }}
                     <div class="mt-3 mb-10 text-2xl">
@@ -64,7 +64,7 @@
                         </div>
                         {{ end }}
                     </div>
-                    <section class="prose prose-invert">{{ .Content | emojify }}</section>
+                    <section class="prose prose-invert">{{ .Content }}</section>
                 </div>
             </div>
         </div>

--- a/layouts/partials/home/page.html
+++ b/layouts/partials/home/page.html
@@ -4,7 +4,7 @@
       <h1>{{ . | emojify }}</h1>
     </header>
   {{ end }}
-  <section>{{ .Content | emojify }}</section>
+  <section>{{ .Content }}</section>
 </article>
 <section>
   {{ partial "recent-articles/main.html" . }}

--- a/layouts/partials/home/profile.html
+++ b/layouts/partials/home/profile.html
@@ -23,14 +23,14 @@
     </h1>
     {{ with .Site.Author.headline }}
     <h2 class="text-xl text-neutral-500 dark:text-neutral-400">
-      {{ . | markdownify | emojify }}
+      {{ . | markdownify }}
     </h2>
     {{ end }}
     <div class="mt-1 text-2xl">
       {{ partialCached "author-links.html" . }}
     </div>
   </header>
-  <section class="prose dark:prose-invert">{{ .Content | emojify }}</section>
+  <section class="prose dark:prose-invert">{{ .Content }}</section>
 </article>
 <section>
   {{ partial "recent-articles/main.html" . }}

--- a/layouts/partials/meta/date-updated.html
+++ b/layouts/partials/meta/date-updated.html
@@ -1,4 +1,4 @@
 <time datetime="{{ . }}">
-  {{- i18n "article.date_updated" (dict "Date" (partial "functions/date.html" .)) | markdownify | emojify -}}
+  {{- i18n "article.date_updated" (dict "Date" (partial "functions/date.html" .)) | markdownify -}}
 </time>
 {{- /* Trim EOF */ -}}

--- a/layouts/partials/meta/date.html
+++ b/layouts/partials/meta/date.html
@@ -1,4 +1,4 @@
 <time datetime="{{ . }}">
-  {{- i18n "article.date" (dict "Date" (partial "functions/date.html" .)) | markdownify | emojify -}}
+  {{- i18n "article.date" (dict "Date" (partial "functions/date.html" .)) | markdownify -}}
 </time>
 {{- /* Trim EOF */ -}}

--- a/layouts/partials/meta/word-count.html
+++ b/layouts/partials/meta/word-count.html
@@ -1,4 +1,4 @@
 <span>
-  {{- i18n "article.word_count" .WordCount | markdownify | emojify -}}
+  {{- i18n "article.word_count" .WordCount | markdownify -}}
 </span>
 {{- /* Trim EOF */ -}}

--- a/layouts/partials/recent-articles/main.html
+++ b/layouts/partials/recent-articles/main.html
@@ -22,7 +22,7 @@
   <a href="{{ $showMoreLinkDest }}">
     <button
       class="bg-transparent hover:text-primary-500 prose dark:prose-invert font-semibold hover:text-white py-2 px-4 border border-primary-500 hover:border-transparent rounded">
-      {{ i18n "recent.show_more" | markdownify | emojify }}
+      {{ i18n "recent.show_more" | markdownify }}
     </button>
   </a>
 </div>

--- a/layouts/partials/translations.html
+++ b/layouts/partials/translations.html
@@ -5,7 +5,7 @@
       {{ partial "icon.html" "language" }}
     </span>
     <div class="text-sm font-medium text-gray-500 hover:text-primary-600 dark:hover:text-primary-400" title="{{ .Title }}">
-      {{- i18n "global.language" | markdownify | emojify -}}
+      {{- i18n "global.language" | markdownify -}}
     </div>
   </div>
   <div class="absolute menuhide">

--- a/layouts/shortcodes/codeberg.html
+++ b/layouts/shortcodes/codeberg.html
@@ -15,12 +15,12 @@
       <div
         id="{{ $id }}-full_name"
         class="m-0 font-bold text-xl text-neutral-800 decoration-primary-500 hover:underline hover:underline-offset-2 dark:text-neutral">
-        {{ .full_name | markdownify | emojify }}
+        {{ .full_name | markdownify }}
       </div>
     </div>
 
     <p id="{{ $id }}-description" class="m-0 mt-2 text-md text-neutral-800 dark:text-neutral">
-      {{ .description | markdownify | emojify }}
+      {{ .description | markdownify }}
     </p>
 
     <div class="m-0 mt-2 flex items-center">

--- a/layouts/shortcodes/github.html
+++ b/layouts/shortcodes/github.html
@@ -15,12 +15,12 @@
       <div
         id="{{ $id }}-full_name"
         class="m-0 font-bold text-xl text-neutral-800 decoration-primary-500 hover:underline hover:underline-offset-2 dark:text-neutral">
-        {{ .full_name | markdownify | emojify }}
+        {{ .full_name | markdownify }}
       </div>
     </div>
 
     <p id="{{ $id }}-description" class="m-0 mt-2 text-md text-neutral-800 dark:text-neutral">
-      {{ .description | markdownify | emojify }}
+      {{ .description | markdownify }}
     </p>
 
     <div class="m-0 mt-2 flex items-center">

--- a/layouts/shortcodes/gitlab.html
+++ b/layouts/shortcodes/gitlab.html
@@ -12,12 +12,12 @@
         {{ partial "icon.html" "gitlab" }}
       </span>
       <div id="{{ $id }}-name_with_namespace" class="m-0 font-bold text-xl text-neutral-800 decoration-primary-500 hover:underline hover:underline-offset-2 dark:text-neutral">
-        {{ .name_with_namespace | markdownify | emojify }}
+        {{ .name_with_namespace | markdownify }}
       </div>
     </div>
 
     <p id="{{ $id }}-description" class="m-0 mt-2 text-md text-neutral-800 dark:text-neutral">
-      {{ .description | markdownify | emojify }}
+      {{ .description | markdownify }}
     </p>
 
     <div class="m-0 mt-2 flex items-center">


### PR DESCRIPTION
Fixes #1497 

Breaking: users need to enable native hugo emojies for them to show up.

This can be done by adding: `enableEmoji = true` inside the `config.toml`/`hugo.toml`