### PR TITLE
Linktree Layout

### DIFF
--- a/exampleSite/content/links.md
+++ b/exampleSite/content/links.md
@@ -1,0 +1,5 @@
+---
+layout: linktree
+links:
+    - "Awesome Master Class": "https://example.com"
+---

--- a/layouts/_default/linktree.html
+++ b/layouts/_default/linktree.html
@@ -1,0 +1,20 @@
+{{ define "main" }}
+<div class="flex flex-col items-center justify-center text-center">
+    <img class="mb-2 rounded-full h-36 w-36 medium-zoom-image" width="144" height="144" alt="{{ .Params.Author.name }}" src="{{ .Params.Author.image }}">
+      {{ with .Site.Params.Author.name | markdownify }}
+    <div class="font-extrabold leading-6 text-neutral-800 dark:text-neutral-300">
+      {{ . }}
+    </div>
+    {{ end }}
+</div>
+  <article class="max-w-full">
+    <header>
+      <h1 class="mt-0 text-4xl font-extrabold text-neutral-900 dark:text-neutral">
+        {{ .Title | emojify }}
+      </h1>
+    </header>
+    <section class="max-w-full mt-6 prose dark:prose-invert">
+      {{ partial "linktree_list.html" . }}
+    </section>
+  </article>
+{{ end }}

--- a/layouts/partials/linktree-list.html
+++ b/layouts/partials/linktree-list.html
@@ -1,0 +1,34 @@
+<div class="flex flex-col items-center justify-center min-h-screen bg-gray-100 p-4">
+    <div class="w-full max-w-md">
+      {{ $siteLinks := .Site.Params.Author.Links | default (slice) }}
+      {{ $pageLinks := .Params.Links | default (slice) }}
+      {{ $allLinks := slice }}
+  
+      {{ range $link := $pageLinks }}
+        {{ $allLinks = $allLinks | append $link }}
+      {{ end }}
+  
+      {{ range $link := $siteLinks }}
+        {{ $allLinks = $allLinks | append $link }}
+      {{ end }}
+  
+      {{ if gt (len $allLinks) 0 }}
+        {{ range $links := $allLinks }}
+          {{ range $name, $url := $links }}
+            <a class="text-center justify-center flex w-full h-24 mb-6 fold-bold relative inline-flex items-center justify-center rounded border-2 border-black bg-white px-3 py-2 text-base font-bold text-black transition duration-100 hover:bg-primary-400 hover:text-primary-900" href="{{ $url }}" target="_blank" rel="noopener">
+              {{ $icon := resources.Get (print "icons/" $name ".svg") }}
+              {{ if $icon }}
+                <span class="w-6 h-6 mr-2 inline-block">
+                  {{ $icon.Content | safeHTML }}
+                </span>
+              {{ end }}
+              <span>{{ $name }}</span>
+            </a>
+          {{ end }}
+        {{ end }}
+      {{ else }}
+        <p class="text-gray-500">No links configured.</p>
+      {{ end }}
+    </div>
+  </div>
+  


### PR DESCRIPTION
Usage:
```
---
layout: linktree
links:
  - "Extra links": "https://example.com"

---
```

This layout show all your social links from your `.Params.Author.links` and show extra links from the actual page.

There is a [Live Demo](https://guisso.dev/links), but it's not equal to this PR, I have customized with more [code](https://github.com/fguisso/fguisso.github.io/blob/486167e62d4d9dff8daee4d8d04021eedd026402/layouts/partials/linktree_list.html#L19).

<img width="384" alt="image" src="https://github.com/user-attachments/assets/01de3223-2337-4a7a-b1d0-4822f30b764d" />
