### PR TITLE
Update to newest Hugo version

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,4 +2,4 @@
 [module.hugoVersion]
 extended = true
 min = "0.87.0"
-max = "0.143.1"
+max = "0.145.0"


### PR DESCRIPTION
To avoid the Hugo warning `Module "blowfish" is not compatible with this Hugo version: 0.87.0/0.143.1;`, I updated the `max` version to `0.145.0`.