### PR TITLE
fix: correct links for the author pages

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -46,7 +46,7 @@
         {{- if $authorData -}}
           {{ range $taxonomyname, $taxonomy := $taxonomies }}
             {{ if (eq $taxonomyname $author) }}
-              {{ $taxonomyLink = delimit (slice $baseURL "/authors/" $author) "" }}
+              {{ $taxonomyLink = delimit (slice $baseURL "authors/" $author "/") "" }}
             {{ end }}
           {{ end }}
           {{ partial "author-extra.html" (dict "context" . "data" $authorData "link" $taxonomyLink) }}
@@ -95,7 +95,7 @@
             {{- if $authorData -}}
               {{ range $taxonomyname, $taxonomy := $taxonomies }}
                 {{ if (eq $taxonomyname $author) }}
-                  {{ $taxonomyLink = delimit (slice $baseURL "/authors/" $author) "" }}
+                  {{ $taxonomyLink = delimit (slice $baseURL "authors/" $author "/") "" }}
                 {{ end }}
               {{ end }}
               {{ partial "author-extra.html" (dict "context" . "data" $authorData "link" $taxonomyLink) }}


### PR DESCRIPTION
Closes #1627 

This PR corrects the URLs for the author pages. 

Without this PR, the URL contains doubled slash and has no trailing slash.

![image](https://github.com/user-attachments/assets/1420fa41-b52b-4ca6-a72e-b86c4851cb55)

With this PR, the generated URL does not contain any doubled slash, and has correct trailing slash.

![image](https://github.com/user-attachments/assets/e0142668-74aa-426a-8d60-6406ea9def7b)
