### PR TITLE
🐛 Fix: disable the search keyboard shortcut in a form (#2041)

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -25,7 +25,14 @@ modal.addEventListener("click", function (event) {
 document.addEventListener("keydown", function (event) {
   // Forward slash to open search wrapper
   if (event.key == "/") {
-    if (!searchVisible) {
+    const active = document.activeElement
+    const tag = active.tagName
+    const isInputField =
+      tag === "INPUT" ||
+      tag === "TEXTAREA" ||
+      active.isContentEditable
+
+    if (!searchVisible && !isInputField) {
       event.preventDefault();
       displaySearch();
     }


### PR DESCRIPTION
Should close #2041