### PR TITLE
✨ Add startLine, endLine Support for `codeimporter`

### DIFF
--- a/exampleSite/content/docs/shortcodes/index.it.md
+++ b/exampleSite/content/docs/shortcodes/index.it.md
@@ -197,8 +197,8 @@ This shortcode is for importing code from external sources easily without copyin
 | --------- | ------------------------------------------------------- |
 | `url`     | **Required** URL to an externally hosted code file.     |
 | `type`    | Code type used for syntax highlighting.                 |
-| `startLine` | Optional. The line number to start the import from.    |
-| `endLine` | Optional. The line number to end the import at.        |
+| `startLine` | **Optional** The line number to start the import from.    |
+| `endLine` | **Optional** The line number to end the import at.        |
 
 
 <!-- prettier-ignore-end -->
@@ -213,11 +213,11 @@ This shortcode is for importing code from external sources easily without copyin
 {{< codeimporter url="https://raw.githubusercontent.com/nunocoracao/blowfish/main/layouts/shortcodes/mdimporter.html" type="go" >}}
 
 ```md
-{{</* codeimporter url="https://raw.githubusercontent.com/nunocoracao/blowfish/main/config/_default/hugo.toml" type="c" startLine="11" endLine="18" */>}}
+{{</* codeimporter url="https://raw.githubusercontent.com/nunocoracao/blowfish/main/config/_default/hugo.toml" type="toml" startLine="11" endLine="18" */>}}
 
 ```
 
-{{< codeimporter url="https://raw.githubusercontent.com/nunocoracao/blowfish/main/config/_default/hugo.toml" type="c" startLine="11" endLine="18">}}
+{{< codeimporter url="https://raw.githubusercontent.com/nunocoracao/blowfish/main/config/_default/hugo.toml" type="toml" startLine="11" endLine="18">}}
 
 
 <br/><br/>

--- a/exampleSite/content/docs/shortcodes/index.it.md
+++ b/exampleSite/content/docs/shortcodes/index.it.md
@@ -197,6 +197,8 @@ This shortcode is for importing code from external sources easily without copyin
 | --------- | ------------------------------------------------------- |
 | `url`     | **Required** URL to an externally hosted code file.     |
 | `type`    | Code type used for syntax highlighting.                 |
+| `startLine` | Optional. The line number to start the import from.    |
+| `endLine` | Optional. The line number to end the import at.        |
 
 
 <!-- prettier-ignore-end -->
@@ -209,6 +211,13 @@ This shortcode is for importing code from external sources easily without copyin
 
 ```
 {{< codeimporter url="https://raw.githubusercontent.com/nunocoracao/blowfish/main/layouts/shortcodes/mdimporter.html" type="go" >}}
+
+```md
+{{</* codeimporter url="https://raw.githubusercontent.com/nunocoracao/blowfish/main/config/_default/hugo.toml" type="c" startLine="11" endLine="18" */>}}
+
+```
+
+{{< codeimporter url="https://raw.githubusercontent.com/nunocoracao/blowfish/main/config/_default/hugo.toml" type="c" startLine="11" endLine="18">}}
 
 
 <br/><br/>

--- a/exampleSite/content/docs/shortcodes/index.ja.md
+++ b/exampleSite/content/docs/shortcodes/index.ja.md
@@ -197,8 +197,8 @@ This shortcode is for importing code from external sources easily without copyin
 | --------- | ------------------------------------------------------- |
 | `url`     | **Required** URL to an externally hosted code file.     |
 | `type`    | Code type used for syntax highlighting.                 |
-| `startLine` | Optional. The line number to start the import from.    |
-| `endLine` | Optional. The line number to end the import at.        |
+| `startLine` | **Optional** The line number to start the import from.    |
+| `endLine` | **Optional** The line number to end the import at.        |
 
 <!-- prettier-ignore-end -->
 
@@ -212,11 +212,11 @@ This shortcode is for importing code from external sources easily without copyin
 {{< codeimporter url="https://raw.githubusercontent.com/nunocoracao/blowfish/main/layouts/shortcodes/mdimporter.html" type="go" >}}
 
 ```md
