### PR TITLE
:sparkles: Feat: Support base64 image format

### DIFF
--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -25,20 +25,21 @@
 {{- end }}
 
 {{- $disableImageOptimizationMD := .Page.Site.Params.disableImageOptimizationMD | default false }}
-{{- $url := urls.Parse .Destination }}
+{{- $urlStr := .Destination | safeURL -}}
+{{- $url := urls.Parse $urlStr -}}
 {{- $altText := .Text }}
 {{- $caption := .Title }}
-{{- $isRemote := findRE "^https?" $url.Scheme }}
+{{- $isRemote := findRE "^(https?|data)" $url.Scheme }}
 {{- $resource := "" }}
 
 {{- if not $isRemote }}
-  {{- $resource = or ($.Page.Resources.GetMatch $url.String) (resources.Get $url.String) }}
+  {{- $resource = or ($.Page.Resources.GetMatch $urlStr) (resources.Get $urlStr) }}
 {{- end }}
 
 
 <figure>
   {{- if $isRemote }}
-    {{ template "RenderImageSimple" (dict "src" $url.String "alt" $altText) }}
+    {{ template "RenderImageSimple" (dict "src" $urlStr "alt" $altText) }}
   {{- else if $resource }}
     {{- $isSVG := eq $resource.MediaType.SubType "svg" }}
     {{- $shouldOptimize := and (not $disableImageOptimizationMD) (not $isSVG) }}
@@ -48,7 +49,7 @@
       {{ template "RenderImageSimple" (dict "src" $resource.RelPermalink "alt" $altText) }}
     {{- end }}
   {{- else }}
-    {{ template "RenderImageSimple" (dict "src" $url.String "alt" $altText) }}
+    {{ template "RenderImageSimple" (dict "src" $urlStr "alt" $altText) }}
   {{- end }}
 
   {{ template "RenderImageCaption" (dict "caption" $caption) }}


### PR DESCRIPTION
Support displaying Base64-formatted images in Markdown files. 
It is worth noting that there seem to be [other issues](https://discourse.gohugo.io/t/markdown-insert-base64-image-error-file-name-too-long/55307/4?u=onqiaujliu) with this file.
 #2221 