### PR TITLE
🐛 Fix: prevent header from blocking footnotes links

### DIFF
--- a/assets/css/compiled/main.css
+++ b/assets/css/compiled/main.css
@@ -3844,6 +3844,9 @@ pre {
   height: 0px;
   visibility: hidden;
 }
+[id^="fn"], [id^="fnref"] {
+  scroll-margin-top: 92px;
+}
 @screen sm {
   .thumbnail {
     min-width: 100%;

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -424,6 +424,11 @@ pre {
   visibility: hidden;
 }
 
+/* Offset scroll position to avoid header overlap */
+[id^="fn"], [id^="fnref"] {
+  scroll-margin-top: 92px;
+}
+
 @screen sm {
   .thumbnail {
     min-width: 100%;


### PR DESCRIPTION
Add scroll-margin-top to offset the header