### PR TITLE
📝 change [author] to [params.author] also in "Basic configuration" docs

### DIFF
--- a/exampleSite/content/docs/getting-started/index.it.md
+++ b/exampleSite/content/docs/getting-started/index.it.md
@@ -51,7 +51,7 @@ Tieni presente che il codice della lingua nel nome del file di configurazione de
 
 title = "My awesome website"
 
-[author]
+[params.author]
 name = "My name"
 image = "img/author.jpg"
 headline = "A generally awesome human"
@@ -60,7 +60,7 @@ links = [
   { twitter = "https://twitter.com/username" }
 ]
 ```
-La configurazione `[author]` determina il modo in cui le informazioni sull'autore vengono visualizzate sul sito web. L'immagine deve essere posizionata nella cartella `assets/`. I link verranno visualizzati nell'ordine in cui sono elencati.
+La configurazione `[params.author]` determina il modo in cui le informazioni sull'autore vengono visualizzate sul sito web. L'immagine deve essere posizionata nella cartella `assets/`. I link verranno visualizzati nell'ordine in cui sono elencati.
 
 Se hai bisogno di ulteriori dettagli, ulteriori informazioni su ciascuna di queste opzioni di configurazione sono trattate nella sezione [Configurazione]({{< ref "configuration" >}}).
 

--- a/exampleSite/content/docs/getting-started/index.ja.md
+++ b/exampleSite/content/docs/getting-started/index.ja.md
@@ -48,7 +48,7 @@ Note that the language code in the language config filename should match the `la
 
 title = "My awesome website"
 
-[author]
+[params.author]
 name = "My name"
 image = "img/author.jpg"
 headline = "A generally awesome human"
@@ -58,7 +58,7 @@ links = [
 ]
 ```
 
-The `[author]` configuration determines how the author information is displayed on the website. The image should be placed in the site's `assets/` folder. Links will be displayed in the order they are listed.
+The `[params.author]` configuration determines how the author information is displayed on the website. The image should be placed in the site's `assets/` folder. Links will be displayed in the order they are listed.
 
 If you need extra detail, further information about each of these configuration options, is covered in the [Configuration]({{< ref "configuration" >}}) section.
 

--- a/exampleSite/content/docs/getting-started/index.md
+++ b/exampleSite/content/docs/getting-started/index.md
@@ -48,7 +48,7 @@ Note that the language code in the language config filename should match the `la
 
 title = "My awesome website"
 
-[author]
+[params.author]
 name = "My name"
 image = "img/author.jpg"
 headline = "A generally awesome human"
@@ -58,7 +58,7 @@ links = [
 ]
 ```
 
-The `[author]` configuration determines how the author information is displayed on the website. The image should be placed in the site's `assets/` folder. Links will be displayed in the order they are listed.
+The `[params.author]` configuration determines how the author information is displayed on the website. The image should be placed in the site's `assets/` folder. Links will be displayed in the order they are listed.
 
 If you need extra detail, further information about each of these configuration options, is covered in the [Configuration]({{< ref "configuration" >}}) section.
 

--- a/exampleSite/content/docs/getting-started/index.zh-cn.md
+++ b/exampleSite/content/docs/getting-started/index.zh-cn.md
@@ -48,7 +48,7 @@ languageCode = "en"
 
 title = "My awesome website"
 
-[author]
+[params.author]
 name = "My name"
 image = "img/author.jpg"
 headline = "A generally awesome human"
@@ -58,7 +58,7 @@ links = [
 ]
 ```
 
-`[author]` 属性决定了作者信息的展示方式。 作者的图片信息应该放在 `assets/` 文件夹中。作者相关的链接将会按照排列顺序依次展示。
+`[params.author]` 属性决定了作者信息的展示方式。 作者的图片信息应该放在 `assets/` 文件夹中。作者相关的链接将会按照排列顺序依次展示。
 
 如果你还需要额外属性，在配置部分会有详细说明。
 


### PR DESCRIPTION
See past PRs #1681 & #1708.

I've left the occurrences in [`exampleSite/content/guides/202310-blowfish-tutorial`](https://github.com/nunocoracao/blowfish/tree/c2db79ee4b1208fcaa3f2428f1dd39d15bdb1731/exampleSite/content/guides/202310-blowfish-tutorial) alone, as I assume that guide is frozen in time.