### PR TITLE
fix: exclude pages with "xml" = false or "externalUrl".

### DIFF
--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -27,7 +27,7 @@
     {{- with .OutputFormats.Get "RSS" -}}
     {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
     {{- end -}}
-    {{ range $pages }}
+    {{ range $pages }}{{ if and (.Param "xml" | default true) (or (not .Params.externalUrl) (and (.Params.externalUrl) (and (not (hasPrefix .Params.externalUrl "http://")) (not (hasPrefix .Params.externalUrl "https://"))))) }}
     <item>
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>
@@ -44,6 +44,6 @@
         {{- end -}}
       {{ end }}
     </item>
-    {{ end }}
+    {{ end }}{{ end }}
   </channel>
 </rss>


### PR DESCRIPTION
Pages that include the `"xml" = false` attribute are excluded from the XML-Sitemap, but they still appeared in the RSS-feed.
Pages that include a `externalUrl` that starts with `http://` or `https://` are excluded from the XML-Sitemap, but they still appeared in the RSS-feed.

This PR implements the same filters used in sitemap.xml in the RSS-feed template.