### PR TITLE
:children_crossing: UX: Use anchor tags in article-meta/basic.html

### DIFF
--- a/layouts/partials/article-link/card-related.html
+++ b/layouts/partials/article-link/card-related.html
@@ -1,78 +1,70 @@
 {{ $disableImageOptimization := .Page.Site.Params.disableImageOptimization | default false }}
-{{ with .Params.externalUrl }}
-<a href="{{ . }}" target="_blank" rel="external" class="min-w-full">
-  {{ else }}
-  <a href="{{ .RelPermalink }}" class="min-w-full">
-    {{ end }}
-    <div class="min-h-full border border-neutral-200 dark:border-neutral-700 border-2 rounded overflow-hidden shadow-2xl relative">
-
-      {{- with $.Params.images -}}
-      {{- range first 6 . }}
-      <meta property="og:image" content="{{ . | absURL }}" />{{ end -}}
-      {{- else -}}
-      {{- $images := $.Resources.ByType "image" -}}
-      {{- $featured := $images.GetMatch "*feature*" -}}
-      {{- if not $featured }}{{ $featured = $images.GetMatch "{*cover*,*thumbnail*}" }}{{ end -}}
-      {{ if and .Params.featureimage (not $featured) }}
+<div
+  class="relative min-h-full min-w-full overflow-hidden rounded border border-2 border-neutral-200 shadow-2xl dark:border-neutral-700">
+  <a
+    {{ partial "article-link/_external-link.html" . | safeHTMLAttr }}
+    class="absolute inset-0"
+    aria-label="{{ $.Title }}"></a>
+  {{- with $.Params.images -}}
+    {{- range first 6 . }}
+      <meta property="og:image" content="{{ . | absURL }}">
+    {{ end -}}
+  {{- else -}}
+    {{- $images := $.Resources.ByType "image" -}}
+    {{- $featured := $images.GetMatch "*feature*" -}}
+    {{- if not $featured }}{{ $featured = $images.GetMatch "{*cover*,*thumbnail*}" }}{{ end -}}
+    {{ if and .Params.featureimage (not $featured) }}
       {{- $url:= .Params.featureimage -}}
       {{ $featured = resources.GetRemote $url }}
-      {{ end }}
-      {{- if not $featured }}{{ with .Site.Params.defaultFeaturedImage }}{{ $featured = resources.Get . }}{{ end }}{{ end -}}
-      {{- with $featured -}}
-      {{ if or $disableImageOptimization (strings.HasSuffix $featured ".svg")}}
+    {{ end }}
+    {{- if not $featured }}
+      {{ with .Site.Params.defaultFeaturedImage }}{{ $featured = resources.Get . }}{{ end }}
+    {{ end -}}
+    {{- with $featured -}}
+      {{ if or $disableImageOptimization (strings.HasSuffix $featured ".svg") }}
         {{ with . }}
-        <div class="w-full thumbnail_card_related nozoom" style="background-image:url({{ .RelPermalink }});"></div>
+          <div
+            class="thumbnail_card_related nozoom w-full"
+            style="background-image:url({{ .RelPermalink }});"></div>
         {{ end }}
       {{ else }}
         {{ with .Resize "600x" }}
-        <div class="w-full thumbnail_card_related nozoom" style="background-image:url({{ .RelPermalink }});"></div>
+          <div
+            class="thumbnail_card_related nozoom w-full"
+            style="background-image:url({{ .RelPermalink }});"></div>
         {{ end }}
       {{ end }}
-      {{- else -}}
+    {{- else -}}
       {{- with $.Site.Params.images }}
