### PR TITLE
♻️ Refactor: make article-link formattable

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -28,8 +28,8 @@ static
 layouts/_default/_markup/render-heading.html
 layouts/_default/index.json
 layouts/_default/list.html
-layouts/partials/hero/background.html
 layouts/shortcodes/screenshot.html
 layouts/shortcodes/figure.html
+layouts/partials/hugo-embedded/shortcodes/figure-default.html
 
 assets/js/appearance.js

--- a/.prettierignore
+++ b/.prettierignore
@@ -28,9 +28,6 @@ static
 layouts/_default/_markup/render-heading.html
 layouts/_default/index.json
 layouts/_default/list.html
-layouts/partials/article-link/card-related.html
-layouts/partials/article-link/card.html
-layouts/partials/article-link/simple.html
 layouts/partials/hero/background.html
 layouts/shortcodes/screenshot.html
 layouts/shortcodes/figure.html

--- a/layouts/partials/article-link/_external-link.html
+++ b/layouts/partials/article-link/_external-link.html
@@ -1,0 +1,5 @@
+{{ with .Params.externalUrl }}
+  href="{{ . }}" target="_blank" rel="external"
+{{ else }}
+  href="{{ .RelPermalink }}"
+{{- end -}}

--- a/layouts/partials/article-link/card-related.html
+++ b/layouts/partials/article-link/card-related.html
@@ -1,44 +1,45 @@
 <a {{ partial "article-link/_external-link.html" . | safeHTMLAttr }} class="min-w-full">
-    <div class="min-h-full border border-neutral-200 dark:border-neutral-700 border-2 rounded overflow-hidden shadow-2xl relative">
-
-      {{- with $.Params.images -}}
+  <div
+    class="min-h-full border border-neutral-200 dark:border-neutral-700 border-2 rounded overflow-hidden shadow-2xl relative">
+    {{- with $.Params.images -}}
       {{- range first 6 . }}
-      <meta property="og:image" content="{{ . | absURL }}" />{{ end -}}
-      {{- else -}}
-        {{ $images := $.Resources.ByType "image" }}
-        {{ $featuredImage := $images.GetMatch "*feature*" }}
-        {{ if not $featuredImage }}
-          {{ $featuredImage = $images.GetMatch "{*cover*,*thumbnail*}" }}
-        {{ end }}
-        {{ if and (not $featuredImage) .Params.featureimage }}
-          {{ $featuredImage = resources.GetRemote .Params.featureimage }}
-        {{ end }}
-        {{ if not $featuredImage }}
-          {{ $featuredImage = resources.Get .Site.Params.defaultFeaturedImage }}
-        {{ end }}
-        {{ $disableImageOptimization := .Page.Site.Params.disableImageOptimization | default false }}
-        {{ if and ($featuredImage) (not (or ($disableImageOptimization) (strings.HasSuffix $featuredImage.Name ".svg"))) }}
-          {{ $featuredImage = $featuredImage.Resize "600x" }}
-        {{ end }}
-        {{ with $featuredImage }}
-          {{ $className := printf "background-image-%s" (md5 .RelPermalink) }}
-          <div class="w-full thumbnail_card_related nozoom {{ $className }}"></div>
-        {{ else }}
-          {{ with $.Site.Params.images }}
-            <meta property="og:image" content="{{ index . 0 | absURL }}" />
+        <meta property="og:image" content="{{ . | absURL }}">
+      {{ end -}}
+    {{- else -}}
+      {{ $images := $.Resources.ByType "image" }}
+      {{ $featuredImage := $images.GetMatch "*feature*" }}
+      {{ if not $featuredImage }}
+        {{ $featuredImage = $images.GetMatch "{*cover*,*thumbnail*}" }}
+      {{ end }}
+      {{ if and (not $featuredImage) .Params.featureimage }}
+        {{ $featuredImage = resources.GetRemote .Params.featureimage }}
+      {{ end }}
+      {{ if not $featuredImage }}
+        {{ $featuredImage = resources.Get .Site.Params.defaultFeaturedImage }}
+      {{ end }}
+      {{ $disableImageOptimization := .Page.Site.Params.disableImageOptimization | default false }}
+      {{ if and ($featuredImage) (not (or ($disableImageOptimization) (strings.HasSuffix $featuredImage.Name ".svg"))) }}
+        {{ $featuredImage = $featuredImage.Resize "600x" }}
+      {{ end }}
+      {{ with $featuredImage }}
+        {{ $className := printf "background-image-%s" (md5 .RelPermalink) }}
+        <div class="w-full thumbnail_card_related nozoom {{ $className }}"></div>
+      {{ else }}
+        {{ with $.Site.Params.images }}
+          <meta property="og:image" content="{{ index . 0 | absURL }}">
         {{ end }}
       {{ end }}
     {{ end }}
 
