### PR TITLE
🐛 Do not prevent default for Enter

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -73,8 +73,6 @@ document.addEventListener("keydown", function (event) {
       } else {
         document.activeElement.click();
       }
-    }else{
-      event.preventDefault();
     }
   }
 


### PR DESCRIPTION
Do not prevent default for "Enter" if search is not visible. Old logic would prevent comment system adding new line using "Enter"

Related to this issue https://github.com/nunocoracao/blowfish/issues/1682