### PR TITLE
🐛 fix: hugo minify breaks repo cards

### DIFF
--- a/layouts/shortcodes/codeberg.html
+++ b/layouts/shortcodes/codeberg.html
@@ -4,6 +4,7 @@
 {{- $codebergColors := .Site.Data.codebergColors -}}
 {{- with $codebergData -}}
 
+<div class="codeberg-card-wrapper">
 <a id="{{ $id }}" target="_blank" href="{{ .html_url }}" class="cursor-pointer">
   <div
     class="w-full md:w-auto pt-3 p-5 border border-neutral-200 dark:border-neutral-700 border rounded-md shadow-2xl">
@@ -64,4 +65,5 @@
       .catch(error => console.error(error))
   </script>
 </a>
+</div>
 {{- end -}}

--- a/layouts/shortcodes/forgejo.html
+++ b/layouts/shortcodes/forgejo.html
@@ -4,6 +4,7 @@
 {{- $forgejoColors := .Site.Data.forgejoColors -}}
 {{- with $forgejoData -}}
 
+<div class="forgejo-card-wrapper">
 <a id="{{ $id }}" target="_blank" href="{{ .html_url }}" class="cursor-pointer">
   <div
     class="w-full md:w-auto pt-3 p-5 border border-neutral-200 dark:border-neutral-700 border rounded-md shadow-2xl">
@@ -64,4 +65,5 @@
       .catch(error => console.error(error))
   </script>
 </a>
+</div>
 {{- end -}}

--- a/layouts/shortcodes/gitea.html
+++ b/layouts/shortcodes/gitea.html
@@ -4,6 +4,7 @@
 {{- $giteaColors := .Site.Data.giteaColors -}}
 {{- with $giteaData -}}
 
+<div class="gitea-card-wrapper">
 <a id="{{ $id }}" target="_blank" href="{{ .html_url }}" class="cursor-pointer">
   <div
     class="w-full md:w-auto pt-3 p-5 border border-neutral-200 dark:border-neutral-700 border rounded-md shadow-2xl">
@@ -64,4 +65,5 @@
       .catch(error => console.error(error))
   </script>
 </a>
+</div>
 {{- end -}}

--- a/layouts/shortcodes/gitlab.html
+++ b/layouts/shortcodes/gitlab.html
@@ -4,6 +4,7 @@
 {{- $gitLabData := resources.GetRemote $gitlabURL | transform.Unmarshal -}}
 {{- with $gitLabData -}}
 
+<div class="gitlab-card-wrapper">
 <a id="{{ $id }}" target="_blank" href="{{ .web_url }}" class="cursor-pointer">
   <div class="w-full md:w-auto pt-3 p-5 border border-neutral-200 dark:border-neutral-700 border rounded-md shadow-2xl">
 
@@ -54,4 +55,5 @@
       .catch(error => console.error(error))
   </script>
 </a>
+</div>
 {{- end -}}


### PR DESCRIPTION
Make all repo cards behave consistently as in #2090. This also makes the CSS selector easier to specify.