-      <meta property="og:image" content="{{ index . 0 | absURL }}" />{{ end -}}
-      {{- end -}}
-      {{- end -}}
-
-
-    {{ if and .Draft .Site.Params.article.showDraftLabel }}
-      <span class="absolute top-0 right-0 m-2">
-        {{ partial "badge.html" (i18n "article.draft" | emojify) }}
-      </span>
-    {{ end }}
-
-
-    <div class="px-6 py-4">
-      {{ with .Params.externalUrl }}
-        <div>
-          <div
-            class="font-bold text-xl text-neutral-800 decoration-primary-500 hover:underline hover:underline-offset-2 dark:text-neutral">
-            {{ $.Title | emojify }}
-            <span class="text-xs align-top cursor-default text-neutral-400 dark:text-neutral-500">
-              <span class="rtl:hidden">&#8599;</span>
-              <span class="ltr:hidden">&#8598;</span>
-            </span>
-          </div>
-        </div>
-      {{ else }}
-        <div
-          class="font-bold text-xl text-neutral-800 decoration-primary-500 hover:underline hover:underline-offset-2 dark:text-neutral"
-          href="{{ .RelPermalink }}">
-          {{ .Title | emojify }}
-        </div>
-      {{ end }}
-
-
-      <div class="text-sm text-neutral-500 dark:text-neutral-400">
-        {{ partial "article-meta/basic.html" . }}
+        <meta property="og:image" content="{{ index . 0 | absURL }}">
+      {{ end -}}
+    {{- end -}}
+  {{- end -}}
+  {{ if and .Draft .Site.Params.article.showDraftLabel }}
+    <span class="absolute top-0 right-0 m-2">
+      {{ partial "badge.html" (i18n "article.draft" | emojify) }}
+    </span>
+  {{ end }}
+  <div class="px-6 py-4">
+    {{ with .Params.externalUrl }}
+      <div
+        class="decoration-primary-500 dark:text-neutral text-xl font-bold text-neutral-800 hover:underline hover:underline-offset-2">
+        {{ $.Title | emojify }}
+        <span class="cursor-default align-top text-xs text-neutral-400 dark:text-neutral-500">
+          <span class="rtl:hidden">&#8599;</span>
+          <span class="ltr:hidden">&#8598;</span>
+        </span>
       </div>
-
-      {{ if .Params.showSummary | default (.Site.Params.list.showSummary | default false) }}
-        <div class="py-1 prose dark:prose-invert">
-          {{ .Summary | plainify }}
-        </div>
-      {{ end }}
-    </div>
-    <div class="px-6 pt-4 pb-2"></div>
+    {{ else }}
+      <div
+        class="decoration-primary-500 dark:text-neutral text-xl font-bold text-neutral-800 hover:underline hover:underline-offset-2">
+        {{ .Title | emojify }}
+      </div>
+    {{ end }}
+    <div class="text-sm text-neutral-500 dark:text-neutral-400">{{ partial "article-meta/basic.html" . }}</div>
+    {{ if .Params.showSummary | default (.Site.Params.list.showSummary | default false) }}
+      <div class="prose dark:prose-invert py-1">{{ .Summary | plainify }}</div>
+    {{ end }}
   </div>
-</a>
+  <div class="px-6 pt-4 pb-2"></div>
+</div>

--- a/layouts/partials/article-link/card.html
+++ b/layouts/partials/article-link/card.html
@@ -1,78 +1,67 @@
 {{ $disableImageOptimization := .Page.Site.Params.disableImageOptimization | default false }}
-{{ with .Params.externalUrl }}
-<a href="{{ . }}" target="_blank" rel="external" class="min-w-full">
-  {{ else }}
-  <a href="{{ .RelPermalink }}" class="min-w-full">
-    {{ end }}
-    <div class="min-h-full border border-neutral-200 dark:border-neutral-700 border-2 rounded overflow-hidden shadow-2xl relative">
-
-      {{- with $.Params.images -}}
-      {{- range first 6 . }}
-      <meta property="og:image" content="{{ . | absURL }}" />{{ end -}}
-      {{- else -}}
-      {{- $images := $.Resources.ByType "image" -}}
-      {{- $featured := $images.GetMatch "*feature*" -}}
-      {{- if not $featured }}{{ $featured = $images.GetMatch "{*cover*,*thumbnail*}" }}{{ end -}}
-      {{ if and .Params.featureimage (not $featured) }}
+<div
+  class="relative min-h-full min-w-full overflow-hidden rounded border border-2 border-neutral-200 shadow-2xl dark:border-neutral-700">
+  <a
+    {{ partial "article-link/_external-link.html" . | safeHTMLAttr }}
+    class="absolute inset-0"
+    aria-label="{{ $.Title }}"></a>
+  {{- with $.Params.images -}}
+    {{- range first 6 . }}
+      <meta property="og:image" content="{{ . | absURL }}">
+    {{ end -}}
+  {{- else -}}
+    {{- $images := $.Resources.ByType "image" -}}
+    {{- $featured := $images.GetMatch "*feature*" -}}
+    {{- if not $featured }}{{ $featured = $images.GetMatch "{*cover*,*thumbnail*}" }}{{ end -}}
+    {{ if and .Params.featureimage (not $featured) }}
       {{- $url:= .Params.featureimage -}}
       {{ $featured = resources.GetRemote $url }}
