### PR TITLE
Move .Site.Author to .Site.Params.Author

### DIFF
--- a/config/_default/languages.en.toml
+++ b/config/_default/languages.en.toml
@@ -1,3 +1,4 @@
+disabled = false
 languageCode = "en"
 languageName = "English"
 weight = 1
@@ -13,7 +14,7 @@ title = "Blowfish"
   # description = "My awesome website"
   # copyright = "Copy, _right?_ :thinking_face:"
 
-# [author]
+# [params.author]
 #   name = "Your name here"
 #   email = "youremail@example.com"
 #   image = "img/blowfish_logo.png"

--- a/exampleSite/content/docs/installation/index.it.md
+++ b/exampleSite/content/docs/installation/index.it.md
@@ -110,6 +110,7 @@ Per questo metodo utilizzerai Hugo per gestire i tuoi temi. Hugo utilizza **Go**
 
    ```toml
    [[imports]]
+   disable = false
    path = "github.com/nunocoracao/blowfish/v2"
    ```
 

--- a/exampleSite/content/docs/installation/index.ja.md
+++ b/exampleSite/content/docs/installation/index.ja.md
@@ -111,6 +111,7 @@ For this method you'll use Hugo to manage your themes. Hugo uses **Go** to initi
 
    ```toml
    [[imports]]
+   disable = false
    path = "github.com/nunocoracao/blowfish/v2"
    ```
 

--- a/exampleSite/content/docs/installation/index.md
+++ b/exampleSite/content/docs/installation/index.md
@@ -111,6 +111,7 @@ For this method you'll use Hugo to manage your themes. Hugo uses **Go** to initi
 
    ```toml
    [[imports]]
+   disable = false
    path = "github.com/nunocoracao/blowfish/v2"
    ```
 

--- a/exampleSite/content/docs/installation/index.zh-cn.md
+++ b/exampleSite/content/docs/installation/index.zh-cn.md
@@ -110,6 +110,7 @@ git submodule add -b main https://github.com/nunocoracao/blowfish.git themes/blo
 
    ```toml
    [[imports]]
+   disable = false
    path = "github.com/nunocoracao/blowfish/v2"
    ```
 

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -17,11 +17,11 @@
     <link>{{ .Permalink }}</link>
     <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
     <generator>Hugo -- gohugo.io</generator>
-    <language>{{ site.LanguageCode }}</language>{{ with .Site.Author.email }}
-    <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
-    <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}
+    <language>{{ site.LanguageCode }}</language>{{ with .Site.Params.Author.email }}
+    <managingEditor>{{.}}{{ with $.Site.Params.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Params.Author.email }}
+    <webMaster>{{.}}{{ with $.Site.Params.Author.name }} ({{.}}){{end}}</webMaster>{{end}}
     {{ if .Site.Params.footer.showCopyright | default true -}}
-    <copyright>{{ with replace .Site.Params.copyright "{ year }" now.Year }}{{.}}{{ else }}© {{ now.Format "2006" }} {{ .Site.Author.name }}{{- end }}</copyright>
+    <copyright>{{ with replace .Site.Params.copyright "{ year }" now.Year }}{{.}}{{ else }}© {{ now.Format "2006" }} {{ .Site.Params.Author.name }}{{- end }}</copyright>
     {{- end }}
     {{ if not .Date.IsZero }}<lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
     {{- with .OutputFormats.Get "RSS" -}}
@@ -32,7 +32,7 @@
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-      {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
+      {{ with .Site.Params.Author.email }}<author>{{.}}{{ with $.Site.Params.Author.name }} ({{.}}){{end}}</author>{{end}}
       <guid>{{ .Permalink }}</guid>
       <description>{{ .Summary | html }}</description>
       {{ range ( where .Site.RegularPages ".RelPermalink" .RelPermalink | first 1 ) }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -87,7 +87,7 @@
             <strong class="block mt-8">
               <a target="_blank" 
               class="m-1 rounded bg-neutral-300 p-1.5 text-neutral-700 hover:bg-primary-500 hover:text-neutral dark:bg-neutral-700 dark:text-neutral-300 dark:hover:bg-primary-400 dark:hover:text-neutral-800"
-              href="mailto:{{ .Site.Author.email }}?subject={{ replace (printf "Reply to %s" .Title) "\"" "'" }}">
+              href="mailto:{{ .Site.Params.Author.email }}?subject={{ replace (printf "Reply to %s" .Title) "\"" "'" }}">
                 Reply by Email
               </a>
             </strong>

