### PR TITLE
✨ Create gist.html

### DIFF
--- a/layouts/shortcodes/gist.html
+++ b/layouts/shortcodes/gist.html
@@ -1,0 +1,1 @@
+<script src="https://gist.github.com/{{ index .Params 0 }}/{{ index .Params 1 }}.js{{if len .Params | eq 3 }}?file={{ index .Params 2 }}{{end}}"></script>


### PR DESCRIPTION
Since the gist shortcode was deprecated in v0.143.0 and will be removed in a future release of Hugo, I followed the instructions provided by [Hugo](https://gohugo.io/shortcodes/gist/).