### PR TITLE
🔧 Chore: add warn message for GetRemote usage in shortcodes

### DIFF
--- a/layouts/shortcodes/codeberg.html
+++ b/layouts/shortcodes/codeberg.html
@@ -56,4 +56,6 @@
         data-repo-id="{{ $id }}"></script>
     </a>
   </div>
+{{- else -}}
+  {{ warnf "codeberg shortcode: unable to fetch %q: %s" $codebergURL .Position }}
 {{- end -}}

--- a/layouts/shortcodes/codeimporter.html
+++ b/layouts/shortcodes/codeimporter.html
@@ -15,7 +15,7 @@
   {{ end }}
 
   {{ if gt $startLine $endLine }}
-    {{ errorf "Code Importer Shortcode - startLine is greater than endLine" . }}
+    {{ errorf "codeimporter shortcode: startLine is greater than endLine" . }}
   {{ end }}
 
   {{ $selectedLines := first $endLine $lines }}
@@ -23,5 +23,5 @@
   {{ $codeBlock := printf "```%s\n%s\n```" $type (delimit $selectedLines "\n") }}
   {{ $codeBlock | markdownify }}
 {{ else }}
-  {{ errorf "Code Importer Shortcode - Unable to get remote resource" . }}
+  {{ warnf "codeimporter shortcode: unable to fetch %q: %s" $url .Position }}
 {{ end }}

--- a/layouts/shortcodes/forgejo.html
+++ b/layouts/shortcodes/forgejo.html
@@ -56,4 +56,6 @@
         data-repo-id="{{ $id }}"></script>
     </a>
   </div>
+{{- else -}}
+  {{ warnf "forgejo shortcode: unable to fetch %q: %s" $forgejoURL .Position }}
 {{- end -}}

--- a/layouts/shortcodes/gitea.html
+++ b/layouts/shortcodes/gitea.html
@@ -56,4 +56,6 @@
         data-repo-id="{{ $id }}"></script>
     </a>
   </div>
+{{- else -}}
+  {{ warnf "gitea shortcode: unable to fetch %q: %s" $giteaURL .Position }}
 {{- end -}}

--- a/layouts/shortcodes/github.html
+++ b/layouts/shortcodes/github.html
@@ -4,9 +4,8 @@
 {{- $githubThumbnailURL := print "https://opengraph.githubassets.com/0/" (.Get "repo") -}}
 {{- $showThumbnail := .Get "showThumbnail" | default true -}}
 
-
-<div class="github-card-wrapper">
-  {{- with $githubData -}}
+{{- with $githubData -}}
+  <div class="github-card-wrapper">
     <a id="{{ $id }}" target="_blank" href="{{ .html_url }}" class="cursor-pointer">
       <div
         class="w-full md:w-auto p-0 m-0 border border-neutral-200 dark:border-neutral-700 border rounded-md shadow-2xl">
@@ -71,7 +70,7 @@
         data-repo-url="{{ $githubURL }}"
         data-repo-id="{{ $id }}"></script>
     </a>
-  {{- else -}}
-    {{ warnf "github shortcode: unable to fetch %q: %s" $githubURL .Position }}
-  {{- end -}}
-</div>
+  </div>
+{{- else -}}
+  {{ warnf "github shortcode: unable to fetch %q: %s" $githubURL .Position }}
+{{- end -}}

--- a/layouts/shortcodes/github.html
+++ b/layouts/shortcodes/github.html
@@ -71,5 +71,7 @@
         data-repo-url="{{ $githubURL }}"
         data-repo-id="{{ $id }}"></script>
     </a>
+  {{- else -}}
+    {{ warnf "github shortcode: unable to fetch %q: %s" $githubURL .Position }}
   {{- end -}}
 </div>

--- a/layouts/shortcodes/mdimporter.html
+++ b/layouts/shortcodes/mdimporter.html
@@ -2,5 +2,5 @@
 {{ with resources.GetRemote (urls.Parse $url) }}
   {{ .Content | markdownify }}
 {{ else }}
-  {{ errorf "Mardown Importer Shortcode - Unable to get remote resource" . }}
+  {{ warnf "mdimporter shortcode: unable to fetch %q: %s" $url .Position }}
 {{ end }}


### PR DESCRIPTION
Previous
<img width="925" height="292" alt="previous" src="https://github.com/user-attachments/assets/b40bab32-5461-4d9a-8af4-83dd15f3eb54" />


now
<img width="970" height="521" alt="now" src="https://github.com/user-attachments/assets/d6686272-0b52-48cc-93cf-80398b3f23fc" />
