### PR TITLE
🐛 RTL top nav bar layout fix.

### DIFF
--- a/assets/css/compiled/main.css
+++ b/assets/css/compiled/main.css
@@ -1616,10 +1616,6 @@ select {
   margin-left:-3rem
 }
 
-.-mr-2 {
-  margin-right:-0.5rem
-}
-
 .-mr-48 {
   margin-right:-12rem
 }
@@ -2161,6 +2157,16 @@ select {
 
 .gap-4 {
   gap:1rem
+}
+
+.gap-x-3 {
+  -moz-column-gap:0.75rem;
+       column-gap:0.75rem
+}
+
+.gap-x-5 {
+  -moz-column-gap:1.25rem;
+       column-gap:1.25rem
 }
 
 .space-x-2 > :not([hidden]) ~ :not([hidden]) {
@@ -5494,8 +5500,8 @@ pre {
   margin-left:0.5rem
 }
 
-.ltr\:mr-14:where([dir="ltr"], [dir="ltr"] *) {
-  margin-right:3.5rem
+.ltr\:mr-1:where([dir="ltr"], [dir="ltr"] *) {
+  margin-right:0.25rem
 }
 
 .ltr\:mr-4:where([dir="ltr"], [dir="ltr"] *) {
@@ -5562,8 +5568,8 @@ pre {
   margin-right:-1.25rem
 }
 
-.rtl\:ml-14:where([dir="rtl"], [dir="rtl"] *) {
-  margin-left:3.5rem
+.rtl\:ml-1:where([dir="rtl"], [dir="rtl"] *) {
+  margin-left:0.25rem
 }
 
 .rtl\:ml-4:where([dir="rtl"], [dir="rtl"] *) {

--- a/layouts/partials/header/basic.html
+++ b/layouts/partials/header/basic.html
@@ -1,5 +1,5 @@
 <div style="padding-left:0;padding-right:0;padding-top:2px;padding-bottom:3px"
-    class="main-menu flex items-center justify-between px-4 py-6 sm:px-6 md:justify-start space-x-3">
+    class="main-menu flex items-center justify-between px-4 py-6 sm:px-6 md:justify-start gap-x-3">
     {{ if .Site.Params.Logo }}
     {{ $logo := resources.Get .Site.Params.Logo }}
     {{ if $logo }}
@@ -30,7 +30,7 @@
             {{ end }}
 
         </nav>
-        <nav class="hidden md:flex items-center space-x-5 md:ml-12 h-12">
+        <nav class="hidden md:flex items-center gap-x-5 md:ml-12 h-12">
 
             {{ if .Site.Menus.main }}
             {{ range .Site.Menus.main }}
@@ -51,7 +51,7 @@
             {{/* Appearance switch */}}
             {{ if .Site.Params.footer.showAppearanceSwitcher | default false }}
             <div
-                class="{{ if .Site.Params.footer.showScrollToTop | default true -}} ltr:mr-14 rtl:ml-14 {{- end }} flex items-center">
+                class="{{ if .Site.Params.footer.showScrollToTop | default true -}} {{- end }} flex items-center">
                 <button id="appearance-switcher" aria-label="Dark mode switcher" type="button" class="text-base hover:text-primary-600 dark:hover:text-primary-400">
                     <div class="flex items-center justify-center dark:hidden">
                         {{ partial "icon.html" "moon" }}
@@ -64,7 +64,7 @@
             {{ end }}
 
         </nav>
-        <div class="flex md:hidden items-center space-x-5 md:ml-12 h-12">
+        <div class="flex md:hidden items-center gap-x-5 md:ml-12 h-12">
 
             <span></span>
 
@@ -79,7 +79,7 @@
 
             {{/* Appearance switch */}}
             {{ if .Site.Params.footer.showAppearanceSwitcher | default false }}
-            <button id="appearance-switcher-mobile" aria-label="Dark mode switcher" type="button" class="text-base hover:text-primary-600 dark:hover:text-primary-400" style="margin-right:5px">
+            <button id="appearance-switcher-mobile" aria-label="Dark mode switcher" type="button" class="text-base hover:text-primary-600 dark:hover:text-primary-400 ltr:mr-1 rtl:ml-1">
                 <div class="flex items-center justify-center dark:hidden">
                     {{ partial "icon.html" "moon" }}
                 </div>
@@ -91,7 +91,7 @@
 
         </div>
     </div>
-    <div class="-my-2 -mr-2 md:hidden">
+    <div class="-my-2 md:hidden">
 
         <label id="menu-button" class="block">
             {{ if .Site.Menus.main }}

--- a/layouts/partials/translations.html
+++ b/layouts/partials/translations.html
@@ -1,7 +1,7 @@
 {{ if .IsTranslated }}
 <div>
   <div class="cursor-pointer flex items-center nested-menu">
-    <span class="mr-1">
+    <span class="ltr:mr-1 rtl:ml-1">
       {{ partial "icon.html" "language" }}
     </span>
     <div class="text-sm font-medium text-gray-500 hover:text-primary-600 dark:hover:text-primary-400" title="{{ .Title }}">


### PR DESCRIPTION
Relevant issue: #1871 

# Current
In RTL languages, the layout of the top nav bar is slightly broken:

![Screenshot_20241219_150634](https://github.com/user-attachments/assets/ca7485de-e6ae-4463-956c-6afd2b5e07a2)
In desktop mode, there's no gap between **EN** and the languages logo, and there's no gap between **Shortcodes** and **Docs** tabs

![Screenshot_20241219_150626](https://github.com/user-attachments/assets/6c76b152-605c-4abd-b660-122f7a494091)
In mobile mode, there's no gap between **EN** and the languages logo.

# Solution
The issue is mainly caused by two things:
- Usage of `mr-X` or `ml-X` in some places, which places the margin in the wrong direction when switched to RTL layout. This is solved by making use of `rtl:` and `ltr:` specifiers. So `mr-1` is changed to `ltr:mr-1 rtl:ml-1`
- Usage of `space-x-X` in some places, which doesn't work well with RTL layouts. This is solved by replacing `space-x-X` with `gap-x-X`.

# Post-fix
![Screenshot_20241219_150741](https://github.com/user-attachments/assets/6ca0f37f-7e05-4f2e-afa0-f125a76fb598)
Desktop mode.

![Screenshot_20241219_150752](https://github.com/user-attachments/assets/3ff2e79d-c2b6-4f27-a108-b82ea42fa7b1)
Mobile mode.