### PR TITLE
🐛 Fix: date still shown when showDate=false

### DIFF
--- a/layouts/partials/article-meta/basic.html
+++ b/layouts/partials/article-meta/basic.html
@@ -12,9 +12,19 @@
 {{ $meta := newScratch }}
 
 {{/* Gather partials for this context */}}
+{{ $shouldShowDate := false }}
+{{ if and (eq $scope "single") (.Params.showDateOnlyInArticle | default (.Site.Params.article.showDateOnlyInArticle | default false)) }}
+  {{ $shouldShowDate = true }}
+{{ end }}
+
+{{/* showDate has higher priority than showDateOnlyInArticle */}}
 {{ if .Params.showDate | default (.Site.Params.article.showDate | default true) }}
-  {{ $meta.Add "partials" (slice (partial "meta/date.html" .Date)) }}
-{{else if and (eq $scope "single") (.Params.showDateOnlyInArticle | default (.Site.Params.article.showDateOnlyInArticle | default false)) }}
+  {{ $shouldShowDate = true }}
+{{ else }}
+  {{ $shouldShowDate = false }}
+{{ end }}
+
+{{ if $shouldShowDate }}
   {{ $meta.Add "partials" (slice (partial "meta/date.html" .Date)) }}
 {{ end }}
 


### PR DESCRIPTION
Fix #2208: Date was still displayed when `showDate=false` in frontmatter.

This change modifies the previous logic and may introduce a minor breaking change.

Previously, the date would be shown if either `showDate` or `showDateOnlyInArticle` was set to true. This PR gives `showDate` higher priority than `showDateOnlyInArticle`. As a result, users who only set `showDateOnlyInArticle` to true but do not explicitly set `showDate=true` will no longer see the date displayed. To show the article date, users must now explicitly set `showDate` to `true`.