-      {{ if and .Draft .Site.Params.article.showDraftLabel }}
+    {{ if and .Draft .Site.Params.article.showDraftLabel }}
       <span class="absolute top-0 right-0 m-2">
         {{ partial "badge.html" (i18n "article.draft" | emojify) }}
       </span>
-      {{ end }}
+    {{ end }}
 
-      <div class="px-6 py-4">
 
-        {{ with .Params.externalUrl }}
+    <div class="px-6 py-4">
+      {{ with .Params.externalUrl }}
         <div>
           <div
             class="font-bold text-xl text-neutral-800 decoration-primary-500 hover:underline hover:underline-offset-2 dark:text-neutral">
@@ -49,23 +50,25 @@
             </span>
           </div>
         </div>
-        {{ else }}
-        <div class="font-bold text-xl text-neutral-800 decoration-primary-500 hover:underline hover:underline-offset-2 dark:text-neutral"
-          href="{{ .RelPermalink }}">{{ .Title | emojify }}</div>
-        {{ end }}
-
-        <div class="text-sm text-neutral-500 dark:text-neutral-400">
-          {{ partial "article-meta/basic.html" . }}
+      {{ else }}
+        <div
+          class="font-bold text-xl text-neutral-800 decoration-primary-500 hover:underline hover:underline-offset-2 dark:text-neutral"
+          href="{{ .RelPermalink }}">
+          {{ .Title | emojify }}
         </div>
+      {{ end }}
 
-        {{ if .Params.showSummary | default (.Site.Params.list.showSummary | default false) }}
+
+      <div class="text-sm text-neutral-500 dark:text-neutral-400">
+        {{ partial "article-meta/basic.html" . }}
+      </div>
+
+      {{ if .Params.showSummary | default (.Site.Params.list.showSummary | default false) }}
         <div class="py-1 prose dark:prose-invert">
           {{ .Summary | plainify }}
         </div>
-        {{ end }}
-      </div>
-      <div class="px-6 pt-4 pb-2">
-
-      </div>
+      {{ end }}
     </div>
-  </a>
+    <div class="px-6 pt-4 pb-2"></div>
+  </div>
+</a>

--- a/layouts/partials/article-link/card-related.html
+++ b/layouts/partials/article-link/card-related.html
@@ -1,8 +1,4 @@
-{{ with .Params.externalUrl }}
-<a href="{{ . }}" target="_blank" rel="external" class="min-w-full">
-  {{ else }}
-  <a href="{{ .RelPermalink }}" class="min-w-full">
-    {{ end }}
+<a {{ partial "article-link/_external-link.html" . | safeHTMLAttr }} class="min-w-full">
     <div class="min-h-full border border-neutral-200 dark:border-neutral-700 border-2 rounded overflow-hidden shadow-2xl relative">
 
       {{- with $.Params.images -}}

--- a/layouts/partials/article-link/card.html
+++ b/layouts/partials/article-link/card.html
@@ -1,48 +1,48 @@
 <a {{ partial "article-link/_external-link.html" . | safeHTMLAttr }} class="min-w-full">
