### PR TITLE
🐛 Fix: render-link.html adding space after each link

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -8,3 +8,4 @@
   {{ end }}>
   {{- .Text | safeHTML -}}
 </a>
+{{- /* Trim EOF */ -}}


### PR DESCRIPTION
Fix #2287