### PR TITLE
🐛 Fix: truncate long text in copy-button

### DIFF
--- a/assets/css/compiled/main.css
+++ b/assets/css/compiled/main.css
@@ -3579,6 +3579,10 @@ body a, body button {
   z-index: 10;
   width: calc(var(--spacing) * 20);
   cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
   border-top-right-radius: var(--radius-md);
   border-bottom-left-radius: var(--radius-md);
   background-color: rgba(var(--color-neutral-200), 1);

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -90,7 +90,9 @@ body button {
 }
 
 .copy-button {
-  @apply absolute top-0 right-0 z-10 invisible w-20 py-1 font-mono text-sm cursor-pointer opacity-90 bg-neutral-200 whitespace-nowrap rounded-bl-md rounded-tr-md text-neutral-700 dark:bg-neutral-600 dark:text-neutral-200;
+  @apply absolute top-0 right-0 z-10 invisible w-20 py-1 font-mono text-sm cursor-pointer
+  opacity-90 bg-neutral-200 whitespace-nowrap rounded-bl-md rounded-tr-md text-neutral-700
+  dark:bg-neutral-600 dark:text-neutral-200 overflow-hidden truncate;
 }
 
 .copy-button:hover,


### PR DESCRIPTION
Fix the issue where long text overflows in the copy button.

Before:
![SCR-20250506-pegg](https://github.com/user-attachments/assets/6f496154-4053-48bd-9abf-2033c4a9be78)

After:
![SCR-20250506-pelc](https://github.com/user-attachments/assets/e4a6d600-faa7-45c9-bf61-62468e8f4316)