-    <div class="min-h-full border border-neutral-200 dark:border-neutral-700 border-2 rounded overflow-hidden shadow-2xl relative">
-
-      {{- with $.Params.images -}}
+  <div
+    class="min-h-full border border-neutral-200 dark:border-neutral-700 border-2 rounded overflow-hidden shadow-2xl relative">
+    {{- with $.Params.images -}}
       {{- range first 6 . }}
-      <meta property="og:image" content="{{ . | absURL }}" />{{ end -}}
-      {{- else -}}
-        {{ $images := $.Resources.ByType "image" }}
-        {{ $featuredImage := $images.GetMatch "*feature*" }}
-        {{ if not $featuredImage }}
-          {{ $featuredImage = $images.GetMatch "{*cover*,*thumbnail*}" }}
-        {{ end }}
-        {{ if and (not $featuredImage) .Params.featureimage }}
-          {{ $featuredImage = resources.GetRemote .Params.featureimage }}
-        {{ end }}
-        {{ if not $featuredImage }}
-          {{ $featuredImage = resources.Get .Site.Params.defaultFeaturedImage }}
-        {{ end }}
-        {{ $disableImageOptimization := .Page.Site.Params.disableImageOptimization | default false }}
-        {{ if and ($featuredImage) (not (or ($disableImageOptimization) (strings.HasSuffix $featuredImage.Name ".svg"))) }}
-          {{ $featuredImage = $featuredImage.Resize "600x" }}
-        {{ end }}
-        {{ if .Params.hideFeatureImage }}
-          {{ $featuredImage = false }}
-        {{ end }}
-        {{ with $featuredImage }}
-          {{ $className := printf "background-image-%s" (md5 .RelPermalink) }}
-          <div class="w-full thumbnail_card nozoom {{ $className }}"></div>
-        {{ else }}
-          {{ with $.Site.Params.images }}
-            <meta property="og:image" content="{{ index . 0 | absURL }}" />
+        <meta property="og:image" content="{{ . | absURL }}">
+      {{ end -}}
+    {{- else -}}
+      {{ $images := $.Resources.ByType "image" }}
+      {{ $featuredImage := $images.GetMatch "*feature*" }}
+      {{ if not $featuredImage }}
+        {{ $featuredImage = $images.GetMatch "{*cover*,*thumbnail*}" }}
+      {{ end }}
+      {{ if and (not $featuredImage) .Params.featureimage }}
+        {{ $featuredImage = resources.GetRemote .Params.featureimage }}
+      {{ end }}
+      {{ if not $featuredImage }}
+        {{ $featuredImage = resources.Get .Site.Params.defaultFeaturedImage }}
+      {{ end }}
+      {{ $disableImageOptimization := .Page.Site.Params.disableImageOptimization | default false }}
+      {{ if and ($featuredImage) (not (or ($disableImageOptimization) (strings.HasSuffix $featuredImage.Name ".svg"))) }}
+        {{ $featuredImage = $featuredImage.Resize "600x" }}
+      {{ end }}
+      {{ if .Params.hideFeatureImage }}
+        {{ $featuredImage = false }}
+      {{ end }}
+      {{ with $featuredImage }}
+        {{ $className := printf "background-image-%s" (md5 .RelPermalink) }}
+        <div class="w-full thumbnail_card nozoom {{ $className }}"></div>
+      {{ else }}
+        {{ with $.Site.Params.images }}
+          <meta property="og:image" content="{{ index . 0 | absURL }}">
         {{ end }}
       {{ end }}
     {{ end }}
 
-
-      {{ if and .Draft .Site.Params.article.showDraftLabel }}
+    {{ if and .Draft .Site.Params.article.showDraftLabel }}
       <span class="absolute top-0 right-0 m-2">
         {{ partial "badge.html" (i18n "article.draft" | emojify) }}
       </span>
