### PR TITLE
Fix broken hugo module on v2.79.0

### DIFF
--- a/processUsers.js
+++ b/processUsers.js
@@ -121,7 +121,7 @@ puppeteer
                 layoutBackgroundHeaderSpace: false\n\
                 \r---\n";
 
-            var dir = usersFolderPath + users[i].title.replaceAll("/", "-");
+            var dir = usersFolderPath + users[i].url.split("//").at(1).replaceAll('/', '');
 
             if (!fs.existsSync(dir)) {
                 fs.mkdirSync(dir);


### PR DESCRIPTION
This PR fixes #1835.

We could have used

```diff
- var dir = usersFolderPath + users[i].title.replaceAll("/", "-");
+ var dir = usersFolderPath + users[i].title.replaceAll("/", "-")
+                                            .replaceAll(".", "-")
+                                            .replaceAll("’", "-");
```

but there are too many symbols to handle.

Use domain for paths should be unique enough.