### PR TITLE
:recycle: Refactor: Improve consistency in <script> tags

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -35,7 +35,7 @@
   </div>
 </body>
 {{ if .Site.Params.buymeacoffee.globalWidget | default false }}
-<script data-name="BMC-Widget" data-cfasync="false" src="https://cdnjs.buymeacoffee.com/1.0.0/widget.prod.min.js"
+<script type="text/javascript" src="https://cdnjs.buymeacoffee.com/1.0.0/widget.prod.min.js" data-name="BMC-Widget" data-cfasync="false"
   data-id="{{ .Site.Params.buymeacoffee.identifier }}" data-description="Support me on Buy me a coffee!" data-message="{{ .Site.Params.buymeacoffee.globalWidgetMessage | default "" }}"
   data-color="{{ .Site.Params.buymeacoffee.globalWidgetColor | default "#FFDD00" }}" data-position="{{ .Site.Params.buymeacoffee.globalWidgetPosition | default "Left" }}" data-x_margin="18" data-y_margin="18"></script>
 {{ end }}

--- a/layouts/partials/analytics/fathom.html
+++ b/layouts/partials/analytics/fathom.html
@@ -1,5 +1,5 @@
 {{ if isset site.Params.fathomAnalytics "domain" }}
-<script defer src="https://{{ site.Params.fathomAnalytics.domain }}/script.js" data-site="{{ site.Params.fathomAnalytics.site }}"></script>
+<script defer type="text/javascript" src="https://{{ site.Params.fathomAnalytics.domain }}/script.js" data-site="{{ site.Params.fathomAnalytics.site }}"></script>
 {{ else }}
-<script defer src="https://cdn.usefathom.com/script.js" data-site="{{ site.Params.fathomAnalytics.site }}"></script>
+<script defer type="text/javascript" src="https://cdn.usefathom.com/script.js" data-site="{{ site.Params.fathomAnalytics.site }}"></script>
 {{ end }}

--- a/layouts/partials/analytics/ga.html
+++ b/layouts/partials/analytics/ga.html
@@ -1,8 +1,7 @@
-<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.Config.Services.GoogleAnalytics.ID }}"></script>
-<script>
+<script async type="text/javascript" src="https://www.googletagmanager.com/gtag/js?id={{ site.Config.Services.GoogleAnalytics.ID }}"></script>
+<script type="text/javascript">
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
-
   gtag('config', '{{ site.Config.Services.GoogleAnalytics.ID }}');
 </script>

--- a/layouts/partials/analytics/seline.html
+++ b/layouts/partials/analytics/seline.html
@@ -1,18 +1,18 @@
-<script async src="https://cdn.seline.so/seline.js" data-token="{{ site.Params.selineAnalytics.token }}" data-id="seline-script"></script>
+<script async type="text/javascript" src="https://cdn.seline.so/seline.js" data-token="{{ site.Params.selineAnalytics.token }}" data-id="seline-script"></script>
 
 {{ if .Site.Params.selineAnalytics.enableTrackEvent | default true }}
 <script type="text/javascript">
-    document.querySelector('script[data-id="seline-script"]')
-        .addEventListener('load', function () {
-            const type = document.head.querySelector('meta[property = "og:type"]').getAttribute('content');
-            let title = document.head.querySelector('meta[property = "og:title"]').getAttribute('content');
-            let url = document.head.querySelector('meta[property = "og:url"]').getAttribute('content');
+  document.querySelector('script[data-id="seline-script"]')
+      .addEventListener('load', function () {
+          const type = document.head.querySelector('meta[property = "og:type"]').getAttribute('content');
+          let title = document.head.querySelector('meta[property = "og:title"]').getAttribute('content');
+          let url = document.head.querySelector('meta[property = "og:url"]').getAttribute('content');
 
-            seline.track("user:" + type + ':' + title, {
-                type: type,
-                title: title,
-                url: url
-            });
-        });
+          seline.track("user:" + type + ':' + title, {
+              type: type,
+              title: title,
+              url: url
+          });
+      });
 </script>
 {{ end }}

