### PR TITLE
✨ Use `RelPermalink` for series links

### DIFF
--- a/layouts/partials/series/series_base.html
+++ b/layouts/partials/series/series_base.html
@@ -13,7 +13,7 @@
     {{ else }}
     <div
         class="py-1 border-dotted border-neutral-300 ltr:-ml-5 ltr:border-l ltr:pl-5 rtl:-mr-5 rtl:border-r rtl:pr-5 dark:border-neutral-600">
-        <a href="{{$post.Permalink}}">
+        <a href="{{$post.RelPermalink}}">
             {{ i18n "article.part" }} {{ $post.Params.series_order }}: {{ $post.Params.title}}
         </a>
     </div>


### PR DESCRIPTION
Fixes #1916

- https://gohugo.io/methods/page/relpermalink/
- https://gohugo.io/methods/page/permalink/

Using full permalinks could cause strange issues inside/outside of production

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated navigation links for post series so that they now use relative URLs for improved consistency without altering the display order or titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->