### PR TITLE
fix: commit #f2e224a whitespace control for umami

### DIFF
--- a/layouts/partials/analytics/umami.html
+++ b/layouts/partials/analytics/umami.html
@@ -2,11 +2,11 @@
   <script
     data-id="umami-script"
     async
-    src="https://{{ site.Params.umamiAnalytics.domain }}/{{ with site.Params.umamiAnalytics.scriptName }}
-      {{ . }}
-    {{ else }}
+    src="https://{{- site.Params.umamiAnalytics.domain -}}/{{- with site.Params.umamiAnalytics.scriptName -}}
+      {{ . -}}
+    {{- else -}}
       script.js
-    {{ end }}"
+    {{- end -}}"
     data-website-id="{{ site.Params.umamiAnalytics.websiteid }}"
     {{ with site.Params.umamiAnalytics.dataDomains }}data-domains="{{ . }}"{{ end }}></script>
 {{ else }}


### PR DESCRIPTION
fix: commit https://github.com/nunocoracao/blowfish/commit/f2e224a042f273a2cef7d46cb9e5634f38844c1f whitespace control for umami

The `src` of umami will be rendered as: `https://umami.example.com/%20%20%20%20%20%20custom.js`

It is unclear what other content may be affected by this commit.

ref: https://github.com/nunocoracao/blowfish/commit/f2e224a042f273a2cef7d46cb9e5634f38844c1f#diff-d7aed1e2ba4542775b6f38c4be562012be7430b6ed2463dd577a59190b532722L3-L6