-      {{ end }}
+    {{ end }}
 
-      <div class="px-6 py-4">
 
-        {{ with .Params.externalUrl }}
+    <div class="px-6 py-4">
+      {{ with .Params.externalUrl }}
         <div>
           <div
             class="font-bold text-xl text-neutral-800 decoration-primary-500 hover:underline hover:underline-offset-2 dark:text-neutral">
@@ -53,23 +53,25 @@
             </span>
           </div>
         </div>
-        {{ else }}
-        <div class="font-bold text-xl text-neutral-800 decoration-primary-500 hover:underline hover:underline-offset-2 dark:text-neutral"
-          href="{{ .RelPermalink }}">{{ .Title | emojify }}</div>
-        {{ end }}
-
-        <div class="text-sm text-neutral-500 dark:text-neutral-400">
-          {{ partial "article-meta/basic.html" . }}
+      {{ else }}
+        <div
+          class="font-bold text-xl text-neutral-800 decoration-primary-500 hover:underline hover:underline-offset-2 dark:text-neutral"
+          href="{{ .RelPermalink }}">
+          {{ .Title | emojify }}
         </div>
+      {{ end }}
 
-        {{ if .Params.showSummary | default (.Site.Params.list.showSummary | default false) }}
+
+      <div class="text-sm text-neutral-500 dark:text-neutral-400">
+        {{ partial "article-meta/basic.html" . }}
+      </div>
+
+      {{ if .Params.showSummary | default (.Site.Params.list.showSummary | default false) }}
         <div class="py-1 prose dark:prose-invert">
           {{ .Summary | plainify }}
         </div>
-        {{ end }}
-      </div>
-      <div class="px-6 pt-4 pb-2">
-
-      </div>
+      {{ end }}
     </div>
-  </a>
+    <div class="px-6 pt-4 pb-2"></div>
+  </div>
+</a>

--- a/layouts/partials/article-link/card.html
+++ b/layouts/partials/article-link/card.html
@@ -1,8 +1,4 @@
-{{ with .Params.externalUrl }}
-<a href="{{ . }}" target="_blank" rel="external" class="min-w-full">
-  {{ else }}
-  <a href="{{ .RelPermalink }}" class="min-w-full">
-    {{ end }}
+<a {{ partial "article-link/_external-link.html" . | safeHTMLAttr }} class="min-w-full">
     <div class="min-h-full border border-neutral-200 dark:border-neutral-700 border-2 rounded overflow-hidden shadow-2xl relative">
 
       {{- with $.Params.images -}}

--- a/layouts/partials/article-link/simple.html
+++ b/layouts/partials/article-link/simple.html
@@ -26,11 +26,7 @@
 {{ end }}
 
 
-{{ with .Params.externalUrl }}
-<a class="{{ $articleClasses }}" href="{{ . }}" target="_blank" rel="external">
-  {{ else }}
-  <a class="{{ $articleClasses }}" href="{{ .RelPermalink }}">
-    {{ end }}
+<a class="{{ $articleClasses }}" {{ partial "article-link/_external-link.html" . | safeHTMLAttr }}>
     {{- with $.Params.images -}}
     {{- range first 6 . }}
     <meta property="og:image" content="{{ . | absURL }}" />{{ end -}}

--- a/layouts/partials/article-link/simple.html
+++ b/layouts/partials/article-link/simple.html
@@ -2,67 +2,68 @@
 
 {{ $articleClasses := "flex flex-wrap md:flex-nowrap article" }}
 {{ if .Site.Params.list.showCards }}
-{{ $articleClasses = delimit (slice $articleClasses "border border-neutral-200 dark:border-neutral-700 border-2 rounded-md overflow-hidden") " " }}
+  {{ $articleClasses = delimit (slice $articleClasses "border border-neutral-200 dark:border-neutral-700 border-2 rounded-md overflow-hidden") " " }}
 {{ else }}