-{{</* codeimporter url="https://raw.githubusercontent.com/nunocoracao/blowfish/main/config/_default/hugo.toml" type="c" startLine="11" endLine="18" */>}}
+{{</* codeimporter url="https://raw.githubusercontent.com/nunocoracao/blowfish/main/config/_default/hugo.toml" type="toml" startLine="11" endLine="18" */>}}
 
 ```
 
-{{< codeimporter url="https://raw.githubusercontent.com/nunocoracao/blowfish/main/config/_default/hugo.toml" type="c" startLine="11" endLine="18">}}
+{{< codeimporter url="https://raw.githubusercontent.com/nunocoracao/blowfish/main/config/_default/hugo.toml" type="toml" startLine="11" endLine="18">}}
 
 
 <br/><br/>

--- a/exampleSite/content/docs/shortcodes/index.ja.md
+++ b/exampleSite/content/docs/shortcodes/index.ja.md
@@ -197,7 +197,8 @@ This shortcode is for importing code from external sources easily without copyin
 | --------- | ------------------------------------------------------- |
 | `url`     | **Required** URL to an externally hosted code file.     |
 | `type`    | Code type used for syntax highlighting.                 |
-
+| `startLine` | Optional. The line number to start the import from.    |
+| `endLine` | Optional. The line number to end the import at.        |
 
 <!-- prettier-ignore-end -->
 
@@ -209,6 +210,13 @@ This shortcode is for importing code from external sources easily without copyin
 
 ```
 {{< codeimporter url="https://raw.githubusercontent.com/nunocoracao/blowfish/main/layouts/shortcodes/mdimporter.html" type="go" >}}
+
+```md
+{{</* codeimporter url="https://raw.githubusercontent.com/nunocoracao/blowfish/main/config/_default/hugo.toml" type="c" startLine="11" endLine="18" */>}}
+
+```
+
+{{< codeimporter url="https://raw.githubusercontent.com/nunocoracao/blowfish/main/config/_default/hugo.toml" type="c" startLine="11" endLine="18">}}
 
 
 <br/><br/>

--- a/exampleSite/content/docs/shortcodes/index.md
+++ b/exampleSite/content/docs/shortcodes/index.md
@@ -197,8 +197,8 @@ This shortcode is for importing code from external sources easily without copyin
 | --------- | ------------------------------------------------------- |
 | `url`     | **Required** URL to an externally hosted code file.     |
 | `type`    | Code type used for syntax highlighting.                 |
-| `startLine` | Optional. The line number to start the import from.    |
-| `endLine` | Optional. The line number to end the import at.        |
+| `startLine` | **Optional** The line number to start the import from.    |
+| `endLine` | **Optional** The line number to end the import at.        |
 
 
 <!-- prettier-ignore-end -->
@@ -213,11 +213,11 @@ This shortcode is for importing code from external sources easily without copyin
 {{< codeimporter url="https://raw.githubusercontent.com/nunocoracao/blowfish/main/layouts/shortcodes/mdimporter.html" type="go" >}}
 
 ```md
-{{</* codeimporter url="https://raw.githubusercontent.com/nunocoracao/blowfish/main/config/_default/hugo.toml" type="c" startLine="11" endLine="18" */>}}
+{{</* codeimporter url="https://raw.githubusercontent.com/nunocoracao/blowfish/main/config/_default/hugo.toml" type="toml" startLine="11" endLine="18" */>}}
 
 ```
 
-{{< codeimporter url="https://raw.githubusercontent.com/nunocoracao/blowfish/main/config/_default/hugo.toml" type="c" startLine="11" endLine="18">}}
+{{< codeimporter url="https://raw.githubusercontent.com/nunocoracao/blowfish/main/config/_default/hugo.toml" type="toml" startLine="11" endLine="18">}}
 
 
 <br/><br/>

--- a/exampleSite/content/docs/shortcodes/index.md
+++ b/exampleSite/content/docs/shortcodes/index.md
@@ -197,6 +197,8 @@ This shortcode is for importing code from external sources easily without copyin
 | --------- | ------------------------------------------------------- |
 | `url`     | **Required** URL to an externally hosted code file.     |
 | `type`    | Code type used for syntax highlighting.                 |
+| `startLine` | Optional. The line number to start the import from.    |
+| `endLine` | Optional. The line number to end the import at.        |
 
 
 <!-- prettier-ignore-end -->
@@ -209,6 +211,13 @@ This shortcode is for importing code from external sources easily without copyin
 
 ```
 {{< codeimporter url="https://raw.githubusercontent.com/nunocoracao/blowfish/main/layouts/shortcodes/mdimporter.html" type="go" >}}
+
+```md
+{{</* codeimporter url="https://raw.githubusercontent.com/nunocoracao/blowfish/main/config/_default/hugo.toml" type="c" startLine="11" endLine="18" */>}}
+
+```
+
+{{< codeimporter url="https://raw.githubusercontent.com/nunocoracao/blowfish/main/config/_default/hugo.toml" type="c" startLine="11" endLine="18">}}
 
 
 <br/><br/>

--- a/exampleSite/content/docs/shortcodes/index.zh-cn.md
+++ b/exampleSite/content/docs/shortcodes/index.zh-cn.md
@@ -197,6 +197,8 @@ data: {
 | --------- | ---------------------------------- |
 | `url`     | **必需的** 外部托管代码文件的 URL. |
 | `type`    | 用于语法突出显示的代码类型.        |
+| `startLine` | **可选** 从代码文件中导入的起始行. |
+| `endLine` | **可选** 从代码文件中导入的结束行. |
 
 
 <!-- prettier-ignore-end -->
@@ -210,6 +212,13 @@ data: {
 ```
 
 {{< codeimporter url="https://raw.githubusercontent.com/nunocoracao/blowfish/main/layouts/shortcodes/mdimporter.html" type="go" >}}
