### PR TITLE
:adhesive_bandage: Fix: Incorrect usage of <label> for menu-button

### DIFF
--- a/layouts/partials/header/basic.html
+++ b/layouts/partials/header/basic.html
@@ -92,7 +92,7 @@
     </div>
     <div class="-my-2 md:hidden">
 
-        <label id="menu-button" class="block">
+        <div id="menu-button" class="block">
             {{ if .Site.Menus.main }}
             <div class="cursor-pointer hover:text-primary-600 dark:hover:text-primary-400">
                 {{ partial "icon.html" "bars" }}
@@ -143,7 +143,7 @@
                 {{ end }}
 
             </div>
-        </label>
+        </div>
     </div>
 </div>
 


### PR DESCRIPTION
This has been tested and works just like using a `<label>` did before, also on different screen sizes. Chrome no longer shows an issue for this.

## Purpose

This fixes the following issue in Chrome: No label associated with a form field.

I don't know why a <label> was used here before, but I see no reason to do so, a div works just as well.