### PR TITLE
:recycle: Refactor: Move 2 inline event handlers out of line

### DIFF
--- a/assets/js/button-likes.js
+++ b/assets/js/button-likes.js
@@ -1,0 +1,4 @@
+document.getElementById("button_likes") &&
+  document.getElementById("button_likes").addEventListener("click", () => {
+    process_article();
+  });

--- a/assets/js/katex-render.js
+++ b/assets/js/katex-render.js
@@ -1,0 +1,4 @@
+document.getElementById("katex-render") &&
+  document.getElementById("katex-render").addEventListener("load", () => {
+    renderMathInElement(document.body);
+  });

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -68,6 +68,10 @@
   {{ end }}
   {{ $jsMobileMenu := resources.Get "js/mobilemenu.js" }}
   {{ $assets.Add "js" (slice $jsMobileMenu) }}
+  {{ $buttonLikes := resources.Get "js/button-likes.js" }}
+  {{ $assets.Add "js" (slice $buttonLikes) }}
+  {{ $katexRender := resources.Get "js/katex-render.js" }}
+  {{ $assets.Add "js" (slice $katexRender) }}
   {{ if $assets.Get "js" }}
   {{ $bundleJS := $assets.Get "js" | resources.Concat "js/main.bundle.js" | resources.Minify | resources.Fingerprint
   (.Site.Params.fingerprintAlgorithm | default "sha512") }}

--- a/layouts/partials/meta/likes_button.html
+++ b/layouts/partials/meta/likes_button.html
@@ -1,8 +1,7 @@
 <span>
   <button
     id="button_likes"
-    class="rounded-md border border-primary-400 px-1 py-[1px] text-xs font-normal text-primary-700 dark:border-primary-600 dark:text-primary-400"
-    onclick="process_article()">
+    class="rounded-md border border-primary-400 px-1 py-[1px] text-xs font-normal text-primary-700 dark:border-primary-600 dark:text-primary-400">
     <span id="button_likes_heart" class="inline-block align-text-bottom hidden"
       >{{ partial "icon.html" "heart" }}
     </span>

--- a/layouts/partials/vendor.html
+++ b/layouts/partials/vendor.html
@@ -37,16 +37,15 @@
     rel="stylesheet"
     href="{{ $katexCSS.RelPermalink }}"
     integrity="{{ $katexCSS.Data.Integrity }}">
-  {{ $katexJS := resources.Get "lib/katex/katex.min.js" }}
-  {{ $katexJS := $katexJS | resources.Fingerprint (.Site.Params.fingerprintAlgorithm | default "sha512") }}
-  <script defer src="{{ $katexJS.RelPermalink }}" integrity="{{ $katexJS.Data.Integrity }}"></script>
-  {{ $katexRenderJS := resources.Get "lib/katex/auto-render.min.js" }}
-  {{ $katexRenderJS := $katexRenderJS | resources.Fingerprint (.Site.Params.fingerprintAlgorithm | default "sha512") }}
+  {{ $katexLib := resources.Get "lib/katex/katex.min.js" }}
+  {{ $katexRenderLib := resources.Get "lib/katex/auto-render.min.js" }}
+  {{ $katexJS := slice $katexLib $katexRenderLib | resources.Concat "js/katex.bundle.js" | resources.Fingerprint (.Site.Params.fingerprintAlgorithm | default "sha512") }}
   <script
     defer
-    src="{{ $katexRenderJS.RelPermalink }}"
-    integrity="{{ $katexRenderJS.Data.Integrity }}"
-    onload="renderMathInElement(document.body);"></script>
+    type="text/javascript"
+    src="{{ $katexJS.RelPermalink }}"
+    integrity="{{ $katexJS.Data.Integrity }}"
+    id="katex-render"></script>
   {{ $katexFonts := resources.Match "lib/katex/fonts/*" }}
   {{ range $katexFonts }}
     <!-- {{ .RelPermalink }} -->


### PR DESCRIPTION
## Purpose

If MDN explicitly warns user not to use them, we probably shouldn't.

MDN also states: "Note that inline event handlers are blocked as well[...]You should replace them with addEventListener calls[...]" regarding CSP.


## Notes

Previously, this was part of https://github.com/nunocoracao/blowfish/pull/2231 and https://github.com/nunocoracao/blowfish/pull/2218, but after some thinking, I just split up the PR.