### PR TITLE
🐛 Fix: handle uppercase values in templates.Exists lookup

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -16,7 +16,7 @@
       "nav.skip_to_main" }}</a>
   </div>
   {{ $header := print "header/" .Site.Params.header.layout ".html" }}
-  {{ if templates.Exists ( printf "partials/%s" $header ) }}
+  {{ if or ( templates.Exists ( printf "partials/%s" $header )) ( templates.Exists ( printf "partials/%s" ( $header | lower ))) }}
   {{ partial $header . }}
   {{ else }}
   {{ partial "header/basic.html" . }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -3,7 +3,7 @@
 {{ .Scratch.Set "scope" "list" }}
 {{ if .Site.Params.list.showHero | default false }}
 {{ $heroStyle := print "hero/" .Site.Params.list.heroStyle ".html" }}
-{{ if templates.Exists ( printf "partials/%s" $heroStyle ) }}
+{{ if or ( templates.Exists ( printf "partials/%s" $heroStyle )) ( templates.Exists ( printf "partials/%s" ( $heroStyle | lower ))) }}
 {{ partial $heroStyle . }}
 {{ else }}
 {{ partial "hero/basic.html" . }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -6,7 +6,7 @@
   {{ $heroStyle := .Params.heroStyle }}
   {{ if not $heroStyle }}{{ $heroStyle = .Site.Params.article.heroStyle }}{{ end }}
   {{ $heroStyle := print "hero/" $heroStyle ".html" }}
-  {{ if templates.Exists ( printf "partials/%s" $heroStyle ) }}
+  {{ if or ( templates.Exists ( printf "partials/%s" $heroStyle )) ( templates.Exists ( printf "partials/%s" ( $heroStyle | lower ))) }}
   {{ partial $heroStyle . }}
   {{ else }}
   {{ partial "hero/basic.html" . }}

--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -3,7 +3,7 @@
 {{ .Scratch.Set "scope" "term" }}
 {{ if .Site.Params.term.showHero | default false }}
 {{ $heroStyle := print "hero/" .Site.Params.term.heroStyle ".html" }}
-{{ if templates.Exists ( printf "partials/%s" $heroStyle ) }}
+{{ if or ( templates.Exists ( printf "partials/%s" $heroStyle )) ( templates.Exists ( printf "partials/%s" ( $heroStyle | lower ))) }}
 {{ partial $heroStyle . }}
 {{ else }}
 {{ partial "hero/basic.html" . }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -3,7 +3,7 @@
 {{ .Scratch.Set "scope" "list" }}
 {{ if .Site.Params.taxonomy.showHero | default false }}
 {{ $heroStyle := print "hero/" .Site.Params.taxonomy.heroStyle ".html" }}
-{{ if templates.Exists ( printf "partials/%s" $heroStyle ) }}
+{{ if or ( templates.Exists ( printf "partials/%s" $heroStyle )) ( templates.Exists ( printf "partials/%s" ( $heroStyle | lower ))) }}
 {{ partial $heroStyle . }}
 {{ else }}
 {{ partial "hero/basic.html" . }}


### PR DESCRIPTION
Due to a bug in Hugo v0.146.0, templates.Exists fails to resolve templates with uppercase characters. This patch adds fallback checks using lowercase names to ensure proper resolution (e.g. thumbAndBackground).