### PR TITLE
add `bilibili` shortcode and `ruby` extended syntax

### DIFF
--- a/assets/css/compiled/main.css
+++ b/assets/css/compiled/main.css
@@ -14,6 +14,25 @@ body.zen-mode-enable {
   }
 }
 
+.bilibili {
+  position: relative;
+}
+
+.bilibili::after {
+  content: "";
+  display: block;
+  padding-bottom: calc(100% / (16 / 9));
+}
+.bilibili > iframe {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  border: 0;
+}
+
+
 /*! tailwindcss v3.4.4 | MIT License | https://tailwindcss.com */
 
 /*

--- a/assets/css/components/bilibili.css
+++ b/assets/css/components/bilibili.css
@@ -1,0 +1,18 @@
+.bilibili {
+  position: relative;
+}
+
+.bilibili::after {
+  content: "";
+  display: block;
+  padding-bottom: calc(100% / (16 / 9));
+}
+
+.bilibili > iframe {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  border: 0;
+}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,6 +1,7 @@
 /*! Blowfish | MIT License | https://github.com/nunocoracao/blowfish */
 
 @import 'components/zen-mode.css';
+@import 'components/bilibili.css';
 
 @tailwind base;
 @tailwind components;

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -49,7 +49,7 @@
     </div>
     {{ end }}
     <div class="min-w-0 min-h-0 max-w-prose">
-      {{ .Content }}
+      {{- dict "Content" .Content "Ruby" .Site.Params.ruby | partial "functions/content.html" | safeHTML -}}
     </div>
 
 

--- a/layouts/_default/simple.html
+++ b/layouts/_default/simple.html
@@ -9,7 +9,7 @@
       </h1>
     </header>
     <section class="max-w-full mt-6 prose dark:prose-invert">
