### PR TITLE
:sparkles: Add data definition for sharing on Bluesky

### DIFF
--- a/data/sharing.json
+++ b/data/sharing.json
@@ -38,5 +38,10 @@
     "icon": "telegram",
     "title": "sharing.telegram",
     "url": "https://t.me/share/url?url=%s&resubmit=true&title=%s"
+  },
+  "bluesky": {
+    "icon": "bluesky",
+    "title": "sharing.bluesky",
+    "url": "https://bsky.app/intent/compose?text=%[2]s+%[1]s"
   }
 }

--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -73,7 +73,7 @@ smartTOCHideUnfocusedChildren = false
   showTaxonomies = true 
   showAuthorsBadges = true 
   showWordCount = false
-  sharingLinks = [ "linkedin", "twitter", "reddit", "whatsapp", "telegram", "pinterest", "facebook", "email"]
+  sharingLinks = [ "linkedin", "twitter", "bluesky", "reddit", "whatsapp", "telegram", "pinterest", "facebook", "email"]
   showZenMode = true
 
 [list]

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -66,6 +66,7 @@ sharing:
   pinterest: "Pin on Pinterest"
   reddit: "Submit to Reddit"
   twitter: "Tweet on Twitter"
+  bluesky: "Post on Bluesky"
 
 shortcode:
   recent_articles: "Recent"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hugo-blowfish-theme",
-  "version": "2.72.0",
+  "version": "2.71.1",
   "description": "Blowfish theme for Hugo.",
   "scripts": {
     "postinstall": "vendor-copy",


### PR DESCRIPTION
Added:

- Bluesky definition in data/sharing.json
- Bluesky to exampleSite params.toml
- Alt text to i18n/en.yaml

Enables the addition of "bluesky" to the default article sharing links using the Action Intent link defined here: https://docs.bsky.app/docs/advanced-guides/intent-links