### PR TITLE
🐛 Fix: minimum version warning not working

### DIFF
--- a/config/_default/module.toml
+++ b/config/_default/module.toml
@@ -1,3 +1,0 @@
-[hugoVersion]
-  extended = false
-  min = "0.87.0"


### PR DESCRIPTION
Removes the content of the module.toml file to resolve the conflict with config.toml.