### PR TITLE
🔧 Chore: adjust develope command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@
 
 - Great! Open a new GitHub pull request with the patch.
 - All development occurs on the `dev` branch and new PRs should be forked from here.
-- The command `npm run example` can be used to test local changes using the example site.
+- The command `npm run example:production` can be used to test local changes using the example site.
 - Ensure the PR description clearly describes the problem and solution. Include the relevant issue number, if applicable.
 - **Before submitting**, check the [coding conventions](#coding-conventions) section below to learn more about coding and commit message expectations.
 

--- a/exampleSite/config/_default/hugo.toml
+++ b/exampleSite/config/_default/hugo.toml
@@ -70,11 +70,19 @@ googleAnalytics = "G-PEDMYR1V0K"
       type = 'fragments'
       weight = 10
 
-# Render only specific parts of the site for faster development. Use: hugo --renderSegments site_core
+# Render only specific parts of the site for faster development. 
+# Note that there are more files are ignored in development/hugo.toml
+#
+# Usage: `hugo --renderSegments core` or `hugo --renderSegments core,en_only`
 [segments]
-  [segments.site_core]
-    [[segments.site_core.includes]]
+  [segments.core]
+    [[segments.core.includes]]
+      # Debug core pages
       path = '{/,/docs,/docs/**,/samples,/samples/**}'
   [segments.en_only]
     [[segments.en_only.includes]]
+      # Alternatively, you can use environment variable
+      #   - UNIX: HUGO_DISABLELANGUAGES='it ja zh-cn' npm run example:core
+      #   - Windows CMD: set "HUGO_DISABLELANGUAGES=it ja zh-cn" && npm run example:core
+      #   - Windows PowerShell: $env:HUGO_DISABLELANGUAGES="it ja zh-cn"; npm run example:core
       lang = 'en'

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -1,7 +1,7 @@
 module.exports = {
   ci: {
     collect: {
-      startServerCommand: "npm run example -- --disableLiveReload --minify",
+      startServerCommand: "npm run example:production -- --disableLiveReload --minify",
       startServerReadyPattern: "Web Server is available",
       url: ["http://localhost:8008/blowfish/samples/emoji/"],
       settings: {

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "dev-windows": "set NODE_ENV=development&& npx @tailwindcss/cli -i ./assets/css/main.css -o ./assets/css/compiled/main.css --jit -w",
     "build-windows": "set NODE_ENV=production&& npx @tailwindcss/cli -i ./assets/css/main.css -o ./assets/css/compiled/main.css --jit",
     "build-hugo": "hugo --minify -s exampleSite --themesDir ../.. -d ../docs --baseURL https://nunocoracao.github.io/blowfish/",
-    "example": "hugo server -E -F --minify --source exampleSite --themesDir ../.. --buildDrafts -b http://localhost/ -p 1313 -e production",
-    "example:site_core": "hugo server -E -F --minify --source exampleSite --themesDir ../.. --buildDrafts -b http://localhost/ -p 1313 --renderSegments site_core",
-    "example:site_core:en_only": "hugo server -E -F --minify --source exampleSite --themesDir ../.. --buildDrafts -b http://localhost/ -p 1313 --renderSegments site_core,en_only",
+    "example:dev": "hugo server -E -F --minify --source exampleSite --themesDir ../.. --buildDrafts -b http://localhost/ -p 1313",
+    "example:dev:core": "hugo server -E -F --minify --source exampleSite --themesDir ../.. --buildDrafts -b http://localhost/ -p 1313 --renderSegments core",
+    "example:production": "hugo server -E -F --minify --source exampleSite --themesDir ../.. --buildDrafts -b http://localhost/ -p 1313 -e production",
     "lighthouse": "lhci autorun"
   },
   "repository": {


### PR DESCRIPTION
## This PR affects codes uses `npm run example`!

I realized that the `example` command was not clear enough. After just two weeks, I had to spend time figuring out what I meant.

Now, both the production and environment commands are clearly defined, and the language disabling feature can be configured via an environment variable.
