### PR TITLE
fix: adjust alignment classes for article link layout

### DIFF
--- a/layouts/partials/article-link/simple.html
+++ b/layouts/partials/article-link/simple.html
@@ -63,8 +63,8 @@
     {{- end -}}
 
 
-    <div class="{{ $articleInnerClasses }}">
-      <div class="items-center text-left text-xl font-semibold">
+    <div class="{{ $articleInnerClasses }} ">
+      <div class="items-center ltr:text-left rtl:text-right text-xl font-semibold ">
         {{ with .Params.externalUrl }}
         <div>
           <div


### PR DESCRIPTION
## Describe your changes
Changed the Allignment of the Title to be based on text direction instead of always being text-left
## Issue ticket number and link
#2023 
## Checklist before requesting a review
- [x] I have performed a self-review of my code