--- a/layouts/partials/analytics/umami.html
+++ b/layouts/partials/analytics/umami.html
@@ -1,23 +1,23 @@
 {{ if isset site.Params.umamiAnalytics "domain" }}
-<script data-id="umami-script" async
+<script async type="text/javascript"
         src="https://{{ site.Params.umamiAnalytics.domain }}/{{ with site.Params.umamiAnalytics.scriptName }}{{ . }}{{ else }}script.js{{ end }}"
-        data-website-id="{{ site.Params.umamiAnalytics.websiteid }}"
+        data-id="umami-script" data-website-id="{{ site.Params.umamiAnalytics.websiteid }}"
         {{ with site.Params.umamiAnalytics.dataDomains }}data-domains="{{ . }}"{{ end }}>
 </script>
 {{ else }}
-<script data-id="umami-script" async src="https://analytics.umami.is/script.js"
+<script async type="text/javascript" src="https://analytics.umami.is/script.js" data-id="umami-script"  
         data-website-id="{{ site.Params.umamiAnalytics.websiteid }}">
 </script>
 {{ end }}
 
 {{ if .Site.Params.umamiAnalytics.enableTrackEvent | default true }}
 <script type="text/javascript">
-    document.querySelector('script[data-id="umami-script"]')
-        .addEventListener('load', function () {
-            const type = document.head.querySelector('meta[property = "og:type"]').getAttribute('content');
-            let title = document.head.querySelector('meta[property = "og:title"]').getAttribute('content');
-            let url = document.head.querySelector('meta[property = "og:url"]').getAttribute('content');
-            umami.track(type + ':' + title, {'url': url});
-    });
+  document.querySelector('script[data-id="umami-script"]')
+      .addEventListener('load', function () {
+          const type = document.head.querySelector('meta[property = "og:type"]').getAttribute('content');
+          let title = document.head.querySelector('meta[property = "og:title"]').getAttribute('content');
+          let url = document.head.querySelector('meta[property = "og:url"]').getAttribute('content');
+          umami.track(type + ':' + title, {'url': url});
+  });
 </script>
 {{ end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -49,13 +49,13 @@
     {{ end }}
 
   </div>
-  <script>
+  <script type="text/javascript">
     {{ if not .Site.Params.disableImageZoom | default true }}
-    mediumZoom(document.querySelectorAll("img:not(.nozoom)"), {
-      margin: 24,
-      background: 'rgba(0,0,0,0.5)',
-      scrollOffset: 0,
-    })
+      mediumZoom(document.querySelectorAll("img:not(.nozoom)"), {
+        margin: 24,
+        background: 'rgba(0,0,0,0.5)',
+        scrollOffset: 0,
+      })
     {{ end }}
   </script>
   {{ $jsProcess := resources.Get "js/process.js" }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -76,8 +76,8 @@
     }}"></script>
   {{ end }}
   {{ if not .Site.Params.disableImageZoom | default true }}
-  {{ $zoomJS := resources.Get "lib/zoom/zoom.min.js" | resources.Fingerprint (.Site.Params.fingerprintAlgorithm | default "sha512") }}
-  <script src="{{ $zoomJS.RelPermalink }}" integrity="{{ $zoomJS.Data.Integrity }}"></script>
+  {{ $zoomJS := resources.Get "lib/zoom/zoom.min.js" | resources.Minify | resources.Fingerprint (.Site.Params.fingerprintAlgorithm | default "sha512") }}
+  <script type="text/javascript" src="{{ $zoomJS.RelPermalink }}" integrity="{{ $zoomJS.Data.Integrity }}"></script>
   {{ end }}
   {{/* Icons */}}
   {{ if templates.Exists "partials/favicons.html" }}
@@ -144,11 +144,10 @@
   {{/* Firebase */}}
   {{ with $.Site.Params.firebase }}
   {{ if isset $.Site.Params "firebase" }}
-  <script src="https://www.gstatic.com/firebasejs/8.10.0/firebase-app.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/8.10.0/firebase-firestore.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/8.10.0/firebase-auth.js"></script>
-  <script>
-
+  <script type="text/javascript" src="https://www.gstatic.com/firebasejs/8.10.0/firebase-app.js"></script>
+  <script type="text/javascript" src="https://www.gstatic.com/firebasejs/8.10.0/firebase-firestore.js"></script>
+  <script type="text/javascript" src="https://www.gstatic.com/firebasejs/8.10.0/firebase-auth.js"></script>
+  <script type="text/javascript">
     const firebaseConfig = {
       apiKey: {{ $.Site.Params.firebase.apiKey }},
       authDomain: {{ $.Site.Params.firebase.apiKey }},
@@ -162,7 +161,6 @@
     var app = firebase.initializeApp(firebaseConfig);
     var db = firebase.firestore();
     var auth = firebase.auth();
-
   </script>
   {{ end }}
   {{ end }}

--- a/layouts/partials/header/basic.html
+++ b/layouts/partials/header/basic.html
@@ -171,13 +171,13 @@
 {{ end }}
 
 {{ if .Site.Params.highlightCurrentMenuArea }}
-<script>
-    (function () {
-        var $mainmenu = $('.main-menu');
-        var path = window.location.pathname;
-        $mainmenu.find('a[href="' + path + '"]').each(function (i, e) {
-            $(e).children('p').addClass('active');
-        });
-    })();
+<script type="text/javascript">
+  (function () {
+      var $mainmenu = $('.main-menu');
+      var path = window.location.pathname;
+      $mainmenu.find('a[href="' + path + '"]').each(function (i, e) {
+          $(e).children('p').addClass('active');
+      });
+  })();
 </script>
 {{ end }}

--- a/layouts/partials/schema.html
+++ b/layouts/partials/schema.html
@@ -1,49 +1,49 @@
 {{ if .IsHome -}}
   <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "WebSite",
-    "@id": "{{ (site.GetPage "/").Permalink | safeURL }}",
-    "name": "{{ .Site.Title | safeJS }}",
-    {{ with .Site.Params.description }}"description": "{{ . | safeJS }}",{{ end }}
-    {{ with .Site.LanguageCode }}"inLanguage": "{{ . }}",{{ end }}
-    "url": "{{ (site.GetPage "/").Permalink | safeURL }}",
-    {{ with .Site.Params.keywords }}"keywords": {{ . }},{{ end }}
-    "publisher" : {
-      "@type": "Person",
-      "name": "{{ .Site.Params.Author.name | safeJS }}"
+    {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      "@id": "{{ (site.GetPage "/").Permalink | safeURL }}",
+      "name": "{{ .Site.Title | safeJS }}",
+      {{ with .Site.Params.description }}"description": "{{ . | safeJS }}",{{ end }}
+      {{ with .Site.LanguageCode }}"inLanguage": "{{ . }}",{{ end }}
+      "url": "{{ (site.GetPage "/").Permalink | safeURL }}",
+      {{ with .Site.Params.keywords }}"keywords": {{ . }},{{ end }}
+      "publisher" : {
+        "@type": "Person",
+        "name": "{{ .Site.Params.Author.name | safeJS }}"
+      }
     }
-  }
   </script>
 {{ else if .IsPage }}
   {{- $iso8601 := "2006-01-02T15:04:05-07:00" -}}
   <script type="application/ld+json">
-  [{
-    "@context": "https://schema.org",
-    "@type": "Article",
-    "articleSection": "{{ (site.GetPage .Section).Title | safeJS }}",
-    "name": "{{ .Title | safeJS }}",
-    "headline": "{{ .Title | safeJS }}",
-    {{ with .Description }}"description": "{{ . | safeJS }}",{{ end }}
-    {{ with .Summary }}"abstract": "{{ . | safeJS }}",{{ end }}
-    {{ with .Site.LanguageCode }}"inLanguage": "{{ . }}",{{ end }}
-    "url" : "{{ .Permalink }}",
-    "author" : {
-      "@type": "Person",
-      "name": "{{ .Site.Params.Author.name | safeJS }}"
-    },
-    {{ with .PublishDate }}"copyrightYear": "{{ .Format "2006" }}",{{ end }}
-    {{ with .Date }}"dateCreated": "{{ .Format $iso8601 }}",{{ end }}
-    {{ with .PublishDate }}"datePublished": "{{ .Format $iso8601 }}",{{ end }}
-    {{ with .ExpiryDate }}"expires": "{{ .Format $iso8601 }}",{{ end }}
-    {{ with .Lastmod }}"dateModified": "{{ .Format $iso8601 }}",{{ end }}
-    {{ if .Keywords }}
-    {{ with .Keywords }}"keywords": {{ . }},{{ end }}
-    {{ else }}
-    {{ with .Params.tags }}"keywords": {{ . }},{{ end }}
-    {{ end }}
-    "mainEntityOfPage": "true",
-    "wordCount": "{{ .WordCount }}"
-  }]
+    [{
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "articleSection": "{{ (site.GetPage .Section).Title | safeJS }}",
+      "name": "{{ .Title | safeJS }}",
+      "headline": "{{ .Title | safeJS }}",
+      {{ with .Description }}"description": "{{ . | safeJS }}",{{ end }}
+      {{ with .Summary }}"abstract": "{{ . | safeJS }}",{{ end }}
+      {{ with .Site.LanguageCode }}"inLanguage": "{{ . }}",{{ end }}
+      "url" : "{{ .Permalink }}",
+      "author" : {
+        "@type": "Person",
+        "name": "{{ .Site.Params.Author.name | safeJS }}"
+      },
+      {{ with .PublishDate }}"copyrightYear": "{{ .Format "2006" }}",{{ end }}
+      {{ with .Date }}"dateCreated": "{{ .Format $iso8601 }}",{{ end }}
+      {{ with .PublishDate }}"datePublished": "{{ .Format $iso8601 }}",{{ end }}
+      {{ with .ExpiryDate }}"expires": "{{ .Format $iso8601 }}",{{ end }}
+      {{ with .Lastmod }}"dateModified": "{{ .Format $iso8601 }}",{{ end }}
+      {{ if .Keywords }}
+      {{ with .Keywords }}"keywords": {{ . }},{{ end }}
+      {{ else }}
+      {{ with .Params.tags }}"keywords": {{ . }},{{ end }}
+      {{ end }}
+      "mainEntityOfPage": "true",
+      "wordCount": "{{ .WordCount }}"
+    }]
   </script>
 {{ end }}

--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -19,47 +19,47 @@
   </div>
 </details>
 
-<script>
-{{ if .Site.Params.smartTOC }}
-  (function () {
-    var $toc = $('#TableOfContents');
-    if ($toc.length > 0) {
-      var $window = $(window);
+<script type="text/javascript">
+  {{ if .Site.Params.smartTOC }}
+    (function () {
+      var $toc = $('#TableOfContents');
+      if ($toc.length > 0) {
+        var $window = $(window);
 
-      function onScroll() {
-        var currentScroll = $window.scrollTop();
-        var h = $('.anchor');
-        var id = "";
-        h.each(function (i, e) {
-          e = $(e);
-          if (e.offset().top - $(window).height()/3 <= currentScroll) {
-            id = decodeURIComponent(e.attr('id'));
-          }
-        });
-        var active = $toc.find('a.active');      
-        if (active.length == 1 && active.eq(0).attr('href') == '#' + id) return true;
+        function onScroll() {
+          var currentScroll = $window.scrollTop();
+          var h = $('.anchor');
+          var id = "";
+          h.each(function (i, e) {
+            e = $(e);
+            if (e.offset().top - $(window).height()/3 <= currentScroll) {
+              id = decodeURIComponent(e.attr('id'));
+            }
+          });
+          var active = $toc.find('a.active');      
+          if (active.length == 1 && active.eq(0).attr('href') == '#' + id) return true;
 
-        active.each(function (i, e) {
+          active.each(function (i, e) {
+            {{ if .Site.Params.smartTOCHideUnfocusedChildren }} 
+              $(e).removeClass('active').siblings('ul').hide();
+            {{ else }}
+              $(e).removeClass('active');
+            {{ end }}
+          });
+          $toc.find('a[href="#' + id + '"]').addClass('active');
+          $toc.find('a[href="#' + id + '"]').parentsUntil('#TableOfContents').each(function (i, e) {
+            $(e).children('a').parents('ul').show();          
+          });
+        }
+
+        $window.on('scroll', onScroll);
+        $(document).ready(function () {
           {{ if .Site.Params.smartTOCHideUnfocusedChildren }} 
-            $(e).removeClass('active').siblings('ul').hide();
-          {{ else }}
-            $(e).removeClass('active');
+            $toc.find('a').parent('li').find('ul').hide();
           {{ end }}
-        });
-        $toc.find('a[href="#' + id + '"]').addClass('active');
-        $toc.find('a[href="#' + id + '"]').parentsUntil('#TableOfContents').each(function (i, e) {
-          $(e).children('a').parents('ul').show();          
+          onScroll();
         });
       }
-
-      $window.on('scroll', onScroll);
-      $(document).ready(function () {
-        {{ if .Site.Params.smartTOCHideUnfocusedChildren }} 
-          $toc.find('a').parent('li').find('ul').hide();
-        {{ end }}
-        onScroll();
-      });
-    }
-  })();
-{{ end }}
+    })();
+  {{ end }}
 </script>

--- a/layouts/shortcodes/gist.html
+++ b/layouts/shortcodes/gist.html
@@ -1,1 +1,1 @@
-<script src="https://gist.github.com/{{ index .Params 0 }}/{{ index .Params 1 }}.js{{if len .Params | eq 3 }}?file={{ index .Params 2 }}{{end}}"></script>
+<script type="text/javascript" src="https://gist.github.com/{{ index .Params 0 }}/{{ index .Params 1 }}.js{{if len .Params | eq 3 }}?file={{ index .Params 2 }}{{end}}"></script>

--- a/layouts/shortcodes/typeit.html
+++ b/layouts/shortcodes/typeit.html
@@ -22,16 +22,16 @@
 
 {{ printf `<%v %v>%s</%v>` $tag $attrs $initialString $tag | safeHTML }}
 
-<script>
-    document.addEventListener("DOMContentLoaded", function () {
-      new TypeIt("#{{ $id }}", {
-        strings: {{ $content }},
-        speed: {{ $speed }},
-        lifeLike: {{ $lifeLike }},
-        startDelay: {{ $startDelay }},
-        breakLines: {{ $breakLines }},
-        waitUntilVisible: {{ $waitUntilVisible }},
-        loop: {{ $loop }}
-      }).go();
-    });
+<script type="text/javascript">
+  document.addEventListener("DOMContentLoaded", function () {
+    new TypeIt("#{{ $id }}", {
+      strings: {{ $content }},
+      speed: {{ $speed }},
+      lifeLike: {{ $lifeLike }},
+      startDelay: {{ $startDelay }},
+      breakLines: {{ $breakLines }},
+      waitUntilVisible: {{ $waitUntilVisible }},
+      loop: {{ $loop }}
+    }).go();
+  });
 </script>


### PR DESCRIPTION
- Minify `zoom.min.js` with `resources.Minify`: I do get that one doesn't have to minify a script that already is, but just having this for consistency is in my opinion a good idea. It also reduces the size of `zoom.min.js` from `9637 bytes` to `9510 bytes`.
- Fix inconsistencies in other `<script>` elements

(Showcase: https://github.com/nunocoracao/blowfish/pull/2227#issuecomment-2980367849)