### PR TITLE
🐛 Fix author badge link

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -49,7 +49,16 @@
               {{ $taxonomyLink = delimit (slice $baseURL "authors/" $author "/") "" }}
             {{ end }}
           {{ end }}
-          {{ partial "author-extra.html" (dict "context" . "data" $authorData "link" $taxonomyLink) }}
+
+          {{ $finalLink := $taxonomyLink }}
+          {{ $currentLang := $.Site.Language.Lang }}
+          {{ if eq $.Site.LanguagePrefix "" }}
+            {{ $finalLink = printf "%sauthors/%s/" $baseURL $author }}
+          {{ else }}
+            {{ $finalLink = printf "%s%s/authors/%s/" $baseURL $currentLang $author }}
+          {{ end }} 
+
+          {{ partial "author-extra.html" (dict "context" . "data" $authorData "link" $finalLink) }}
         {{- end -}}
       {{ end }}
 


### PR DESCRIPTION
## Current
When a user clicks the author's name element on an article's author badge with a non-default language selected, it will redirect to the default language author page, not the corresponding user selected language.

![Screenshot 2025-02-25 213230](https://github.com/user-attachments/assets/ccf692c7-004c-4811-bb93-514a9e35d387)

## Solution
I added some conditional where if it detects a prefix that is empty, meaning default language is selected by user, it will default to none added to the URL, else user selected non-default language, it will add the language name to the URL. This will pass the correct context link to author-extra.html partial.

Fixes #1999 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Author links now adapt to the site's language settings, displaying language-specific URLs when applicable for enhanced localized navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->