### PR TITLE
🐛 fix: incorrect path for gallery (#2042)

### DIFF
--- a/layouts/shortcodes/gallery.html
+++ b/layouts/shortcodes/gallery.html
@@ -1,5 +1,31 @@
 {{ $id := delimit (slice "gallery" (partial "functions/uid.html" .)) "-" }}
 
 <div id="{{ $id }}" class="gallery">
-  {{ .Inner }}
+  {{ $page := .Page }}
+  
+  {{/* find all img tags */}}
+  {{ $imgTagRegex := `<img\s+[^>]*>` }}
+  {{ $imgTags := findRE $imgTagRegex .Inner }}
+  {{ $newContent := .Inner }}
+  
+  {{ range $imgTags }}
+    {{ $imgTag := . }}
+    {{/* extract src attribute */}}
+    {{ $srcRegex := `src=['"]([^'"]+)['"]` }}
+    {{ $srcMatches := findRESubmatch $srcRegex $imgTag }}
+    
+    {{ if $srcMatches }}
+      {{ $srcFull := index (index $srcMatches 0) 0 }}
+      {{ $src := index (index $srcMatches 0) 1 }}
+      
+      {{ $resource := $page.Resources.GetMatch $src }}
+      {{ if $resource }}
+        {{ $newSrc := printf `src="%s"` $resource.RelPermalink }}
+        {{ $newImg := replace $imgTag $srcFull $newSrc }}
+        {{ $newContent = replace $newContent $imgTag $newImg }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+  
+  {{ $newContent | safeHTML }}
 </div>


### PR DESCRIPTION
This PR fixes the gallery path error (#2042) by using `resource.RelPermalink`. Since the document uses `<img>` tags in the gallery shortcode, a regex is needed to properly resolve the `<img>` tag.

In the following example, all images work as expected on default language pages. However, on non-default language pages, images will not be displayed if `<img>` tags are not used in the image shortcode, which is the same behavior as before this PR.

```md
{{< gallery >}}
  <!-- Result of "non-default language" pages -->
  <!-- ❌ picture -->
  <picture class='grid-w50 md:grid-w33 xl:grid-w25'>
    <source srcset='gallery/01.jpg' type='image/jpeg'>
    <img src='gallery/01.jpg' alt='' class='w-full h-auto' />
  </picture>
  
  <!-- ❌ embed -->
  <embed src='gallery/02.jpg' type='image/jpeg' class='grid-w50 md:grid-w33 xl:grid-w25' />
  
  <!-- ❌ object -->
  <object data='gallery/03.jpg' type='image/jpeg' class='grid-w50 md:grid-w33 xl:grid-w25'></object>

  <!-- ✅ single quote -->
  <img src='gallery/04.jpg' class='grid-w50 md:grid-w33 xl:grid-w25' />

  <!-- ✅ double quote -->
  <img src="gallery/06.jpg" class='grid-w50 md:grid-w33 xl:grid-w25' />

  <!-- ✅ from static folder -->
  <img src='/android-chrome-512x512.png' class='grid-w33' />
{{< /gallery >}}
```
