### PR TITLE
🐛 fix: add default figure shortcode as partial

### DIFF
--- a/layouts/partials/hugo-embedded/shortcodes/figure-default.html
+++ b/layouts/partials/hugo-embedded/shortcodes/figure-default.html
@@ -1,0 +1,43 @@
+{{/*
+  Copied from Hugo v0.146
+  Source: https://github.com/gohugoio/hugo/blob/83cfdd78ca6469e6d7265323d9fad1448880e559/tpl/tplimpl/embedded/templates/_shortcodes/figure.html
+*/}}
+
+<figure{{ with .Get "class" }} class="{{ . }}"{{ end }}>
+  {{- if .Get "link" -}}
+    <a href="{{ .Get "link" }}"{{ with .Get "target" }} target="{{ . }}"{{ end }}{{ with .Get "rel" }} rel="{{ . }}"{{ end }}>
+  {{- end -}}
+
+  {{- $u := urls.Parse (.Get "src") -}}
+  {{- $src := $u.String -}}
+  {{- if not $u.IsAbs -}}
+    {{- with or (.Page.Resources.Get $u.Path) (resources.Get $u.Path) -}}
+      {{- $src = .RelPermalink -}}
+    {{- end -}}
+  {{- end -}}
+
+  <img src="{{ $src }}"
+    {{- if or (.Get "alt") (.Get "caption") }}
+    alt="{{ with .Get "alt" }}{{ . }}{{ else }}{{ .Get "caption" | markdownify| plainify }}{{ end }}"
+    {{- end -}}
+    {{- with .Get "width" }} width="{{ . }}"{{ end -}}
+    {{- with .Get "height" }} height="{{ . }}"{{ end -}}
+    {{- with .Get "loading" }} loading="{{ . }}"{{ end -}}
+  ><!-- Closing img tag -->
+  {{- if .Get "link" }}</a>{{ end -}}
+  {{- if or (or (.Get "title") (.Get "caption")) (.Get "attr") -}}
+    <figcaption>
+      {{ with (.Get "title") -}}
+        <h4>{{ . }}</h4>
+      {{- end -}}
+      {{- if or (.Get "caption") (.Get "attr") -}}<p>
+        {{- .Get "caption" | markdownify -}}
+        {{- with .Get "attrlink" }}
+          <a href="{{ . }}">
+        {{- end -}}
+        {{- .Get "attr" | markdownify -}}
+        {{- if .Get "attrlink" }}</a>{{ end }}</p>
+      {{- end }}
+    </figcaption>
+  {{- end }}
+</figure>

--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -1,6 +1,6 @@
 {{ $disableImageOptimization := .Site.Params.disableImageOptimization | default false }}
 {{ if .Get "default" }}
-  {{ partial "shortcodes/figure.html" . }}
+  {{ partial "hugo-embedded/shortcodes/figure-default.html" . }}
 {{ else }}
   {{- $url := urls.Parse (.Get "src") }}
   {{- $altText := .Get "alt" }}


### PR DESCRIPTION
I updated the blowfish submodule in my Hugo project and ran into the error `partial "shortcodes/figure.html" not found`. It has already been discussed in #2052, #2053, then reported again in #2093. However, [this fix](https://github.com/nunocoracao/blowfish/pull/2055/files#diff-dd648b847f1ddc24890196195d38087229de05e7b6a08bbf2de0da28c4765244R3) from #2053 doesn't solve the problem, because, from what I gather, `partial` doesn't have access to embedded shortcodes anymore.

This PR has the embedded `figure` shortcode renamed and copied to partials. This seems to be the way to fix such issues as of now.

**Update**:

I see that another way to fix this is to revert the fix linked above for the figure shortcode and keep `{{ template "_internal/shortcodes/figure.html" . }}`. Even though, it is [discouraged](https://github.com/gohugoio/hugo/issues/13553) by Hugo maintainers. But, in this case, the existing `figure.html` shortcode with the custom logic should be renamed, which, in turn, means that the shortcode names for non-`default-true` figures in all existing content would need to be updated accordingly. So the proposed fix still seems like a safer alternative. It is also better in terms of maintaining the existing content.

> [!WARNING] 
> This PR breaks the project's [coding convention](https://github.com/nunocoracao/blowfish/blob/main/CONTRIBUTING.md#coding-conventions): `Avoid code reuse in templates by extracting components into partials.`
>
> However, since Hugo v0.146 removed access to embedded templates like "_internal/shortcodes/figure.html", I see no other way to deal with the issue, except for copying the Hugo's embedded shortcode into `layouts/partials/hugo-embedded/shortcodes/figure-default.html`.