### PR TITLE
✨ don't add `mailto:` links to `<head>`

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -115,7 +115,9 @@
   {{ with .Site.Params.Author.links }}
   {{ range $links := . }}
   {{ range $name, $url := $links }}
+  {{ if not (strings.HasPrefix $url "mailto:") }}
   <link href="{{ $url }}" rel="me" />{{ end }}
+  {{ end }}
   {{ end }}
   {{ end }}
   {{/* Vendor */}}


### PR DESCRIPTION
This pull request avoids adding `mailto:x@y.z` links inside the `head` tag. As far as I know there is no real use for it anyway, but not adding it would enable users to use Cloudflare's [Email Address Obfuscation](https://developers.cloudflare.com/waf/tools/scrape-shield/email-address-obfuscation/) correctly as Cloudflare does _not_ remove these inside of the `head` tag.