### PR TITLE
🐛 fix: Preserve Mermaid indentation disrupted by Hugo minify (#2069)

### DIFF
--- a/assets/js/mermaid.js
+++ b/assets/js/mermaid.js
@@ -2,6 +2,17 @@ function css(name) {
   return "rgb(" + getComputedStyle(document.documentElement).getPropertyValue(name) + ")";
 }
 
+document.addEventListener("DOMContentLoaded", () => {
+  const mermaidDivs = document.querySelectorAll("div.mermaid");
+
+  for (const div of mermaidDivs) {
+    const preElement = div.querySelector("pre");
+    if (preElement) {
+      div.textContent = preElement.textContent;
+    }
+  }
+});
+
 mermaid.initialize({
   theme: "base",
   themeVariables: {

--- a/layouts/shortcodes/mermaid.html
+++ b/layouts/shortcodes/mermaid.html
@@ -1,3 +1,3 @@
 <div class="mermaid" align="center">
-  {{ .Inner }}
+  <pre>{{ .Inner | safeHTML }}</pre>
 </div>


### PR DESCRIPTION
Add a pre tag to the Mermaid class to preserve indentation and ensure data retrieval on DOMContentLoaded. This should close #2069.