### PR TITLE
:recycle: Refactor: Improve consistency in <script> tags

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -44,13 +44,14 @@
   </body>
   {{ if .Site.Params.buymeacoffee.globalWidget | default false }}
     <script
-      data-name="BMC-Widget"
-      data-cfasync="false"
+      type="text/javascript"
       src="https://cdnjs.buymeacoffee.com/1.0.0/widget.prod.min.js"
-      data-id="{{ .Site.Params.buymeacoffee.identifier }}"
-      data-description="Support me on Buy me a coffee!"
-      data-message="{{ .Site.Params.buymeacoffee.globalWidgetMessage | default "" }}"
+      data-cfasync="false"
       data-color="{{ .Site.Params.buymeacoffee.globalWidgetColor | default "#FFDD00" }}"
+      data-description="Support me on Buy me a coffee!"
+      data-id="{{ .Site.Params.buymeacoffee.identifier }}"
+      data-message="{{ .Site.Params.buymeacoffee.globalWidgetMessage | default "" }}"
+      data-name="BMC-Widget"
       data-position="{{ .Site.Params.buymeacoffee.globalWidgetPosition | default "Left" }}"
       data-x_margin="18"
       data-y_margin="18"></script>

--- a/layouts/partials/analytics/fathom.html
+++ b/layouts/partials/analytics/fathom.html
@@ -1,11 +1,13 @@
 {{ if isset site.Params.fathomAnalytics "domain" }}
   <script
     defer
+    type="text/javascript"
     src="https://{{ site.Params.fathomAnalytics.domain }}/script.js"
     data-site="{{ site.Params.fathomAnalytics.site }}"></script>
 {{ else }}
   <script
     defer
+    type="text/javascript"
     src="https://cdn.usefathom.com/script.js"
     data-site="{{ site.Params.fathomAnalytics.site }}"></script>
 {{ end }}

--- a/layouts/partials/analytics/ga.html
+++ b/layouts/partials/analytics/ga.html
@@ -1,7 +1,8 @@
 <script
   async
+  type="text/javascript"
   src="https://www.googletagmanager.com/gtag/js?id={{ site.Config.Services.GoogleAnalytics.ID }}"></script>
-<script>
+<script type="text/javascript">
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());

--- a/layouts/partials/analytics/seline.html
+++ b/layouts/partials/analytics/seline.html
@@ -1,5 +1,6 @@
 <script
   async
+  type="text/javascript"
   src="https://cdn.seline.so/seline.js"
   data-token="{{ site.Params.selineAnalytics.token }}"
   data-id="seline-script"></script>

--- a/layouts/partials/analytics/umami.html
+++ b/layouts/partials/analytics/umami.html
@@ -1,19 +1,21 @@
 {{ if isset site.Params.umamiAnalytics "domain" }}
   <script
-    data-id="umami-script"
     async
+    type="text/javascript"
     src="https://{{ site.Params.umamiAnalytics.domain }}/{{ with site.Params.umamiAnalytics.scriptName }}
       {{ . }}
     {{ else }}
       script.js
     {{ end }}"
+    data-id="umami-script"
     data-website-id="{{ site.Params.umamiAnalytics.websiteid }}"
     {{ with site.Params.umamiAnalytics.dataDomains }}data-domains="{{ . }}"{{ end }}></script>
 {{ else }}
   <script
-    data-id="umami-script"
     async
+    type="text/javascript"
     src="https://analytics.umami.is/script.js"
+    data-id="umami-script"
     data-website-id="{{ site.Params.umamiAnalytics.websiteid }}"></script>
 {{ end }}
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -52,7 +52,7 @@
     {{ end }}
 
   </div>
-  <script>
+  <script type="text/javascript">
     {{ if not .Site.Params.disableImageZoom | default true }}
     mediumZoom(document.querySelectorAll("img:not(.nozoom)"), {
       margin: 24,

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -71,13 +71,12 @@
   {{ if $assets.Get "js" }}
   {{ $bundleJS := $assets.Get "js" | resources.Concat "js/main.bundle.js" | resources.Minify | resources.Fingerprint
   (.Site.Params.fingerprintAlgorithm | default "sha512") }}
-  <script defer type="text/javascript" id="script-bundle" src="{{ $bundleJS.RelPermalink }}"
-    integrity="{{ $bundleJS.Data.Integrity }}" data-copy="{{ i18n "code.copy" }}" data-copied="{{ i18n "code.copied"
-    }}"></script>
+  <script defer type="text/javascript" src="{{ $bundleJS.RelPermalink }}" integrity="{{ $bundleJS.Data.Integrity }}"
+    id="script-bundle" data-copy="{{ i18n "code.copy" }}" data-copied="{{ i18n "code.copied" }}"></script>
   {{ end }}
   {{ if not .Site.Params.disableImageZoom | default true }}
   {{ $zoomJS := resources.Get "lib/zoom/zoom.min.js" | resources.Fingerprint (.Site.Params.fingerprintAlgorithm | default "sha512") }}
