### PR TITLE
✨ Feat: support extend-head access .Page (#1781)

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -128,6 +128,10 @@
   {{ if templates.Exists "partials/extend-head.html" }}
   {{ partialCached "extend-head.html" .Site }}
   {{ end }}
+  {{/* Uncached extend head - e.g. {{ with .Page.HasShortcode "gallery" }} do something {{ end }}  */}}
+  {{ if templates.Exists "partials/extend-head-uncached.html" }}
+  {{ partial "extend-head-uncached.html" . }}
+  {{ end }}
   <meta name="theme-color"/>
   {{/* Firebase */}}
   {{ with $.Site.Params.firebase }}


### PR DESCRIPTION
Fix #1781: Use extend-head-uncached.html for backward compatibility.