--- a/layouts/partials/author-links.html
+++ b/layouts/partials/author-links.html
@@ -1,4 +1,4 @@
-{{ with .Site.Author.links }}
+{{ with .Site.Params.Author.links }}
   <div class="flex flex-wrap text-neutral-400 dark:text-neutral-500">
     {{ range $links := . }}
       {{ range $name, $url := $links }}

--- a/layouts/partials/author.html
+++ b/layouts/partials/author.html
@@ -1,6 +1,6 @@
 {{ $disableImageOptimization := .Site.Params.disableImageOptimization | default false }}
 <div class="flex author">
-  {{ with .Site.Author.image }}
+  {{ with .Site.Params.Author.image }}
     {{ $authorImage := "" }}
     {{ if or (strings.HasPrefix . "http:") (strings.HasPrefix . "https:") }}
       {{ $authorImage = resources.GetRemote . }}
@@ -12,18 +12,18 @@
         {{ $authorImage = $authorImage.Fill "192x192" }}
       {{ end }}
       <img class="!mt-0 !mb-0 h-24 w-24 rounded-full ltr:mr-4 rtl:ml-4" width="96" height="96"
-      alt="{{ $.Site.Author.name | default " Author" }}" src="{{ $authorImage.RelPermalink }}" />
+      alt="{{ $.Site.Params.Author.name | default " Author" }}" src="{{ $authorImage.RelPermalink }}" />
     {{ else }}
       {{ $authorImage := resources.GetRemote . }}
       {{ if not $disableImageOptimization }}
         {{ $authorImage = $authorImage.Fill "192x192" }}
       {{ end }}
       <img class="!mt-0 !mb-0 h-24 w-24 rounded-full ltr:mr-4 rtl:ml-4" width="96" height="96"
-      alt="{{ $.Site.Author.name | default " Author" }}" src="{{ $authorImage.RelPermalink }}" />
+      alt="{{ $.Site.Params.Author.name | default " Author" }}" src="{{ $authorImage.RelPermalink }}" />
     {{ end }}
   {{ end }}
   <div class="place-self-center">
-    {{ with .Site.Author.name | markdownify }}
+    {{ with .Site.Params.Author.name | markdownify }}
     <div class="text-[0.6rem] uppercase leading-3 text-neutral-500 dark:text-neutral-400">
       {{ i18n "author.byline_title" | markdownify }}
     </div>
@@ -31,7 +31,7 @@
       {{ . }}
     </div>
     {{ end }}
-    {{ with .Site.Author.bio | markdownify }}
+    {{ with .Site.Params.Author.bio | markdownify }}
     <div class="text-sm text-neutral-700 dark:text-neutral-400">{{ . }}</div>
     {{ end }}
     <div class="text-2xl sm:text-lg">{{ partialCached "author-links.html" . }}</div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -31,7 +31,7 @@
       {{- else }}
       &copy;
       {{ now.Format "2006" }}
