### PR TITLE
🐛 fix: Correct the attributes of the `<img>` tag

### DIFF
--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -27,13 +27,14 @@
       <img
         class="my-0 rounded-md"
         loading="lazy"
+        decoding="async"
+        fetchpriority="low"
         srcset="
         {{ (.Resize "330x").RelPermalink }} 330w,
         {{ (.Resize "660x").RelPermalink }} 660w,
-        {{ (.Resize "1024x").RelPermalink }} 1024w,
-        {{ (.Resize "1320x").RelPermalink }} 2x"
-        data-zoom-src="{{ (.Resize "1320x").RelPermalink }}"
-        src="{{ (.Resize "660x").RelPermalink }}"
+        {{ (.Resize "1280x").RelPermalink }} 1280w"
+        data-zoom-src="{{ .RelPermalink }}"
+        src="{{ .RelPermalink }}"
         alt="{{ $altText }}"
       />
       {{- end }}


### PR DESCRIPTION
Previously, the image always displayed the largest available (but still compressed) version, without selecting an appropriate size based on the device. Additionally, it never showed the original image, which negatively affects users who use Blowfish as an image gallery.

Changes made:

1. Remove the `x` descriptor

   > It is incorrect to mix width descriptors and pixel density descriptors in the same `srcset` attribute.  
   > https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img#attr-srcset  

2. Set `data-zoom-src` to point to the original, uncompressed image

3. Remove sizes 1024 and 1320 due to minimal difference; replace with 1280

4. With change `3`, conversion speed is about twice as fast as 1024 and 1320 are very close. Also, I tested and found that the gap only affects a small range of browser zoom levels.

5. Add new attributes: `decoding` and `fetchpriority`

Below is the demo of fixed srcset, it will now correctly load the image with appropriate size (see right network panel), not always the largest but still compressed image, and the js zoom will show the original image.

https://github.com/user-attachments/assets/aa69310b-188e-410b-8bc1-808b7a19561f)](https://github.com/user-attachments/assets/aa69310b-188e-410b-8bc1-808b7a19561f