-{{ $articleClasses = delimit (slice $articleClasses "") " " }}
+  {{ $articleClasses = delimit (slice $articleClasses "") " " }}
 {{ end }}
 
 {{ $articleImageClasses := "w-full md:w-auto h-full thumbnail nozoom" }}
 {{ if .Site.Params.list.showCards }}
-{{ $articleImageClasses = delimit (slice $articleImageClasses "") " " }}
+  {{ $articleImageClasses = delimit (slice $articleImageClasses "") " " }}
 {{ else }}
-{{ $articleImageClasses = delimit (slice $articleImageClasses "thumbnailshadow md:mr-7") " " }}
+  {{ $articleImageClasses = delimit (slice $articleImageClasses "thumbnailshadow md:mr-7") " " }}
 {{ end }}
 
 {{ $articleInnerClasses := "" }}
 {{ if .Site.Params.list.showCards }}
-{{ $articleInnerClasses = delimit (slice $articleInnerClasses "p-4") " " }}
+  {{ $articleInnerClasses = delimit (slice $articleInnerClasses "p-4") " " }}
 {{ else }}
-{{ $articleInnerClasses = delimit (slice $articleInnerClasses "mt-3 md:mt-0") " " }}
+  {{ $articleInnerClasses = delimit (slice $articleInnerClasses "mt-3 md:mt-0") " " }}
 {{ end }}
 
 {{ if $constrainItemsWidth }}
-{{ $articleClasses = delimit (slice $articleClasses "max-w-prose") " " }}
+  {{ $articleClasses = delimit (slice $articleClasses "max-w-prose") " " }}
 {{ end }}
 
 
 <a class="{{ $articleClasses }}" {{ partial "article-link/_external-link.html" . | safeHTMLAttr }}>
-    {{- with $.Params.images -}}
+  {{- with $.Params.images -}}
     {{- range first 6 . }}
-    <meta property="og:image" content="{{ . | absURL }}" />{{ end -}}
-    {{- else -}}
-      {{ $images := $.Resources.ByType "image" }}
-      {{ $featuredImage := $images.GetMatch "*feature*" }}
-      {{ if not $featuredImage }}
-        {{ $featuredImage = $images.GetMatch "{*cover*,*thumbnail*}" }}
-      {{ end }}
-      {{ if and (not $featuredImage) .Params.featureimage }}
-        {{ $featuredImage = resources.GetRemote .Params.featureimage }}
-      {{ end }}
-      {{ if not $featuredImage }}
-        {{ $featuredImage = resources.Get .Site.Params.defaultFeaturedImage }}
-      {{ end }}
-      {{ $disableImageOptimization := .Page.Site.Params.disableImageOptimization | default false }}
-      {{ if and ($featuredImage) (not (or ($disableImageOptimization) (strings.HasSuffix $featuredImage.Name ".svg"))) }}
-        {{ $featuredImage = $featuredImage.Resize "600x" }}
-      {{ end }}
-      {{ if .Params.hideFeatureImage }}
-        {{ $featuredImage = false }}
-      {{ end }}
-      {{ with $featuredImage }}
-        {{ $className := printf "background-image-%s" (md5 .RelPermalink) }}
-        <div class="{{ $articleImageClasses }} {{ $className }}"></div>
-      {{ else }}
-        {{ with $.Site.Params.images }}
-          <meta property="og:image" content="{{ index . 0 | absURL }}" />
-        {{ end }}
+      <meta property="og:image" content="{{ . | absURL }}">
+    {{ end -}}
+  {{- else -}}
+    {{ $images := $.Resources.ByType "image" }}
+    {{ $featuredImage := $images.GetMatch "*feature*" }}
+    {{ if not $featuredImage }}
+      {{ $featuredImage = $images.GetMatch "{*cover*,*thumbnail*}" }}
+    {{ end }}
+    {{ if and (not $featuredImage) .Params.featureimage }}
+      {{ $featuredImage = resources.GetRemote .Params.featureimage }}
+    {{ end }}
+    {{ if not $featuredImage }}
+      {{ $featuredImage = resources.Get .Site.Params.defaultFeaturedImage }}
+    {{ end }}
+    {{ $disableImageOptimization := .Page.Site.Params.disableImageOptimization | default false }}
+    {{ if and ($featuredImage) (not (or ($disableImageOptimization) (strings.HasSuffix $featuredImage.Name ".svg"))) }}
+      {{ $featuredImage = $featuredImage.Resize "600x" }}
+    {{ end }}
+    {{ if .Params.hideFeatureImage }}
+      {{ $featuredImage = false }}
+    {{ end }}
+    {{ with $featuredImage }}
+      {{ $className := printf "background-image-%s" (md5 .RelPermalink) }}
+      <div class="{{ $articleImageClasses }} {{ $className }}"></div>
+    {{ else }}
+      {{ with $.Site.Params.images }}
+        <meta property="og:image" content="{{ index . 0 | absURL }}">
       {{ end }}
     {{ end }}
