### PR TITLE
Fix typos in main.css related to '2xl'

### DIFF
--- a/assets/css/compiled/main.css
+++ b/assets/css/compiled/main.css
@@ -4499,107 +4499,107 @@ pre {
 }
 
 @media (min-width: 1536px) {
-  .2xl\:grid-w10 {
+  .\2xl\:grid-w10 {
     width: calc(10% - 5px);
     margin: 0px !important;
   }
 
-  .2xl\:grid-w15 {
+  .\2xl\:grid-w15 {
     width: calc(15% - 5px);
     margin: 0px !important;
   }
 
-  .2xl\:grid-w20 {
+  .\2xl\:grid-w20 {
     width: calc(20% - 5px);
     margin: 0px !important;
   }
 
-  .2xl\:grid-w25 {
+  .\2xl\:grid-w25 {
     width: calc(25% - 5px);
     margin: 0px !important;
   }
 
-  .2xl\:grid-w30 {
+  .\2xl\:grid-w30 {
     width: calc(30% - 5px);
     margin: 0px !important;
   }
 
-  .2xl\:grid-w33 {
+  .\2xl\:grid-w33 {
     width: calc(33% - 5px);
     margin: 0px !important;
   }
 
-  .2xl\:grid-w35 {
+  .\2xl\:grid-w35 {
     width: calc(35% - 5px);
     margin: 0px !important;
   }
 
-  .2xl\:grid-w40 {
+  .\2xl\:grid-w40 {
     width: calc(40% - 5px);
     margin: 0px !important;
   }
 
-  .2xl\:grid-w45 {
+  .\2xl\:grid-w45 {
     width: calc(45% - 5px);
     margin: 0px !important;
   }
 
-  .2xl\:grid-w50 {
+  .\2xl\:grid-w50 {
     width: calc(50% - 5px);
     margin: 0px !important;
   }
 
-  .2xl\:grid-w55 {
+  .\2xl\:grid-w55 {
     width: calc(55% - 5px);
     margin: 0px !important;
   }
 
-  .2xl\:grid-w60 {
+  .\2xl\:grid-w60 {
     width: calc(60% - 5px);
     margin: 0px !important;
   }
 
-  .2xl\:grid-w65 {
+  .\2xl\:grid-w65 {
     width: calc(65% - 5px);
     margin: 0px !important;
   }
 
-  .2xl\:grid-w66 {
+  .\2xl\:grid-w66 {
     width: calc(66% - 5px);
     margin: 0px !important;
   }
 
-  .2xl\:grid-w70 {
+  .\2xl\:grid-w70 {
     width: calc(70% - 5px);
     margin: 0px !important;
   }
 
-  .2xl\:grid-w75 {
+  .\2xl\:grid-w75 {
     width: calc(75% - 5px);
     margin: 0px !important;
   }
 
-  .2xl\:grid-w80 {
+  .\2xl\:grid-w80 {
     width: calc(80% - 5px);
     margin: 0px !important;
   }
 
-  .2xl\:grid-w85 {
+  .\2xl\:grid-w85 {
     width: calc(85% - 5px);
     margin: 0px !important;
   }
 
-  .2xl\:grid-w90 {
+  .\2xl\:grid-w90 {
     width: calc(90% - 5px);
     margin: 0px !important;
   }
 
-  .2xl\:grid-w95 {
+  .\2xl\:grid-w95 {
     width: calc(95% - 5px);
     margin: 0px !important;
   }
 
-  .2xl\:grid-w100 {
+  .\2xl\:grid-w100 {
     width: calc(100% - 5px);
     margin: 0px !important;
   }
@@ -4706,19 +4706,19 @@ pre {
 }
 
 @media (min-width: 1536px) {
-  .2xl\:ratio-16-9 {
+  .\2xl\:ratio-16-9 {
     padding-top: 56.25%;
   }
 
   /* 16:9 Aspect Ratio */
 
-  .2xl\:ratio-21-9 {
+  .\2xl\:ratio-21-9 {
     padding-top: 42.85%;
   }
 
   /* 21:9 Aspect Ratio */
 
-  .2xl\:ratio-32-9 {
+  .\2xl\:ratio-32-9 {
     padding-top: 28.125%;
   }
 
@@ -5473,7 +5473,7 @@ pre {
 }
 
 @media (min-width: 1536px) {
-  .\32xl\:grid-cols-5 {
+  .\2xl\:grid-cols-5 {
     grid-template-columns:repeat(5, minmax(0, 1fr))
   }
 }

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -595,27 +595,27 @@ pre {
 }
 
 @screen 2xl {
-  .2xl\:grid-w10 { width: calc(10% - 5px); margin: 0px !important; }
-  .2xl\:grid-w15 { width: calc(15% - 5px); margin: 0px !important; }
-  .2xl\:grid-w20 { width: calc(20% - 5px); margin: 0px !important; }
-  .2xl\:grid-w25 { width: calc(25% - 5px); margin: 0px !important; }
-  .2xl\:grid-w30 { width: calc(30% - 5px); margin: 0px !important; }
-  .2xl\:grid-w33 { width: calc(33% - 5px); margin: 0px !important; }
-  .2xl\:grid-w35 { width: calc(35% - 5px); margin: 0px !important; }
-  .2xl\:grid-w40 { width: calc(40% - 5px); margin: 0px !important; }
-  .2xl\:grid-w45 { width: calc(45% - 5px); margin: 0px !important; }
-  .2xl\:grid-w50 { width: calc(50% - 5px); margin: 0px !important; }
-  .2xl\:grid-w55 { width: calc(55% - 5px); margin: 0px !important; }
-  .2xl\:grid-w60 { width: calc(60% - 5px); margin: 0px !important; }
-  .2xl\:grid-w65 { width: calc(65% - 5px); margin: 0px !important; }
-  .2xl\:grid-w66 { width: calc(66% - 5px); margin: 0px !important; }
-  .2xl\:grid-w70 { width: calc(70% - 5px); margin: 0px !important; }
-  .2xl\:grid-w75 { width: calc(75% - 5px); margin: 0px !important; }
-  .2xl\:grid-w80 { width: calc(80% - 5px); margin: 0px !important; }
-  .2xl\:grid-w85 { width: calc(85% - 5px); margin: 0px !important; }
-  .2xl\:grid-w90 { width: calc(90% - 5px); margin: 0px !important; }
-  .2xl\:grid-w95 { width: calc(95% - 5px); margin: 0px !important; }
-  .2xl\:grid-w100 { width: calc(100% - 5px); margin: 0px !important; }
+  .\2xl\:grid-w10 { width: calc(10% - 5px); margin: 0px !important; }
+  .\2xl\:grid-w15 { width: calc(15% - 5px); margin: 0px !important; }
+  .\2xl\:grid-w20 { width: calc(20% - 5px); margin: 0px !important; }
+  .\2xl\:grid-w25 { width: calc(25% - 5px); margin: 0px !important; }
+  .\2xl\:grid-w30 { width: calc(30% - 5px); margin: 0px !important; }
+  .\2xl\:grid-w33 { width: calc(33% - 5px); margin: 0px !important; }
+  .\2xl\:grid-w35 { width: calc(35% - 5px); margin: 0px !important; }
+  .\2xl\:grid-w40 { width: calc(40% - 5px); margin: 0px !important; }
+  .\2xl\:grid-w45 { width: calc(45% - 5px); margin: 0px !important; }
+  .\2xl\:grid-w50 { width: calc(50% - 5px); margin: 0px !important; }
+  .\2xl\:grid-w55 { width: calc(55% - 5px); margin: 0px !important; }
+  .\2xl\:grid-w60 { width: calc(60% - 5px); margin: 0px !important; }
+  .\2xl\:grid-w65 { width: calc(65% - 5px); margin: 0px !important; }
+  .\2xl\:grid-w66 { width: calc(66% - 5px); margin: 0px !important; }
+  .\2xl\:grid-w70 { width: calc(70% - 5px); margin: 0px !important; }
+  .\2xl\:grid-w75 { width: calc(75% - 5px); margin: 0px !important; }
+  .\2xl\:grid-w80 { width: calc(80% - 5px); margin: 0px !important; }
+  .\2xl\:grid-w85 { width: calc(85% - 5px); margin: 0px !important; }
+  .\2xl\:grid-w90 { width: calc(90% - 5px); margin: 0px !important; }
+  .\2xl\:grid-w95 { width: calc(95% - 5px); margin: 0px !important; }
+  .\2xl\:grid-w100 { width: calc(100% - 5px); margin: 0px !important; }
 }
 
 /* Carousel Specific Styles */
@@ -648,7 +648,7 @@ pre {
 }
 
 @screen 2xl {
-  .2xl\:ratio-16-9 { padding-top: 56.25%; } /* 16:9 Aspect Ratio */
-  .2xl\:ratio-21-9 { padding-top: 42.85%; } /* 21:9 Aspect Ratio */
-  .2xl\:ratio-32-9 { padding-top: 28.125%; } /* 32:9 Aspect Ratio */
+  .\2xl\:ratio-16-9 { padding-top: 56.25%; } /* 16:9 Aspect Ratio */
+  .\2xl\:ratio-21-9 { padding-top: 42.85%; } /* 21:9 Aspect Ratio */
+  .\2xl\:ratio-32-9 { padding-top: 28.125%; } /* 32:9 Aspect Ratio */
 }


### PR DESCRIPTION
Noticed that the class selectors starting with '2xl' were not properly escaped and was causing errors in main.css. Also there was a fat finger typo that resulted in a '32xl'. Not sure what this does functionality-wise but I am pretty sure my corrections are syntactically correct.