### PR TITLE
Fix zen mode footer line bug

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -141,7 +141,7 @@
       {{ end }}
   
     </section>
-  <footer class="pt-8 max-w-prose print:hidden">
+  <footer id="single_footer" class="pt-8 max-w-prose print:hidden">
 
     {{ partial "article-pagination.html" . }}
     {{ if .Params.showComments | default (.Site.Params.article.showComments | default false) }}


### PR DESCRIPTION
Fix zen mode footer line bug.

Fixes #1663 Zen Mode Footer Line Issue. Author info is working as intended. 