+  {{ end }}
 
 
-    <div class="{{ $articleInnerClasses }}">
-      <div class="items-center text-left text-xl font-semibold">
-        {{ with .Params.externalUrl }}
+  <div class="{{ $articleInnerClasses }}">
+    <div class="items-center text-left text-xl font-semibold">
+      {{ with .Params.externalUrl }}
         <div>
           <div
             class="font-bold text-xl text-neutral-800 decoration-primary-500 hover:underline hover:underline-offset-2 dark:text-neutral">
@@ -73,26 +74,29 @@
             </span>
           </div>
         </div>
-        {{ else }}
-        <div class="font-bold text-xl text-neutral-800 decoration-primary-500 hover:underline hover:underline-offset-2 dark:text-neutral"
-          href="{{ .RelPermalink }}">{{ .Title | emojify }}</div>
-        {{ end }}
-        {{ if and .Draft .Site.Params.article.showDraftLabel }}
+      {{ else }}
+        <div
+          class="font-bold text-xl text-neutral-800 decoration-primary-500 hover:underline hover:underline-offset-2 dark:text-neutral"
+          href="{{ .RelPermalink }}">
+          {{ .Title | emojify }}
+        </div>
+      {{ end }}
+      {{ if and .Draft .Site.Params.article.showDraftLabel }}
         <div class=" ltr:ml-2 rtl:mr-2">
           {{ partial "badge.html" (i18n "article.draft" | emojify) }}
         </div>
-        {{ end }}
-        {{ if templates.Exists "partials/extend-article-link.html" }}
+      {{ end }}
+      {{ if templates.Exists "partials/extend-article-link.html" }}
         {{ partial "extend-article-link.html" . }}
-        {{ end }}
-      </div>
-      <div class="text-sm text-neutral-500 dark:text-neutral-400">
-        {{ partial "article-meta/basic.html" . }}
-      </div>
-      {{ if .Params.showSummary | default (.Site.Params.list.showSummary | default false) }}
+      {{ end }}
+    </div>
+    <div class="text-sm text-neutral-500 dark:text-neutral-400">
+      {{ partial "article-meta/basic.html" . }}
+    </div>
+    {{ if .Params.showSummary | default (.Site.Params.list.showSummary | default false) }}
       <div class="py-1 max-w-fit prose dark:prose-invert">
         {{ .Summary | plainify }}
       </div>
-      {{ end }}
-    </div>
-  </a>
+    {{ end }}
+  </div>
+</a>


### PR DESCRIPTION
This PR abstracts anchor attributes to enable formatting of article links.

To achieve this, an additional partial file was introduced. Given that only three files require formatting, the cost of adding a new file should be carefully evaluated. While using an [inline partial](https://gohugo.io/functions/go-template/define/) can avoid creating a new file, embedding an inline partial inside the article-link file may cause confusion for users.

This PR performs the same task as #2179.