-      {{ end }}
-      {{- if not $featured }}{{ with .Site.Params.defaultFeaturedImage }}{{ $featured = resources.Get . }}{{ end }}{{ end -}}
-      {{ if .Params.hideFeatureImage }}{{ $featured = false }}{{ end }}
-      {{- with $featured -}}
-      {{ if or $disableImageOptimization (strings.HasSuffix $featured ".svg")}}
+    {{ end }}
+    {{- if not $featured }}
+      {{ with .Site.Params.defaultFeaturedImage }}{{ $featured = resources.Get . }}{{ end }}
+    {{ end -}}
+    {{ if .Params.hideFeatureImage }}{{ $featured = false }}{{ end }}
+    {{- with $featured -}}
+      {{ if or $disableImageOptimization (strings.HasSuffix $featured ".svg") }}
         {{ with . }}
-        <div class="w-full thumbnail_card nozoom" style="background-image:url({{ .RelPermalink }});"></div>
+          <div class="thumbnail_card nozoom w-full" style="background-image:url({{ .RelPermalink }});"></div>
         {{ end }}
       {{ else }}
         {{ with .Resize "600x" }}
-        <div class="w-full thumbnail_card nozoom" style="background-image:url({{ .RelPermalink }});"></div>
+          <div class="thumbnail_card nozoom w-full" style="background-image:url({{ .RelPermalink }});"></div>
         {{ end }}
       {{ end }}
-      {{- else -}}
+    {{- else -}}
       {{- with $.Site.Params.images }}
-      <meta property="og:image" content="{{ index . 0 | absURL }}" />{{ end -}}
-      {{- end -}}
-      {{- end -}}
-
-    {{ if and .Draft .Site.Params.article.showDraftLabel }}
-      <span class="absolute top-0 right-0 m-2">
-        {{ partial "badge.html" (i18n "article.draft" | emojify) }}
-      </span>
-    {{ end }}
-
-
-    <div class="px-6 py-4">
-      {{ with .Params.externalUrl }}
-        <div>
-          <div
-            class="font-bold text-xl text-neutral-800 decoration-primary-500 hover:underline hover:underline-offset-2 dark:text-neutral">
-            {{ $.Title | emojify }}
-            <span class="text-xs align-top cursor-default text-neutral-400 dark:text-neutral-500">
-              <span class="rtl:hidden">&#8599;</span>
-              <span class="ltr:hidden">&#8598;</span>
-            </span>
-          </div>
-        </div>
-      {{ else }}
-        <div
-          class="font-bold text-xl text-neutral-800 decoration-primary-500 hover:underline hover:underline-offset-2 dark:text-neutral"
-          href="{{ .RelPermalink }}">
-          {{ .Title | emojify }}
-        </div>
-      {{ end }}
-
-
-      <div class="text-sm text-neutral-500 dark:text-neutral-400">
-        {{ partial "article-meta/basic.html" . }}
+        <meta property="og:image" content="{{ index . 0 | absURL }}">
+      {{ end -}}
+    {{- end -}}
+  {{- end -}}
+  {{ if and .Draft .Site.Params.article.showDraftLabel }}
+    <span class="absolute top-0 right-0 m-2">
+      {{ partial "badge.html" (i18n "article.draft" | emojify) }}
+    </span>
+  {{ end }}
+  <div class="px-6 py-4">
+    {{ with .Params.externalUrl }}
+      <div
+        class="decoration-primary-500 dark:text-neutral text-xl font-bold text-neutral-800 hover:underline hover:underline-offset-2">
+        {{ $.Title | emojify }}
+        <span class="cursor-default align-top text-xs text-neutral-400 dark:text-neutral-500">
+          <span class="rtl:hidden">&#8599;</span>
+          <span class="ltr:hidden">&#8598;</span>
+        </span>
       </div>