-      {{ .Content }}
+      {{- dict "Content" .Content "Ruby" .Site.Params.ruby | partial "functions/content.html" | safeHTML -}}
     </section>
     <footer class="pt-8">
       {{ partial "sharing-links.html" . }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -80,7 +80,7 @@
         {{ partial "series/series.html" . }}
 
         <div class="article-content max-w-prose mb-20">
-          {{ .Content }}
+          {{- dict "Content" .Content "Ruby" .Site.Params.ruby | partial "functions/content.html" | safeHTML -}}
         </div>
         
         {{ if (.Params.showAuthorBottom | default ( .Site.Params.article.showAuthorBottom | default false)) }}

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -25,7 +25,7 @@
   {{ if .Content }}
     <section class="flex flex-col max-w-full mt-0 prose dark:prose-invert lg:flex-row">
       <div class="min-w-0 min-h-0 max-w-prose">
-        {{ .Content }}
+        {{- dict "Content" .Content "Ruby" .Site.Params.ruby | partial "functions/content.html" | safeHTML -}}
       </div>
     </section>
   {{ end }}

--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -24,7 +24,7 @@
   <section class="flex flex-col max-w-full mt-0 mb-5 prose dark:prose-invert lg:flex-row">
     {{ if .Content }}
     <div class="min-w-0 min-h-0 max-w-prose">
-      {{ .Content }}
+      {{- dict "Content" .Content "Ruby" .Site.Params.ruby | partial "functions/content.html" | safeHTML -}}
     </div>
     {{ end }}
     <script>

--- a/layouts/partials/functions/content.html
+++ b/layouts/partials/functions/content.html
@@ -1,0 +1,7 @@
+{{- $content := .Content -}}
+
+{{- if .Ruby -}}
+    {{- $content = partial "functions/ruby.html" $content -}}
+{{- end -}}
+
+{{- return $content -}}

--- a/layouts/partials/functions/ruby.html
+++ b/layouts/partials/functions/ruby.html
@@ -1,0 +1,5 @@
+{{- /* Ruby */ -}}
+{{- /* [EN]^(English) -> <strong><ruby>EN<rt>English</rt></ruby></strong> */ -}}
+{{- $REin := `\[(.+?)\]\^\((.+?)\)` -}}
+{{- $REout := `<strong><ruby>$1<rt>$2</rt></ruby></strong>` -}}
+{{- return replaceRE $REin $REout . -}}

--- a/layouts/partials/home/background.html
+++ b/layouts/partials/home/background.html
@@ -67,7 +67,7 @@
                         </div>
                         {{ end }}
                     </div>
-                    <section class="prose dark:prose-invert">{{ .Content }}</section>
+                    <section class="prose dark:prose-invert">{{- dict "Content" .Content "Ruby" .Site.Params.ruby | partial "functions/content.html" | safeHTML -}}</section>
                 </div>
             </div>
         </div>

--- a/layouts/partials/home/card.html
+++ b/layouts/partials/home/card.html
@@ -9,7 +9,7 @@
                         <h1>{{ . | emojify }}</h1>
                       </header>
                     {{ end }}
-                    <section>{{ .Content }}</section>
+                    <section>{{- dict "Content" .Content "Ruby" .Site.Params.ruby | partial "functions/content.html" | safeHTML -}}                    </section>
                   </article>
             </div>
             <div class="mt-6 sm:mt-16 lg:mt-0 mx-auto max-w-xl px-4 sm:px-6 lg:mx-0 lg:max-w-none lg:py-16 lg:px-0">

--- a/layouts/partials/home/hero.html
+++ b/layouts/partials/home/hero.html
@@ -64,7 +64,7 @@
                         </div>
                         {{ end }}
                     </div>
-                    <section class="prose prose-invert">{{ .Content }}</section>
+                    <section class="prose prose-invert">{{- dict "Content" .Content "Ruby" .Site.Params.ruby | partial "functions/content.html" | safeHTML -}}</section>
                 </div>
             </div>
         </div>

--- a/layouts/partials/home/page.html
+++ b/layouts/partials/home/page.html
@@ -4,7 +4,7 @@
       <h1>{{ . | emojify }}</h1>
     </header>
   {{ end }}
-  <section>{{ .Content }}</section>
+  <section>{{- dict "Content" .Content "Ruby" .Site.Params.ruby | partial "functions/content.html" | safeHTML -}}</section>
 </article>
 <section>
   {{ partial "recent-articles/main.html" . }}

--- a/layouts/partials/home/profile.html
+++ b/layouts/partials/home/profile.html
@@ -30,7 +30,7 @@
       {{ partialCached "author-links.html" . }}
     </div>
   </header>
-  <section class="prose dark:prose-invert">{{ .Content }}</section>
+  <section class="prose dark:prose-invert">{{- dict "Content" .Content "Ruby" .Site.Params.ruby | partial "functions/content.html" | safeHTML -}}</section>
 </article>
 <section>
   {{ partial "recent-articles/main.html" . }}

--- a/layouts/shortcodes/bilibili.html
+++ b/layouts/shortcodes/bilibili.html
@@ -1,0 +1,7 @@
+<div class="bilibili">
+  {{- if .IsNamedParams -}}
+      <iframe src="//player.bilibili.com/player.html?bvid={{ .Get `id` }}&page={{ .Get `p` | default 1 }}" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true"></iframe>
+  {{- else -}}
+      <iframe src="//player.bilibili.com/player.html?bvid={{ .Get 0 }}&page={{ .Get 1 | default 1 }}" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true"></iframe>
+  {{- end -}}
+</div>


### PR DESCRIPTION
1. use `{{<bilibili id>}}` to add bilibili video

2. support `ruby` syntax:

enable in `Params` configs: `ruby = true`

example:

`[関連]^(かんれん)`  

<img width="49" alt="image" src="https://github.com/nunocoracao/blowfish/assets/3363806/5285410a-c211-45b4-8a90-48985b6fbbb8">