-  <script src="{{ $zoomJS.RelPermalink }}" integrity="{{ $zoomJS.Data.Integrity }}"></script>
+  <script type="text/javascript" src="{{ $zoomJS.RelPermalink }}" integrity="{{ $zoomJS.Data.Integrity }}"></script>
   {{ end }}
   {{/* Icons */}}
   {{ if templates.Exists "partials/favicons.html" }}
@@ -144,11 +143,10 @@
   {{/* Firebase */}}
   {{ with $.Site.Params.firebase }}
   {{ if isset $.Site.Params "firebase" }}
-  <script src="https://www.gstatic.com/firebasejs/8.10.0/firebase-app.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/8.10.0/firebase-firestore.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/8.10.0/firebase-auth.js"></script>
-  <script>
-
+  <script type="text/javascript" src="https://www.gstatic.com/firebasejs/8.10.0/firebase-app.js"></script>
+  <script type="text/javascript" src="https://www.gstatic.com/firebasejs/8.10.0/firebase-firestore.js"></script>
+  <script type="text/javascript" src="https://www.gstatic.com/firebasejs/8.10.0/firebase-auth.js"></script>
+  <script type="text/javascript">
     const firebaseConfig = {
       apiKey: {{ $.Site.Params.firebase.apiKey }},
       authDomain: {{ $.Site.Params.firebase.apiKey }},
@@ -162,7 +160,6 @@
     var app = firebase.initializeApp(firebaseConfig);
     var db = firebase.firestore();
     var auth = firebase.auth();
-
   </script>
   {{ end }}
   {{ end }}

--- a/layouts/partials/header/basic.html
+++ b/layouts/partials/header/basic.html
@@ -168,7 +168,7 @@
 {{ end }}
 
 {{ if .Site.Params.highlightCurrentMenuArea }}
-<script>
+<script type="text/javascript">
     (function () {
         var $mainmenu = $('.main-menu');
         var path = window.location.pathname;

--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -23,7 +23,7 @@
 </details>
 
 {{ if .Site.Params.smartTOC }}
-<script>
+<script type="text/javascript">
   (function () {
     'use strict'
 

--- a/layouts/shortcodes/gist.html
+++ b/layouts/shortcodes/gist.html
@@ -1,3 +1,3 @@
-<script src="https://gist.github.com/{{ index .Params 0 }}/{{ index .Params 1 }}.js{{ if len .Params | eq 3 }}
-    ?file={{ index .Params 2 }}
+<script type="text/javascript" src="https://gist.github.com/{{ index .Params 0 }}/{{ index .Params 1 }}.js{{ if len .Params | eq 3 }}
+?file={{ index .Params 2 }}
   {{ end }}"></script>

--- a/layouts/shortcodes/typeit.html
+++ b/layouts/shortcodes/typeit.html
@@ -21,7 +21,7 @@
 
 {{ printf `<%v %v>%s</%v>` $tag $attrs $initialString $tag | safeHTML }}
 
-<script>
+<script type="text/javascript">
     document.addEventListener("DOMContentLoaded", function () {
       new TypeIt("#{{ $id }}", {
         strings: {{ $content }},


### PR DESCRIPTION
- Add `type="text/javascript"` and restructure attributes in various tags
- Some scripts have been left out because they are included in https://github.com/nunocoracao/blowfish/pull/2231

I am resubmitting this PR with required changes to merge into current main.

This PR was created due to a possibly unwanted closure of [my previous PR](https://github.com/nunocoracao/blowfish/pull/2227). See [this comment](https://github.com/nunocoracao/blowfish/pull/2218#issuecomment-2982008992) for details.  Sorry if you didn't want me to do that again just to be sure.

PR has been confirmed working after 1min of testing :)

EDIT: I am no longer using `resources.Minify` since that might've mostly been a personal preference and I don't necessarily want to get into a disagreement.

## Purpose

- Right now, we sometimes use `type="text/javascript"` and in other cases omit it. These changes improve consistency, readability and maintainability since people will know right away what type of `<script>` they are looking at and will no longer stumple upon inconsistencies in the codebase.