### PR TITLE
🐛 Update basic.html so navigation doesn't bubble up.

### DIFF
--- a/layouts/partials/article-meta/basic.html
+++ b/layouts/partials/article-meta/basic.html
@@ -71,7 +71,7 @@
   {{ if (eq $taxonomy "authors")}}
   {{ if (gt (len ($context.GetTerms $taxonomy)) 0) }}
   {{ range $i, $a := $context.GetTerms $taxonomy }}
-    {{ if not (eq $i 0) }} ,&nbsp; {{ end }} <div style="cursor: pointer;" onclick="window.open({{ $a.RelPermalink }},'_self')">{{ $a.LinkTitle }}</div>
+    {{ if not (eq $i 0) }} ,&nbsp; {{ end }} <div style="cursor: pointer;" onclick="window.open({{ $a.RelPermalink }},'_self');return false;">{{ $a.LinkTitle }}</div>
   {{ end }}
   {{ end }}
   {{ end }}
@@ -86,7 +86,7 @@
   {{ if and (not (eq $taxonomy "authors")) (not (eq $taxonomy "series"))}}
   {{ if (gt (len ($context.GetTerms $taxonomy)) 0) }}
   {{ range $context.GetTerms $taxonomy }}
-  <span style="margin-top:0.5rem" class="mr-2" onclick="window.open({{ .RelPermalink }},'_self');">
+  <span style="margin-top:0.5rem" class="mr-2" onclick="window.open({{ .RelPermalink }},'_self');return false;">
     {{ partial "badge.html" .LinkTitle }}
   </span>
   {{ end }}


### PR DESCRIPTION
Currently, clicking any terms within a list will **not** redirect to the intended location, due to navigation event bubbling up.
We can easily verify this by checking the network log in chrome.

Navigate to https://blowfish.page/samples/ and click the `authors` term. We will be redirected to the `a` tag `href` instead of the `authors` term page.

![image](https://github.com/user-attachments/assets/46ee3800-e412-4d11-9c76-88810920fef5)

This can be easily fixed, returning `false` from the `onclick` handler, thus canceling the parent `a` tag navigation.