### PR TITLE
✨ Improved Table of Contents Display

### DIFF
--- a/assets/css/compiled/main.css
+++ b/assets/css/compiled/main.css
@@ -1507,8 +1507,8 @@ body.zen-mode-enable {
   .overflow-visible {
     overflow: visible;
   }
-  .overflow-y-scroll {
-    overflow-y: scroll;
+  .overflow-y-auto {
+    overflow-y: auto;
   }
   .overscroll-contain {
     overscroll-behavior: contain;
@@ -3536,6 +3536,11 @@ body a, body button {
 }
 #TableOfContents {
   max-width: 25vw;
+}
+#TOCView {
+  max-height: calc(100vh - 150px);
+  min-height: 0;
+  overflow-x: hidden;
 }
 .toc ul, .toc li {
   list-style-type: none;

--- a/assets/css/compiled/main.css
+++ b/assets/css/compiled/main.css
@@ -3534,6 +3534,9 @@ body a, body button {
 .prose div.min-w-0.max-w-prose>*:first-child {
   margin-top: calc(var(--spacing) * 3);
 }
+#TableOfContents {
+  max-width: 25vw;
+}
 .toc ul, .toc li {
   list-style-type: none;
   padding-inline: calc(var(--spacing) * 0);

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -63,6 +63,12 @@ body button {
   max-width: 25vw;
 }
 
+#TOCView {
+    max-height: calc(100vh - 150px);
+    min-height: 0;
+    overflow-x: hidden;
+}
+
 .toc ul,
 .toc li {
   @apply px-0 leading-snug list-none;

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -59,6 +59,10 @@ body button {
 }
 
 /* Table of Contents */
+#TableOfContents {
+  max-width: 25vw;
+}
+
 .toc ul,
 .toc li {
   @apply px-0 leading-snug list-none;

--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -1,5 +1,4 @@
-<details open id="TOCView"
-  class="toc-right mt-0 overflow-y-scroll overscroll-contain scrollbar-thin scrollbar-track-neutral-200 scrollbar-thumb-neutral-400 dark:scrollbar-track-neutral-800 dark:scrollbar-thumb-neutral-600 rounded-lg ltr:-ml-5 ltr:pl-5 rtl:-mr-5 rtl:pr-5 hidden lg:block">
+<details open id="TOCView" class="toc-right mt-0 overflow-y-auto overscroll-contain scrollbar-thin scrollbar-track-neutral-200 scrollbar-thumb-neutral-400 dark:scrollbar-track-neutral-800 dark:scrollbar-thumb-neutral-600 rounded-lg ltr:-ml-5 ltr:pl-5 rtl:-mr-5 rtl:pr-5 hidden lg:block">
   <summary
     class="block py-1 text-lg font-semibold cursor-pointer bg-neutral-100 text-neutral-800 ltr:-ml-5 ltr:pl-5 rtl:-mr-5 rtl:pr-5 dark:bg-neutral-700 dark:text-neutral-100 lg:hidden">
     {{ i18n "article.table_of_contents" }}
@@ -21,32 +20,7 @@
 </details>
 
 <script>
-
-  var margin = 200;
-  var marginError = 50;
-
-  (function () {
-    var $window = $(window);
-    var $toc = $('#TOCView');
-    var tocHeight = $toc.height();
-
-    function onResize() {
-      var windowAndMarginHeight = $window.height() - margin;
-      if(tocHeight >= windowAndMarginHeight) {
-        $toc.css("overflow-y", "scroll")
-        $toc.css("max-height", (windowAndMarginHeight + marginError) + "px")
-      } else {
-        $toc.css("overflow-y", "hidden")
-        $toc.css("max-height", "9999999px")
-      }
-    }
-
-    $window.on('resize', onResize);
-    $(document).ready(onResize);
-  })();
-
 {{ if .Site.Params.smartTOC }}
-
   (function () {
     var $toc = $('#TableOfContents');
     if ($toc.length > 0) {
@@ -72,7 +46,7 @@
             $(e).removeClass('active');
           {{ end }}
         });
-        $toc.find('a[href="#' + id + '"]').addClass('active')
+        $toc.find('a[href="#' + id + '"]').addClass('active');
         $toc.find('a[href="#' + id + '"]').parentsUntil('#TableOfContents').each(function (i, e) {
           $(e).children('a').parents('ul').show();          
         });
@@ -88,5 +62,4 @@
     }
   })();
 {{ end }}
-
 </script>


### PR DESCRIPTION
This PR fixes two ToC issue.

## Table of Contents takes too much space (#1607)

| Before Fix | After Fix |
|------------|-----------|
| ![Before](https://github.com/user-attachments/assets/6ebc067f-3d7e-40a7-85eb-7394805acb9f) | ![After](https://github.com/user-attachments/assets/3dd6eac3-bad1-4f54-bb6e-33d7525c567c) |

<br><br>

## Prevent ToC flicker on initial load

Use CSS to control ToC height instead of JavaScript to prevent flicker, this also enable scrollbar under no-JS environment.

| Before Fix | After Fix |
|------------|-----------|
| ![a_2x](https://github.com/user-attachments/assets/a89be08b-0c25-4d6a-be46-d59341ac6403) | ![b_2x](https://github.com/user-attachments/assets/cc84b5fc-9299-46b2-a29b-cd05771cf107) |


