### PR TITLE
🧑‍💻 chore: add options for faster development

### DIFF
--- a/exampleSite/config/_default/hugo.toml
+++ b/exampleSite/config/_default/hugo.toml
@@ -69,3 +69,12 @@ googleAnalytics = "G-PEDMYR1V0K"
       name = 'fragmentrefs'
       type = 'fragments'
       weight = 10
+
+# Render only specific parts of the site for faster development. Use: hugo --renderSegments docs_only
+[segments]
+  [segments.site_core]
+    [[segments.site_core.includes]]
+      path = '{/,/docs,/docs/**,/samples,/samples/**}'
+  [segments.en_only]
+    [[segments.en_only.includes]]
+      lang = 'en'

--- a/exampleSite/config/_default/hugo.toml
+++ b/exampleSite/config/_default/hugo.toml
@@ -70,7 +70,7 @@ googleAnalytics = "G-PEDMYR1V0K"
       type = 'fragments'
       weight = 10
 
-# Render only specific parts of the site for faster development. Use: hugo --renderSegments docs_only
+# Render only specific parts of the site for faster development. Use: hugo --renderSegments site_core
 [segments]
   [segments.site_core]
     [[segments.site_core.includes]]

--- a/exampleSite/config/development/hugo.toml
+++ b/exampleSite/config/development/hugo.toml
@@ -1,0 +1,5 @@
+# Development configuration. Disable this by running: hugo server -e production
+# https://gohugo.io/quick-reference/glossary/#environment
+
+# Exclude folders containing large numbers of images
+ignoreFiles = ['content/guides', 'content/users']

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "dev-windows": "set NODE_ENV=development&& npx @tailwindcss/cli -i ./assets/css/main.css -o ./assets/css/compiled/main.css --jit -w",
     "build-windows": "set NODE_ENV=production&& npx @tailwindcss/cli -i ./assets/css/main.css -o ./assets/css/compiled/main.css --jit",
     "build-hugo": "hugo --minify -s exampleSite --themesDir ../.. -d ../docs --baseURL https://nunocoracao.github.io/blowfish/",
-    "example": "hugo server -E -F --minify --source exampleSite --themesDir ../.. --buildDrafts -b http://localhost/ -p 1313",
+    "example": "hugo server -E -F --minify --source exampleSite --themesDir ../.. --buildDrafts -b http://localhost/ -p 1313 -e production",
+    "example:site_core": "hugo server -E -F --minify --source exampleSite --themesDir ../.. --buildDrafts -b http://localhost/ -p 1313 --renderSegments site_core",
+    "example:site_core:en_only": "hugo server -E -F --minify --source exampleSite --themesDir ../.. --buildDrafts -b http://localhost/ -p 1313 --renderSegments site_core,en_only",
     "lighthouse": "lhci autorun"
   },
   "repository": {


### PR DESCRIPTION
This PR introduces two new development commands—`example:site_core` and `example:site_core:en_only` to significantly reduce development CPU usage without disrupting existing workflows. Since we typically focus on `shortcode` and `samples` pages during development, rendering the entire site is unnecessary.

|                  | `npm run example` (original) | `npm run example:site_core` | `npm run example:site_core:en_only` |
| ---------------- | ----------------- | --------------------------- | ----------------------------------- |
| Pages            | 1400              | 132                         | 34                                  |
| Non-page files   | 800               | 224                         | 56                                  |
| Images processed | 289               | 12                          | 12                                  |
| Percentage | 100%               | 10.7%               | 4%                                  |

- Nothing changes for existing developers. `npm run example` keeps the original behavior by adding `-e production`.
- Easy to understand. New commands are clearly named and scoped.
- Significantly faster, only the needed content is rendered.

A `development/hugo.toml` is included to omit image processing, as segments do not skip image rendering. See https://gohugo.io/configuration/segments/ for details.

This only affects local development and does not impact the production build or distribution. Even if using a new config file (`exampleSite/config/development/hugo.toml`) is not preferred, including only the segment settings already improves development performance a lot.