+
+```md
+{{</* codeimporter url="https://raw.githubusercontent.com/nunocoracao/blowfish/main/config/_default/hugo.toml" type="c" startLine="11" endLine="18" */>}}
+
+```
+
+{{< codeimporter url="https://raw.githubusercontent.com/nunocoracao/blowfish/main/config/_default/hugo.toml" type="c" startLine="11" endLine="18">}}
 
 
 <br/><br/>

--- a/exampleSite/content/docs/shortcodes/index.zh-cn.md
+++ b/exampleSite/content/docs/shortcodes/index.zh-cn.md
@@ -214,11 +214,11 @@ data: {
 {{< codeimporter url="https://raw.githubusercontent.com/nunocoracao/blowfish/main/layouts/shortcodes/mdimporter.html" type="go" >}}
 
 ```md
-{{</* codeimporter url="https://raw.githubusercontent.com/nunocoracao/blowfish/main/config/_default/hugo.toml" type="c" startLine="11" endLine="18" */>}}
+{{</* codeimporter url="https://raw.githubusercontent.com/nunocoracao/blowfish/main/config/_default/hugo.toml" type="toml" startLine="11" endLine="18" */>}}
 
 ```
 
-{{< codeimporter url="https://raw.githubusercontent.com/nunocoracao/blowfish/main/config/_default/hugo.toml" type="c" startLine="11" endLine="18">}}
+{{< codeimporter url="https://raw.githubusercontent.com/nunocoracao/blowfish/main/config/_default/hugo.toml" type="toml" startLine="11" endLine="18">}}
 
 
 <br/><br/>

--- a/layouts/shortcodes/codeimporter.html
+++ b/layouts/shortcodes/codeimporter.html
@@ -1,8 +1,27 @@
 {{ $url := .Get "url" }}
 {{ $type := .Get "type" }}
-{{ with resources.GetRemote (urls.Parse $url) }}
-{{ $codeBlock := printf "```%s\n%s\n```" $type .Content }}
-{{ $codeBlock | markdownify }}
+{{ $startLine := .Get "startLine" | default 1 | int }}
+{{ $startLine = sub $startLine 1 }}
+{{ $endLine := .Get "endLine" | default -1 | int }}
+{{ $selectedLines := slice }}
+{{ with resources.GetRemote ( printf $url ) }}
+  {{ $lines := split .Content "\n" }}
+  {{ $totalLine := $lines | len }}
+
+  {{ if ne $endLine -1 }}
+    {{ $endLine = math.Min $endLine $totalLine }}
+  {{ else }}
+    {{ $endLine = $totalLine }}
+  {{ end }}
+  
+  {{ if gt $startLine $endLine }}
+    {{ errorf "Code Importer Shortcode - startLine is greater than endLine" . }}
+  {{ end }}
+
+  {{ $selectedLines := first $endLine $lines }}
+  {{ $selectedLines = after $startLine $selectedLines }}
+  {{ $codeBlock := printf "```%s\n%s\n```" $type (delimit $selectedLines "\n") }}
+  {{ $codeBlock | markdownify }}
 {{ else }}
-{{ errorf "Code Importer Shortcode - Unable to get remote resource" . }}
+  {{ errorf "Code Importer Shortcode - Unable to get remote resource" . }}
 {{ end }}

--- a/layouts/shortcodes/codeimporter.html
+++ b/layouts/shortcodes/codeimporter.html
@@ -4,7 +4,7 @@
 {{ $startLine = sub $startLine 1 }}
 {{ $endLine := .Get "endLine" | default -1 | int }}
 {{ $selectedLines := slice }}
-{{ with resources.GetRemote ( printf $url ) }}
+{{ with resources.GetRemote (urls.Parse $url) }}
   {{ $lines := split .Content "\n" }}
   {{ $totalLine := $lines | len }}
 


### PR DESCRIPTION
# Feat: Adding startLine, endLine support for `codeimporter` shortcodes

- I'm writing a blog that needs to import code from GitHub, but only a specific range of code.
    - The current `codeimporter` shortcodes don't provide this feature.
- If `startLine` and `endLine` are not provided, the whole code will be imported .
- Updated the docs and provided examples as well (have run `npm run example`, works nicely).

Working example on my blog:
```md
{{< codeimporter url="https://raw.githubusercontent.com/redis/redis/811c5d7aeb0b76494d78efe61e418f574c310ec0/src/rdb.c" type="c" startLine="3907" endLine="3942">}}
```
![Working example on my blog](https://github.com/nunocoracao/blowfish/assets/68415893/54fae704-fc00-4ff3-b7f8-c7cb78450e07)


Big thanks for sharing this theme 💯
I'm enjoying the i18n support and wonderful UX. I will promote it to my friends 🙌
