### PR TITLE
feat: option to plainify summary

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -90,6 +90,7 @@ forgejoDefaultServer = "https://v8.next.forgejo.org"
   layoutBackgroundHeaderSpace = true # only used when heroStyle equals background
   showBreadcrumbs = false
   showSummary = false
+  plainifySummary = true # only used when showSummary = true
   showViews = false
   showLikes = false
   showTableOfContents = false

--- a/layouts/partials/article-link/card-related.html
+++ b/layouts/partials/article-link/card-related.html
@@ -65,7 +65,11 @@
 
         {{ if .Params.showSummary | default (.Site.Params.list.showSummary | default false) }}
         <div class="py-1 prose dark:prose-invert">
+          {{- if .Params.plainifySummary | default (.Site.Params.list.plainifySummary | default true) }}
+          {{ .Summary | plainify }}
+          {{- else }}
           {{ .Summary }}
+          {{- end }}
         </div>
         {{ end }}
       </div>

--- a/layouts/partials/article-link/card.html
+++ b/layouts/partials/article-link/card.html
@@ -66,7 +66,11 @@
 
         {{ if .Params.showSummary | default (.Site.Params.list.showSummary | default false) }}
         <div class="py-1 prose dark:prose-invert">
+          {{- if .Params.plainifySummary | default (.Site.Params.list.plainifySummary | default true) }}
+          {{ .Summary | plainify }}
+          {{- else }}
           {{ .Summary }}
+          {{- end }}
         </div>
         {{ end }}
       </div>

--- a/layouts/partials/article-link/simple.html
+++ b/layouts/partials/article-link/simple.html
@@ -94,7 +94,11 @@
       </div>
       {{ if .Params.showSummary | default (.Site.Params.list.showSummary | default false) }}
       <div class="py-1 max-w-fit prose dark:prose-invert">
+        {{- if .Params.plainifySummary | default (.Site.Params.list.plainifySummary | default true) }}
+        {{ .Summary | plainify }}
+        {{- else }}
         {{ .Summary }}
+        {{- end }}
       </div>
       {{ end }}
     </div>


### PR DESCRIPTION
In the release of [Hugo v0.134](https://github.com/gohugoio/hugo/releases/tag/v0.134.0) they changed the way summaries are done. Not plainifying the summaries leads to layout issues in lists, this fixes that