### PR TITLE
:art: Structure: Restructure vendor.html and add missing hugo fingerprints

### DIFF
--- a/layouts/partials/vendor.html
+++ b/layouts/partials/vendor.html
@@ -62,7 +62,12 @@
 {{/* Packery */}}
 {{ if .Page.HasShortcode "gallery" }}
   {{ $packeryLib := resources.Get "lib/packery/packery.pkgd.min.js" }}
-  <script defer src="{{ $packeryLib.RelPermalink }}" integrity="{{ $packeryLib.Data.Integrity }}"></script>
+  {{ $packeryLib = $packeryLib | resources.Fingerprint (.Site.Params.fingerprintAlgorithm | default "sha512") }}
+  <script
+    defer
+    type="text/javascript"
+    src="{{ $packeryLib.RelPermalink }}"
+    integrity="{{ $packeryLib.Data.Integrity }}"></script>
 
   {{ $jsShortcodeGallery := resources.Get "js/shortcodes/gallery.js" }}
   {{ $jsShortcodeGallery = $jsShortcodeGallery | resources.Minify | resources.Fingerprint (.Site.Params.fingerprintAlgorithm | default "sha512") }}
@@ -75,19 +80,27 @@
 {{/* tw-elements */}}
 {{ if or (.Page.HasShortcode "carousel") (.Page.HasShortcode "timeline") }}
   {{ $twelementsLib := resources.Get "lib/tw-elements/index.min.js" }}
+  {{ $twelementsLib = $twelementsLib | resources.Fingerprint (.Site.Params.fingerprintAlgorithm | default "sha512") }}
   <script
     defer
+    type="text/javascript"
     src="{{ $twelementsLib.RelPermalink }}"
     integrity="{{ $twelementsLib.Data.Integrity }}"></script>
 {{ end }}
 
 {{/* youtubeLite */}}
 {{ if .Page.HasShortcode "youtubeLite" }}
-  {{ $youtubeLiteJS := resources.Get "lib/lite-youtube-embed/lite-yt-embed.js" | resources.Fingerprint (.Site.Params.fingerprintAlgorithm | default "sha512") }}
   {{ $youtubeLiteCSS := resources.Get "lib/lite-youtube-embed/lite-yt-embed.css" }}
+  {{ $youtubeLiteCSS = $youtubeLiteCSS | resources.Fingerprint (.Site.Params.fingerprintAlgorithm | default "sha512") }}
   <link
+    type="text/css"
     rel="stylesheet"
     href="{{ $youtubeLiteCSS.RelPermalink }}"
     integrity="{{ $youtubeLiteCSS.Data.Integrity }}">
-  <script src="{{ $youtubeLiteJS.RelPermalink }}" integrity="{{ $youtubeLiteJS.Data.Integrity }}"></script>
+  {{ $youtubeLiteLib := resources.Get "lib/lite-youtube-embed/lite-yt-embed.js" }}
+  {{ $youtubeLiteLib = $youtubeLiteLib | resources.Fingerprint (.Site.Params.fingerprintAlgorithm | default "sha512") }}
+  <script
+    type="text/javascript"
+    src="{{ $youtubeLiteLib.RelPermalink }}"
+    integrity="{{ $youtubeLiteLib.Data.Integrity }}"></script>
 {{ end }}


### PR DESCRIPTION
## Purpose

This renames $youtubeLiteJS $youtubeLiteLib to match the naming of other files in assets/lib and moves the initialization of $youtubeLiteLib to the bottom, above the script element

This also adds 3 missing fingerprints, one to $packeryLib, one to $twelementsLib and one to $youtubeLiteCSS

## Notes

Previously, this was part of https://github.com/nunocoracao/blowfish/pull/2231 and https://github.com/nunocoracao/blowfish/pull/2218, but after some thinking, I just split up the PR.