### PR TITLE
🎨 Improvements to image handling and link handling

### DIFF
--- a/exampleSite/content/docs/shortcodes/index.md
+++ b/exampleSite/content/docs/shortcodes/index.md
@@ -18,7 +18,7 @@ In addition to all the [default Hugo shortcodes](https://gohugo.io/content-manag
 <!-- prettier-ignore-start -->
 | Parameter   | Description                                                                                                                                                                                  |
 | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `icon`      | **Optional.** the icon to display on the left side.<br>**Default:** `exclaimation triangle icon` (Check out the [icon shortcode](#icon) for more details on using icons.)                    |
+| `icon`      | **Optional.** the icon to display on the left side.<br>**Default:** `triangle-exclamation` (Check out the [icon shortcode](#icon) for more details on using icons.)                    |
 | `iconColor` | **Optional.** the color for the icon in basic CSS style.<br>Can be either hex values (`#FFFFFF`) or color names (`white`)<br>By default chosen based on the current color theme .            |
 | `cardColor` | **Optional.** the color for the card background in basic CSS style.<br>Can be either hex values (`#FFFFFF`) or color names (`white`)<br>By default chosen based on the current color theme . |
 | `textColor` | **Optional.** the color for the text in basic CSS style.<br>Can be either hex values (`#FFFFFF`) or color names (`white`)<br>By default chosen based on the current color theme .            |

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -16,7 +16,7 @@
   {{ end }}
   {{ with $resource }}
     <figure>
-      {{ if $disableImageOptimization }}
+      {{ if or $disableImageOptimization (eq .MediaType.SubType "svg") }}
       <img
         class="my-0 rounded-md"
         loading="lazy"

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,29 +1,29 @@
-{{ $disableImageOptimization := .Page.Site.Params.disableImageOptimization | default false }}
-{{ $url := urls.Parse .Destination }}
-{{ $altText := .Text }}
-{{ $caption := .Title }}
-{{ if findRE "^https?" $url.Scheme }}
+{{- $disableImageOptimization := .Page.Site.Params.disableImageOptimization | default false }}
+{{- $url := urls.Parse .Destination }}
+{{- $altText := .Text }}
+{{- $caption := .Title }}
+{{- if findRE "^https?" $url.Scheme }}
   <figure>
     <img class="my-0 rounded-md" loading="lazy" src="{{ $url.String }}" alt="{{ $altText }}" />
     {{ with $caption }}<figcaption>{{ . | markdownify }}</figcaption>{{ end }}
   </figure>
-{{ else }}
-  {{ $resource := "" }}
-  {{ if $.Page.Resources.GetMatch ($url.String) }}
-    {{ $resource = $.Page.Resources.GetMatch ($url.String) }}
-  {{ else if resources.GetMatch ($url.String) }}
-    {{ $resource = resources.Get ($url.String) }}
-  {{ end }}
-  {{ with $resource }}
+{{- else }}
+  {{- $resource := "" }}
+  {{- if $.Page.Resources.GetMatch ($url.String) }}
+    {{- $resource = $.Page.Resources.GetMatch ($url.String) }}
+  {{- else if resources.GetMatch ($url.String) }}
+    {{- $resource = resources.Get ($url.String) }}
+  {{- end }}
+  {{- with $resource }}
     <figure>
-      {{ if or $disableImageOptimization (eq .MediaType.SubType "svg") }}
+      {{- if or $disableImageOptimization (eq .MediaType.SubType "svg")}}
       <img
         class="my-0 rounded-md"
         loading="lazy"
         src="{{ .RelPermalink }}"
         alt="{{ $altText }}"
       />
-      {{ else }}
+      {{- else }}
       <img
         class="my-0 rounded-md"
         loading="lazy"
@@ -35,13 +35,13 @@
         src="{{ (.Resize "660x").RelPermalink }}"
         alt="{{ $altText }}"
       />
-      {{ end }}
+      {{- end }}
       {{ with $caption }}<figcaption>{{ . | markdownify }}</figcaption>{{ end }}
     </figure>
-  {{ else }}
+  {{- else }}
     <figure>
       <img class="my-0 rounded-md" loading="lazy" src="{{ $url.String }}" alt="{{ $altText }}" />
       {{ with $caption }}<figcaption>{{ . | markdownify }}</figcaption>{{ end }}
     </figure>
-  {{ end }}
-{{ end }}
+  {{- end }}
+{{- end }}

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,1 +1,7 @@
-<a href="{{ .Destination | safeURL }}" {{ with .Title}} title="{{ . }}"{{ end }}{{ if or (strings.HasPrefix .Destination "http:") (strings.HasPrefix .Destination "https:") }} target="_blank"{{ end }}>{{ .Text | safeHTML }}</a>
+<a href="{{ .Destination | safeURL }}"
+    {{- with .Title -}}
+    title="{{ . }}"
+    {{- end }}
+    {{- if or (strings.HasPrefix .Destination "http:") (strings.HasPrefix .Destination "https:") }} target="_blank"{{ end -}}>
+    {{- .Text | safeHTML -}}
+</a>

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -2,6 +2,6 @@
     {{- with .Title -}}
     title="{{ . }}"
     {{- end }}
-    {{- if or (strings.HasPrefix .Destination "http:") (strings.HasPrefix .Destination "https:") }} target="_blank"{{ end -}}>
+    {{- if or (strings.HasPrefix .Destination "http:") (strings.HasPrefix .Destination "https:") }} target="_blank"{{ end }}>
     {{- .Text | safeHTML -}}
 </a>

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,2 +1,1 @@
-<a href="{{ .Destination | safeURL }}" {{ with .Title}} title="{{ . }}"{{ end }} {{ if or (strings.HasPrefix .Destination "http:") (strings.HasPrefix .Destination "https:") }} target="_blank"{{ end }}>
-    {{ .Text | safeHTML }}</a>
+<a href="{{ .Destination | safeURL }}" {{ with .Title}} title="{{ . }}"{{ end }}{{ if or (strings.HasPrefix .Destination "http:") (strings.HasPrefix .Destination "https:") }} target="_blank"{{ end }}>{{ .Text | safeHTML }}</a>

--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -2,49 +2,49 @@
 {{ if .Get "default" }}
   {{ template "_internal/shortcodes/figure.html" . }}
 {{ else }}
-  {{ $url := urls.Parse (.Get "src") }}
-  {{ $altText := .Get "alt" }}
-  {{ $caption := .Get "caption" }}
-  {{ $href := .Get "href" }}
-  {{ $class := .Get "class" }}
-  {{ $target := .Get "target" | default "_blank" }}
-  {{ $nozoom := .Get "nozoom" | default false }}
+  {{- $url := urls.Parse (.Get "src") }}
+  {{- $altText := .Get "alt" }}
+  {{- $caption := .Get "caption" }}
+  {{- $href := .Get "href" }}
+  {{- $class := .Get "class" }}
+  {{- $target := .Get "target" | default "_blank" }}
+  {{- $nozoom := .Get "nozoom" | default false -}}
 
   <figure>
-  {{ with $href }}<a href="{{ . }}" {{ with $target }}target="{{ . }}"{{ end }}>{{ end }}
-  {{ if findRE "^https?" $url.Scheme }}
-      <img class="my-0 rounded-md {{ with $nozoom }} nozoom {{ end }}{{ with $class }} {{ . }} {{ end }}" src="{{ $url.String }}" alt="{{ $altText }}" />
-  {{ else }}
-    {{ $resource := "" }}
-    {{ if $.Page.Resources.GetMatch ($url.String) }}
-      {{ $resource = $.Page.Resources.GetMatch ($url.String) }}
-    {{ else if resources.GetMatch ($url.String) }}
-      {{ $resource = resources.Get ($url.String) }}
-    {{ end }}
-    {{ with $resource }}
-          {{ if $disableImageOptimization }}
-          <img
-            class="my-0 rounded-md {{ with $nozoom }} nozoom {{ end }}{{ with $class }} {{ . }} {{ end }}"
-            src="{{ .RelPermalink }}"
-            alt="{{ $altText }}"
-          />
-          {{ else }}
-          <img
-            class="my-0 rounded-md {{ with $nozoom }} nozoom {{ end }}{{ with $class }} {{ . }} {{ end }}"
-            srcset="
-            {{ (.Resize "330x").RelPermalink }} 330w,
-            {{ (.Resize "660x").RelPermalink }} 660w,
-            {{ (.Resize "1024x").RelPermalink }} 1024w,
-            {{ (.Resize "1320x").RelPermalink }} 2x"
-            src="{{ (.Resize "660x").RelPermalink }}"
-            alt="{{ $altText }}"
-          />
-          {{ end }}
-    {{ else }}
-        <img class="my-0 rounded-md {{ with $nozoom }} nozoom {{ end }}{{ with $class }} {{ . }} {{ end }}" src="{{ $url.String }}" alt="{{ $altText }}" />
-    {{ end }}
-  {{ end }}
-  {{ with $caption }}<figcaption>{{ . | markdownify }}</figcaption>{{ end }}
-  {{ if $href }}</a>{{ end }}
+  {{- with $href }}<a href="{{ . }}" {{ with $target }}target="{{ . }}"{{ end }}>{{ end -}}
+  {{- if findRE "^https?" $url.Scheme }}
+      <img class="my-0 rounded-md{{ with $nozoom }} nozoom{{ end }}{{ with $class }} {{ . }}{{ end }}" src="{{ $url.String }}" alt="{{ $altText }}" />
+  {{- else }}
+    {{- $resource := "" }}
+    {{- if $.Page.Resources.GetMatch ($url.String) }}
+      {{- $resource = $.Page.Resources.GetMatch ($url.String) }}
+    {{- else if resources.GetMatch ($url.String) }}
+      {{- $resource = resources.Get ($url.String) }}
+    {{- end }}
+    {{- with $resource }}
+      {{- if or $disableImageOptimization (eq .MediaType.SubType "svg")}}
+        <img
+          class="my-0 rounded-md{{ with $nozoom }} nozoom{{ end }}{{ with $class }} {{ . }}{{ end }}"
+          src="{{ .RelPermalink }}"
+          alt="{{ $altText }}"
+        />
+      {{- else }}
+        <img
+          class="my-0 rounded-md{{ with $nozoom }} nozoom{{ end }}{{ with $class }} {{ . }}{{ end }}"
+          srcset="
+          {{ (.Resize "330x").RelPermalink }} 330w,
+          {{ (.Resize "660x").RelPermalink }} 660w,
+          {{ (.Resize "1024x").RelPermalink }} 1024w,
+          {{ (.Resize "1320x").RelPermalink }} 2x"
+          src="{{ (.Resize "660x").RelPermalink }}"
+          alt="{{ $altText }}"
+        />
+      {{- end }}
+    {{- else }}
+      <img class="my-0 rounded-md{{ with $nozoom }} nozoom{{ end }}{{ with $class }} {{ . }}{{ end }}" src="{{ $url.String }}" alt="{{ $altText }}" />
+    {{- end }}
+  {{- end }}
+  {{- with $caption }}<figcaption>{{ . | markdownify }}</figcaption>{{ end }}
+  {{- if $href }}</a>{{ end }}
   </figure>
-{{ end }}
+{{- end -}}

--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -44,7 +44,7 @@
       <img class="my-0 rounded-md{{ with $nozoom }} nozoom{{ end }}{{ with $class }} {{ . }}{{ end }}" src="{{ $url.String }}" alt="{{ $altText }}" />
     {{- end }}
   {{- end }}
-  {{- with $caption }}<figcaption>{{ . | markdownify }}</figcaption>{{ end }}
-  {{- if $href }}</a>{{ end }}
+  {{ with $caption }}<figcaption>{{ . | markdownify }}</figcaption>{{ end }}
+  {{ if $href }}</a>{{ end }}
   </figure>
 {{- end -}}


### PR DESCRIPTION
# Links

Due to the way the old shortcode was written, weird cosmetic errors like the one below were cropping up:
![image](https://github.com/nunocoracao/blowfish/assets/63574588/35fb6776-64b4-4fc0-801f-5c54396ad5b4)

The input Markdown was:
```md
2. The ANTLR generated files generate huge diffs when changes are made to the grammar files. ([Here is an example.](https://github.com/sympy/sympy/pull/23535/files))
```

I changed the shortcode to not add that spurious space.
 
# Images

When I was investigating the HTML output for the image shortcodes, I noticed two things:
1. Usage of the image shortcodes introduced a lot of newlines into the output HTML. While it's not a big deal in production, it made debugging a little annoying. I removed all the whitespace from the image shortcodes.
2. Including a local SVG in the image shortcodes, when `disableImageOptimization` is `false`, would cause the Hugo build to fail because you cannot resize a SVG. I included a check for this edge case in the image shortcodes.