-
-      {{ if .Params.showSummary | default (.Site.Params.list.showSummary | default false) }}
-        <div class="py-1 prose dark:prose-invert">
-          {{ .Summary | plainify }}
-        </div>
-      {{ end }}
-    </div>
-    <div class="px-6 pt-4 pb-2"></div>
+    {{ else }}
+      <div
+        class="decoration-primary-500 dark:text-neutral text-xl font-bold text-neutral-800 hover:underline hover:underline-offset-2">
+        {{ .Title | emojify }}
+      </div>
+    {{ end }}
+    <div class="text-sm text-neutral-500 dark:text-neutral-400">{{ partial "article-meta/basic.html" . }}</div>
+    {{ if .Params.showSummary | default (.Site.Params.list.showSummary | default false) }}
+      <div class="prose dark:prose-invert py-1">{{ .Summary | plainify }}</div>
+    {{ end }}
   </div>
-</a>
+  <div class="px-6 pt-4 pb-2"></div>
+</div>

--- a/layouts/partials/article-link/simple.html
+++ b/layouts/partials/article-link/simple.html
@@ -1,6 +1,6 @@
 {{ $constrainItemsWidth := .Page.Site.Params.list.constrainItemsWidth | default false }}
 
-{{ $articleClasses := "flex flex-wrap md:flex-nowrap article" }}
+{{ $articleClasses := "flex flex-wrap md:flex-nowrap article relative" }}
 {{ if .Site.Params.list.showCards }}
   {{ $articleClasses = delimit (slice $articleClasses "border border-neutral-200 dark:border-neutral-700 border-2 rounded-md overflow-hidden") " " }}
 {{ else }}
@@ -28,73 +28,73 @@
 {{ end }}
 
 
-<a class="{{ $articleClasses }}" {{ partial "article-link/_external-link.html" . | safeHTMLAttr }}>
+<div class="{{ $articleClasses }}">
+  <a
+    {{ partial "article-link/_external-link.html" . | safeHTMLAttr }}
+    class="absolute inset-0"
+    aria-label="{{ $.Title }}"></a>
   {{- with $.Params.images -}}
     {{- range first 6 . }}
-    <meta property="og:image" content="{{ . | absURL }}" />{{ end -}}
-    {{- else -}}
+      <meta property="og:image" content="{{ . | absURL }}">
+    {{ end -}}
+  {{- else -}}
     {{- $images := $.Resources.ByType "image" -}}
     {{- $featured := $images.GetMatch "*feature*" -}}
     {{- if not $featured }}{{ $featured = $images.GetMatch "{*cover*,*thumbnail*}" }}{{ end -}}
     {{ if and .Params.featureimage (not $featured) }}
-    {{- $url:= .Params.featureimage -}}
-    {{ $featured = resources.GetRemote $url }}
+      {{- $url:= .Params.featureimage -}}
+      {{ $featured = resources.GetRemote $url }}
     {{ end }}
-    {{- if not $featured }}{{ with .Site.Params.defaultFeaturedImage }}{{ $featured = resources.Get . }}{{ end }}{{ end -}}
+    {{- if not $featured }}
+      {{ with .Site.Params.defaultFeaturedImage }}{{ $featured = resources.Get . }}{{ end }}
+    {{ end -}}
     {{ if .Params.hideFeatureImage }}{{ $featured = false }}{{ end }}
     {{- with $featured -}}
