### PR TITLE
✨ Custom font via Google Fonts CDN

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -118,6 +118,9 @@ disableTextInHeader = false
   cardView = false
   cardViewScreenWidth = false
 
+[static]
+  # googleFonts = ""
+
 [firebase]
   # apiKey = "XXXXXX"
   # authDomain = "XXXXXX"

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -85,6 +85,12 @@
   <link rel="icon" type="image/png" sizes="16x16" href="{{ "favicon-16x16.png" | relURL }}" />
   <link rel="manifest" href="{{ "site.webmanifest" | relURL }}" />
   {{ end }}
+  {{/* Google Fonts */}}
+  {{ with .Site.Params.static.googleFonts }}
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="stylesheet" href="{{ . | safeURL }}" />
+  {{ end }}
   {{/* Site Verification */}}
   {{ with .Site.Params.verification.google }}
   <meta name="google-site-verification" content="{{ . }}" />


### PR DESCRIPTION
Importing fonts from a folder may be superior in terms of customization and full control, but it might require more effort. if performance and ease of use are priorities, importing fonts via Google Fonts CDN may be more practical, depending on individual factors and preferences.

**As an example:**

- Input the Google Fonts CDN that you intend to use (Here, I’m using [Fira Sans](https://fonts.google.com/specimen/Fira+Sans?query=fira) and [Fira Code](https://fonts.google.com/specimen/Fira+Code?query=fira)).

```toml
[static]
  googleFonts = "https://fonts.googleapis.com/css2?family=Fira+Code:wght@300..700&family=Fira+Sans:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap"
```

- Then, set the `font-family` and other styles in Your `custom.css` file.

```css
html {
  font-family: Fira Sans;
  font-size: 13px;
  /* more style */
}

code {
  font-family: Fira Code;
  font-size: 1.3em;
  /* more style */
}
```

- You’ve done and thanks!