### PR TITLE
Revert "✨ add SVG support for logos"

### DIFF
--- a/assets/css/compiled/main.css
+++ b/assets/css/compiled/main.css
@@ -3163,13 +3163,6 @@ body button {
   width:1em
 }
 
-/* Scale SVG logos to appropriate size */
-
-.logo svg {
-  height:5rem;
-  width:5rem
-}
-
 /* Search */
 
 #search-query::-webkit-search-cancel-button,

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -16,11 +16,6 @@ body button {
   @apply h-[1em] w-[1em];
 }
 
-/* Scale SVG logos to appropriate size */
-.logo svg {
-  @apply h-[5rem] w-[5rem];
-}
-
 /* Search */
 #search-query::-webkit-search-cancel-button,
 #search-query::-webkit-search-decoration,

--- a/layouts/partials/header/basic.html
+++ b/layouts/partials/header/basic.html
@@ -7,14 +7,8 @@
         <a href="{{ "" | relLangURL }}" class="flex">
             <span class="sr-only">{{ .Site.Title | markdownify }}</span>
 
-            {{ if eq $logo.MediaType.SubType "svg" }}
-            <span class="logo object-scale-down object-left nozoom">
-                {{ $logo.Content | safeHTML }}
-            </span>
-            {{ else }}
             <img src="{{ $logo.RelPermalink }}" width="{{ div $logo.Width 2 }}" height="{{ div $logo.Height 2 }}"
                 class="logo max-h-[5rem] max-w-[5rem] object-scale-down object-left nozoom" alt="{{ .Site.Title }}" />
-            {{ end }}
 
         </a>
     </div>


### PR DESCRIPTION
Reverts nunocoracao/blowfish#1646

> Rationale:
>     1. This does not handle the "secondary" logo at all ie. breaks the parameter.
>     2. The raw SVG logo data will be injected into every HTML file, therefore will not be cached!

:warning: **Please do not merge yet, this is WIP** :warning: 