-      {{ .Site.Author.name | markdownify }}
+      {{ .Site.Params.Author.name | markdownify }}
       {{- end }}
     </p>
     {{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -105,9 +105,9 @@
   {{/* Schema */}}
   {{ partial "schema.html" . }}
   {{/* Me */}}
-  {{ with .Site.Author.name }}
+  {{ with .Site.Params.Author.name }}
   <meta name="author" content="{{ . }}" />{{ end }}
-  {{ with .Site.Author.links }}
+  {{ with .Site.Params.Author.links }}
   {{ range $links := . }}
   {{ range $name, $url := $links }}
   <link href="{{ $url }}" rel="me" />{{ end }}

--- a/layouts/partials/home/background.html
+++ b/layouts/partials/home/background.html
@@ -31,7 +31,7 @@
                     {{ end }}
                 </div>
                 <div class="relative px-1 py-1 flex flex-col items-center justify-center text-center">
-                    {{ with .Site.Author.image }}
+                    {{ with .Site.Params.Author.image }}
                         {{ $authorImage := "" }}
                         {{ if or (strings.HasPrefix . "http:") (strings.HasPrefix . "https:") }}
                             {{ $authorImage = resources.GetRemote . }}
@@ -40,22 +40,22 @@
                         {{ end }}
                         {{ if $authorImage }}
                             {{ if not $disableImageOptimization }}
-                                {{ $authorImage = $authorImage.Fill (print "288x288 q" ( $.Site.Author.imagequality | default "96" )) }}
+                                {{ $authorImage = $authorImage.Fill (print "288x288 q" ( $.Site.Params.Author.imagequality | default "96" )) }}
                             {{ end }}
                             <img class="mb-2 rounded-full h-36 w-36" width="144" height="144"
-                                alt="{{ $.Site.Author.name | default " Author" }}" src="{{ $authorImage.RelPermalink }}" />
+                                alt="{{ $.Site.Params.Author.name | default " Author" }}" src="{{ $authorImage.RelPermalink }}" />
                         {{ end }}
                     {{ end }}
                     <h1 class="mb-2 text-4xl font-extrabold text-neutral-800 dark:text-neutral-200">
-                        {{ .Site.Author.name | default .Site.Title }}
+                        {{ .Site.Params.Author.name | default .Site.Title }}
                     </h1>
-                    {{ with .Site.Author.headline }}
+                    {{ with .Site.Params.Author.headline }}
                     <h2 class="mt-0 mb-0 text-xl text-neutral-800 dark:text-neutral-300">
                         {{ . | markdownify }}
                     </h2>
                     {{ end }}
                     <div class="mt-3 mb-10 text-2xl">
-                        {{ with .Site.Author.links }}
+                        {{ with .Site.Params.Author.links }}
                         <div class="flex flex-wrap">
                             {{ range $links := . }}
                             {{ range $name, $url := $links }}

--- a/layouts/partials/home/hero.html
+++ b/layouts/partials/home/hero.html
@@ -28,7 +28,7 @@
                     {{ end }}
                 </div>
                 <div class="relative px-4 py-16 sm:px-6 sm:py-24 lg:py-32 lg:px-8 flex flex-col items-center justify-center text-center">
-                    {{ with .Site.Author.image }}
+                    {{ with .Site.Params.Author.image }}
                         {{ $authorImage := "" }}
                         {{ if or (strings.HasPrefix . "http:") (strings.HasPrefix . "https:") }}
                             {{ $authorImage = resources.GetRemote . }}
@@ -37,22 +37,22 @@
                         {{ end }}
                         {{ if $authorImage }}
                             {{ if not $disableImageOptimization }}
-                                {{ $authorImage = $authorImage.Fill (print "288x288 q" ( $.Site.Author.imagequality | default "96" )) }}
+                                {{ $authorImage = $authorImage.Fill (print "288x288 q" ( $.Site.Params.Author.imagequality | default "96" )) }}
                             {{ end }}
                             <img class="mb-2 rounded-full h-36 w-36" width="144" height="144"
-                                alt="{{ $.Site.Author.name | default " Author" }}" src="{{ $authorImage.RelPermalink }}" />
+                                alt="{{ $.Site.Params.Author.name | default " Author" }}" src="{{ $authorImage.RelPermalink }}" />
                         {{ end }}
                     {{ end }}
                     <h1 class="mb-2 text-4xl font-extrabold text-neutral-200">
-                        {{ .Site.Author.name | default .Site.Title }}
+                        {{ .Site.Params.Author.name | default .Site.Title }}
                     </h1>
-                    {{ with .Site.Author.headline }}
+                    {{ with .Site.Params.Author.headline }}
                     <h2 class="mt-0 mb-0 text-xl text-neutral-300">
                         {{ . | markdownify }}
                     </h2>
                     {{ end }}
                     <div class="mt-3 mb-10 text-2xl">
-                        {{ with .Site.Author.links }}
+                        {{ with .Site.Params.Author.links }}
                         <div class="flex flex-wrap">
                             {{ range $links := . }}
                             {{ range $name, $url := $links }}

--- a/layouts/partials/home/profile.html
+++ b/layouts/partials/home/profile.html
@@ -3,7 +3,7 @@
     h-full
   {{ end }} flex flex-col items-center justify-center text-center">
   <header class="relative px-1 py-1 flex flex-col items-center mb-3">
-    {{ with .Site.Author.image }}
+    {{ with .Site.Params.Author.image }}
       {{ $authorImage := "" }}
       {{ if or (strings.HasPrefix . "http:") (strings.HasPrefix . "https:") }}
         {{ $authorImage = resources.GetRemote . }}
@@ -12,16 +12,16 @@
       {{ end }}
       {{ if $authorImage }}
         {{ if not $disableImageOptimization }}
-          {{ $authorImage = $authorImage.Fill (print "288x288 q" ( $.Site.Author.imagequality | default "96" )) }}
+          {{ $authorImage = $authorImage.Fill (print "288x288 q" ( $.Site.Params.Author.imagequality | default "96" )) }}
         {{ end }}
-        <img class="mb-2 rounded-full h-36 w-36" width="144" height="144" alt="{{ $.Site.Author.name | default " Author" }}"
+        <img class="mb-2 rounded-full h-36 w-36" width="144" height="144" alt="{{ $.Site.Params.Author.name | default " Author" }}"
           src="{{ $authorImage.RelPermalink }}" />
       {{ end }}
     {{ end }}
     <h1 class="text-4xl font-extrabold">
-      {{ .Site.Author.name | default .Site.Title }}
+      {{ .Site.Params.Author.name | default .Site.Title }}
     </h1>
-    {{ with .Site.Author.headline }}
+    {{ with .Site.Params.Author.headline }}
     <h2 class="text-xl text-neutral-500 dark:text-neutral-400">
       {{ . | markdownify }}
     </h2>

--- a/layouts/partials/schema.html
+++ b/layouts/partials/schema.html
@@ -11,7 +11,7 @@
     {{ with .Site.Params.keywords }}"keywords": {{ . }},{{ end }}
     "publisher" : {
       "@type": "Person",
-      "name": "{{ .Site.Author.name | safeJS }}"
+      "name": "{{ .Site.Params.Author.name | safeJS }}"
     }
   }
   </script>
@@ -30,7 +30,7 @@
     "url" : "{{ .Permalink }}",
     "author" : {
       "@type": "Person",
-      "name": "{{ .Site.Author.name | safeJS }}"
+      "name": "{{ .Site.Params.Author.name | safeJS }}"
     },
     {{ with .PublishDate }}"copyrightYear": "{{ .Format "2006" }}",{{ end }}
     {{ with .Date }}"dateCreated": "{{ .Format $iso8601 }}",{{ end }}


### PR DESCRIPTION
Fix warning `deprecated: .Site.Author was deprecated in Hugo v0.124.0 and will be removed in a future release.`
As it said, `.Site.Author` was deprecated by [hugo #11569](https://github.com/gohugoio/hugo/pull/11569) in [v0.124.0](https://github.com/gohugoio/hugo/releases/tag/v0.124.0) in fact.

Moreover, add `disabled = false` field (in example & docs) to remind everyone that `i18n config` and `hugo modules` COULD be disabled **very simply**.
> Although double negatives are a confusing and BAD naming convention. ~~Not me, [bep](https://github.com/bep) did.~~