### PR TITLE
🐛 Fix: anchor not working for non-ascii characters

### DIFF
--- a/layouts/_default/_markup/render-heading.html
+++ b/layouts/_default/_markup/render-heading.html
@@ -1,12 +1,11 @@
-{{ $strAnchor := urlize .Anchor }}
-{{ $replacedAnchor := replaceRE "%25" "" $strAnchor }}
+{{ $anchor := anchorize .Anchor }}
 <h{{ .Level }} class="relative group">{{ .Text | safeHTML }} 
-    <div id="{{ .Anchor | safeURL | urlize }}" class="anchor"></div>
-    {{ if.Page.Params.showHeadingAnchors | default (.Page.Site.Params.article.showHeadingAnchors | default true) }}
+    <div id="{{ $anchor }}" class="anchor"></div>
+    {{ if .Page.Params.showHeadingAnchors | default (.Page.Site.Params.article.showHeadingAnchors | default true) }}
     <span
         class="absolute top-0 w-6 transition-opacity opacity-0 ltr:-left-6 rtl:-right-6 not-prose group-hover:opacity-100">
         <a class="group-hover:text-primary-300 dark:group-hover:text-neutral-700"
-            style="text-decoration-line: none !important;" href="#{{ $replacedAnchor | safeURL }}" aria-label="{{ i18n "article.anchor_label" }}">#</a>
+            style="text-decoration-line: none !important;" href="#{{ $anchor }}" aria-label="{{ i18n "article.anchor_label" }}">#</a>
     </span>        
     {{ end }}
 </h{{ .Level }}>


### PR DESCRIPTION
Fix in-page anchor links by replacing urlize with anchorize.

Most in-page link syntaxes in the translated markdown pages are incorrect. [This page](https://deploy-preview-2122--snazzy-dango-efb2ec.netlify.app/ja/docs/installation/#git-%e3%82%92%e4%bd%bf%e7%94%a8%e3%81%97%e3%81%a6%e3%82%a4%e3%83%b3%e3%82%b9%e3%83%88%e3%83%bc%e3%83%ab%e3%81%99%e3%82%8b) is one of the few that uses the correct syntax and demonstrates the fix.
