### PR TITLE
:bug: fix: Enable zooming to a higher resolution image using `srcset` and `medium-zoom`

### DIFF
--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -32,6 +32,7 @@
         {{ (.Resize "660x").RelPermalink }} 660w,
         {{ (.Resize "1024x").RelPermalink }} 1024w,
         {{ (.Resize "1320x").RelPermalink }} 2x"
+        data-zoom-src="{{ (.Resize "1320x").RelPermalink }}"
         src="{{ (.Resize "660x").RelPermalink }}"
         alt="{{ $altText }}"
       />

--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -37,6 +37,7 @@
           {{ (.Resize "1024x").RelPermalink }} 1024w,
           {{ (.Resize "1320x").RelPermalink }} 2x"
           src="{{ (.Resize "660x").RelPermalink }}"
+          data-zoom-src="{{ (.Resize "1320x").RelPermalink }}"
           alt="{{ $altText }}"
         />
       {{- end }}


### PR DESCRIPTION
The current version of Blowfish generates a very nice array of `srcset` images in `figure.html` and `render-image.html`, but doesn't correctly setup them with the `medium-zoom` library.

If you click to zoom an image with an `srcset`, it will only zoom to a `660x` version, as below:

![Screenshot from 2025-04-26 13-12-42](https://github.com/user-attachments/assets/1f471a27-23f5-4b60-b6bb-763e023680c0)

`medium-zoom` has a mechanic which removes `srcset` when zooming to choose the biggest image, but it's activated only when the `data-zoom-src` is set (as per [this PR](https://github.com/francoischalifour/medium-zoom/pull/51).  With that, the example looks as below:

![Screenshot from 2025-04-26 13-12-24](https://github.com/user-attachments/assets/58b41b9b-144b-4695-b5ce-424697bb77b8)