-    {{ if or $disableImageOptimization (strings.HasSuffix $featured ".svg")}}
+      {{ if or $disableImageOptimization (strings.HasSuffix $featured ".svg") }}
         {{ with . }}
-        <div class="{{ $articleImageClasses }}" style="background-image:url({{ .RelPermalink }});"></div>
+          <div class="{{ $articleImageClasses }}" style="background-image:url({{ .RelPermalink }});"></div>
         {{ end }}
       {{ else }}
-        {{ with .Resize "600x"  }}
-        <div class="{{ $articleImageClasses }}" style="background-image:url({{ .RelPermalink }});"></div>
+        {{ with .Resize "600x" }}
+          <div class="{{ $articleImageClasses }}" style="background-image:url({{ .RelPermalink }});"></div>
         {{ end }}
       {{ end }}
     {{- else -}}
-    {{- with $.Site.Params.images }}
-    <meta property="og:image" content="{{ index . 0 | absURL }}" />{{ end -}}
+      {{- with $.Site.Params.images }}
+        <meta property="og:image" content="{{ index . 0 | absURL }}">
+      {{ end -}}
     {{- end -}}
-    {{- end -}}
+  {{- end -}}
 
 
   <div class="{{ $articleInnerClasses }}">
     <div class="items-center text-left text-xl font-semibold">
       {{ with .Params.externalUrl }}
-        <div>
-          <div
-            class="font-bold text-xl text-neutral-800 decoration-primary-500 hover:underline hover:underline-offset-2 dark:text-neutral">
-            {{ $.Title | emojify }}
-            <span class="text-xs align-top cursor-default text-neutral-400 dark:text-neutral-500">
-              <span class="rtl:hidden">&#8599;</span>
-              <span class="ltr:hidden">&#8598;</span>
-            </span>
-          </div>
+        <div
+          class="decoration-primary-500 dark:text-neutral text-xl font-bold text-neutral-800 hover:underline hover:underline-offset-2">
+          {{ $.Title | emojify }}
+          <span class="cursor-default align-top text-xs text-neutral-400 dark:text-neutral-500">
+            <span class="rtl:hidden">&#8599;</span>
+            <span class="ltr:hidden">&#8598;</span>
+          </span>
         </div>
       {{ else }}
         <div
-          class="font-bold text-xl text-neutral-800 decoration-primary-500 hover:underline hover:underline-offset-2 dark:text-neutral"
-          href="{{ .RelPermalink }}">
+          class="decoration-primary-500 dark:text-neutral text-xl font-bold text-neutral-800 hover:underline hover:underline-offset-2">
           {{ .Title | emojify }}
         </div>
       {{ end }}
       {{ if and .Draft .Site.Params.article.showDraftLabel }}
-        <div class=" ltr:ml-2 rtl:mr-2">
-          {{ partial "badge.html" (i18n "article.draft" | emojify) }}
-        </div>
+        <div class="ltr:ml-2 rtl:mr-2">{{ partial "badge.html" (i18n "article.draft" | emojify) }}</div>
       {{ end }}
       {{ if templates.Exists "partials/extend-article-link.html" }}
         {{ partial "extend-article-link.html" . }}
       {{ end }}
     </div>
-    <div class="text-sm text-neutral-500 dark:text-neutral-400">
-      {{ partial "article-meta/basic.html" . }}
-    </div>
+    <div class="text-sm text-neutral-500 dark:text-neutral-400">{{ partial "article-meta/basic.html" . }}</div>
     {{ if .Params.showSummary | default (.Site.Params.list.showSummary | default false) }}
-      <div class="py-1 max-w-fit prose dark:prose-invert">
-        {{ .Summary | plainify }}
-      </div>
+      <div class="prose dark:prose-invert max-w-fit py-1">{{ .Summary | plainify }}</div>
     {{ end }}
   </div>
-</a>
+  <div class="px-6 pt-4 pb-2"></div>
+</div>

--- a/layouts/partials/article-meta/basic.html
+++ b/layouts/partials/article-meta/basic.html
@@ -97,7 +97,9 @@
         {{ if and (not (eq $taxonomy "authors")) (not (eq $taxonomy "series")) }}
           {{ if (gt (len ($context.GetTerms $taxonomy)) 0) }}
             {{ range $context.GetTerms $taxonomy }}
