### PR TITLE
Enable Goldmark passthrough extension for math rendering

### DIFF
--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -67,3 +67,12 @@ enableEmoji = true
       name = 'fragmentrefs'
       type = 'fragments'
       weight = 10
+
+[markup]
+  [markup.goldmark]
+    [markup.goldmark.extensions]
+      [markup.goldmark.extensions.passthrough]
+        enable = true
+        [markup.goldmark.extensions.passthrough.delimiters]
+          block = [['\[', '\]'], ['$$', '$$']]
+          inline = [['\(', '\)']]


### PR DESCRIPTION
In Hugo v0.132.0, the Goldmark passthrough extension was introduced to preserve raw Markdown text within designated delimiters, ensuring that MathJax or KaTeX can render formulas correctly. With this configuration in place, you no longer need to manually escape characters inside math expressions (for example, \\ → \\\\ or x_y → x\_y).

According the official document of Hugo:  
- [mathematics/#step-1](https://gohugo.io/content-management/mathematics/#step-1)
- [Passthrough render hooks](https://gohugo.io/render-hooks/passthrough/)