### PR TITLE
🐛 Fix: gist shortcode breaks smartTOC

### DIFF
--- a/layouts/shortcodes/gist.html
+++ b/layouts/shortcodes/gist.html
@@ -1,1 +1,1 @@
-<script src="https://gist.github.com/{{ index .Params 0 }}/{{ index .Params 1 }}.js{{if len .Params | eq 3 }}?file={{ index .Params 2 }}{{end}}"></script>
+<script src="https://gist.github.com/{{ index .Params 0 }}/{{ index .Params 1 }}.js{{if len .Params | eq 3 }} ?file={{ index .Params 2 }}{{end}}"></script>


### PR DESCRIPTION
Adding space after gist shortcode prevents it from breaking ToC items above the gist.

No idea why, but it works.