-              <a class="mr-2 mt-[0.5rem] relative" href="{{ .RelPermalink }}">{{ partial "badge.html" .LinkTitle }}</a>
+              <a class="relative mt-[0.5rem] mr-2" href="{{ .RelPermalink }}"
+                >{{ partial "badge.html" .LinkTitle }}</a
+              >
             {{ end }}
           {{ end }}
         {{ end }}
@@ -109,7 +111,9 @@
   {{ if .Params.showCategoryOnly | default (.Site.Params.article.showCategoryOnly | default false) }}
     <div class="flex flex-row flex-wrap items-center">
       {{ range (.GetTerms "categories") }}
-        <a class="mr-2 mt-[0.5rem] relative" href="{{ .RelPermalink }}">{{ partial "badge.html" .LinkTitle }}</a>
+        <a class="relative mt-[0.5rem] mr-2" href="{{ .RelPermalink }}"
+          >{{ partial "badge.html" .LinkTitle }}</a
+        >
       {{ end }}
     </div>
   {{ end }}

--- a/layouts/partials/article-meta/basic.html
+++ b/layouts/partials/article-meta/basic.html
@@ -82,9 +82,7 @@
           {{ if (gt (len ($context.GetTerms $taxonomy)) 0) }}
             {{ range $i, $a := $context.GetTerms $taxonomy }}
               {{ if not (eq $i 0) }},&nbsp;{{ end }}
-              <div class="cursor-pointer" onclick="window.open({{ $a.RelPermalink }},'_self');return false;">
-                {{ $a.LinkTitle }}
-              </div>
+              <a href="{{ $a.RelPermalink }}" class="relative">{{ $a.LinkTitle }}</a>
             {{ end }}
           {{ end }}
         {{ end }}
@@ -99,11 +97,7 @@
         {{ if and (not (eq $taxonomy "authors")) (not (eq $taxonomy "series")) }}
           {{ if (gt (len ($context.GetTerms $taxonomy)) 0) }}
             {{ range $context.GetTerms $taxonomy }}
-              <span
-                class="mr-2 mt-[0.5rem]"
-                onclick="window.open({{ .RelPermalink }},'_self');return false;">
-                {{ partial "badge.html" .LinkTitle }}
-              </span>
+              <a class="mr-2 mt-[0.5rem] relative" href="{{ .RelPermalink }}">{{ partial "badge.html" .LinkTitle }}</a>
             {{ end }}
           {{ end }}
         {{ end }}
@@ -115,9 +109,7 @@
   {{ if .Params.showCategoryOnly | default (.Site.Params.article.showCategoryOnly | default false) }}
     <div class="flex flex-row flex-wrap items-center">
       {{ range (.GetTerms "categories") }}
-        <span class="mr-2 mt-[0.5rem]" onclick="window.open({{ .RelPermalink }},'_self');return false;">
-          {{ partial "badge.html" .LinkTitle }}
-        </span>
+        <a class="mr-2 mt-[0.5rem] relative" href="{{ .RelPermalink }}">{{ partial "badge.html" .LinkTitle }}</a>
       {{ end }}
     </div>
   {{ end }}


### PR DESCRIPTION
- This removes an inline event handler
- This also adds an aria-label

## Purpose

Using javascript instead of just using `<a>` tag is bad practice regarding accessibility and automated processing of web pages. Even the browser doesn't show a hint if hovering badges when using the old implementation. This in my opinion is a good way to replace inline event handlers in that code.


## Notes

Previously, this was part of https://github.com/nunocoracao/blowfish/pull/2231 and https://github.com/nunocoracao/blowfish/pull/2218, but after some thinking, I just split up the PR.

## Warning

> :warning: This currently isn't compatible with https://github.com/nunocoracao/blowfish/pull/2249 and https://github.com/nunocoracao/blowfish/pull/2268. Please notify me to make the necessary changes.