### PR TITLE
Dynamic attributes on Button shortcode

### DIFF
--- a/layouts/shortcodes/button.html
+++ b/layouts/shortcodes/button.html
@@ -1,8 +1,8 @@
 <a
   class="!rounded-md bg-primary-600 px-4 py-2 !text-neutral !no-underline hover:!bg-primary-500 dark:bg-primary-800 dark:hover:!bg-primary-700"
-  {{ with .Get "href" }}href="{{ . }}"{{ end }}
-  {{ with .Get "target" }}target="{{ . }}"{{ end }}
-  {{ with .Get "rel" }}rel="{{ . }}"{{ end }}
+  {{- range $key, $value := .Params -}}
+    {{ printf `%s="%s"` $key $value | safeHTMLAttr }}
+  {{- end }}
   role="button">
   {{ .Inner }}
 </a>


### PR DESCRIPTION
Closes #2339

As it stands, only the 3 predefined attributes on button shortcodes can be used. This isn't enough for a lot of use cases, other than simple link opening

By using dynamic attributes, we aren't breaking existing buttons and allowing for more attributes to used such as `download=""`, `style=""`, etc.
