### PR TITLE
:art: Formatting: Actually use prettier-plugin-tailwindcss

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -6,8 +6,9 @@
   "trailingComma": "all",
   "proseWrap": "always",
   "plugins": [
+    "@awmottaz/prettier-plugin-void-html",
     "prettier-plugin-go-template",
-    "@awmottaz/prettier-plugin-void-html"
+    "prettier-plugin-tailwindcss"
   ],
   "overrides": [
     {


### PR DESCRIPTION
I couldn't find any reason why this plugin is in package.json but not in .prettierrc. Also no issues/PRs etc.

## Purpose

Auto formatting with this hasn't been added or tested for accuracy yet (only for functionality), but I assume that if the plugin is in package.json, it should actually get used by prettier.

> :warning: It might be wise to wait with merging this until the auto formatting has actually been tested for accuracy.