### PR TITLE
🔧 Chore: remove prettier-plugin-tailwind

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -7,8 +7,7 @@
   "proseWrap": "always",
   "plugins": [
     "@awmottaz/prettier-plugin-void-html",
-    "prettier-plugin-go-template",
-    "prettier-plugin-tailwindcss"
+    "prettier-plugin-go-template"
   ],
   "overrides": [
     {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "packery": "^3.0.0",
     "prettier": "^3.6.2",
     "prettier-plugin-go-template": "^0.0.15",
-    "prettier-plugin-tailwindcss": "^0.6.13",
     "puppeteer": "^24.12.1",
     "rimraf": "^6.0.1",
     "tailwind-scrollbar": "^4.0.2",


### PR DESCRIPTION
The behavior is inconsistent in dark mode and with some hover interactions. Generally, we prefer to order classes by shape, margin, and padding first, followed by color, and finally by variants such as dark mode and hover. This is also how Blowfish was originally structured.

However, even though the [documentation](https://github.com/tailwindlabs/prettier-plugin-tailwindcss) [states this](https://tailwindcss.com/blog/automatic-class-sorting-with-prettier#how-classes-are-sorted), it formats the code like this:

```diff
-  class="m-1 rounded bg-neutral-300 p-1.5 text-neutral-700 hover:bg-primary-500 hover:text-neutral dark:bg-neutral-700 dark:text-neutral-300 dark:hover:bg-primary-400 dark:hover:text-neutral-800"
+  class="hover:bg-primary-500 hover:text-neutral dark:hover:bg-primary-400 m-1 rounded bg-neutral-300 p-1.5 text-neutral-700 dark:bg-neutral-700 dark:text-neutral-300 dark:hover:text-neutral-800"
```

Since the current setup works well, there is no need to introduce another tool that causes more issues than the value it provides.
