### PR TITLE
🩹 Chore: tweak processUsers.js to reduce feature image size (#980)

### DIFF
--- a/processUsers.js
+++ b/processUsers.js
@@ -140,7 +140,7 @@ puppeteer
           fs.writeFileSync(dir + '/index.' + targetLangs[j] + '.md', content);
         }
         await page.goto(users[i].url);
-        await page.screenshot({ path: dir + "/feature.jpg" });
+        await page.screenshot({ path: dir + "/feature.jpg", type: 'webp', quality: 50, });
       }
     }
 


### PR DESCRIPTION
While we can't rewrite history, we can at least slow its growth. WebP with lower quality settings gives about 2x size reduction with acceptable visual results.

We now have 100 users, and each `processUsers.js` update takes around 10 MB. Ideally, we should run `processUsers.js` in CI, set the `featureimage` field in the frontmatter to each corresponding filename, and move the scraped images to the `static` directory. This way, user images wouldn't be tracked by Git.
