### PR TITLE
♻️  Refactor: make base-template easier to read

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -27,7 +27,6 @@ static
 
 layouts/_default/_markup/render-heading.html
 layouts/_default/index.json
-layouts/_default/list.html
 layouts/shortcodes/screenshot.html
 layouts/shortcodes/figure.html
 layouts/partials/hugo-embedded/shortcodes/figure-default.html

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,14 +1,14 @@
 <!doctype html>
 <html
-  lang="{{ with .Site.Params.isoCode | default (.Site.LanguageCode | default " en") }}{{- . -}}{{ end }}"
-  dir="{{ if .Site.Params.rtl | default false -}}
+  lang="{{ with site.Params.isoCode | default (site.LanguageCode | default " en") }}{{- . -}}{{ end }}"
+  dir="{{ if site.Params.rtl | default false -}}
     rtl
   {{- else -}}
     ltr
   {{- end }}"
   class="scroll-smooth"
-  data-default-appearance="{{ .Site.Params.defaultAppearance | default " light" }}"
-  data-auto-appearance="{{ .Site.Params.autoSwitchAppearance | default " true" }}">
+  data-default-appearance="{{ site.Params.defaultAppearance | default " light" }}"
+  data-auto-appearance="{{ site.Params.autoSwitchAppearance | default " true" }}">
   {{- partial "head.html" . -}}
 
 
@@ -22,7 +22,7 @@
         {{ i18n "nav.skip_to_main" }}
       </a>
     </div>
-    {{ $header := print "header/" .Site.Params.header.layout ".html" }}
+    {{ $header := print "header/" site.Params.header.layout ".html" }}
     {{ if templates.Exists ( printf "partials/%s" $header ) }}
       {{ partial $header . }}
     {{ else }}
@@ -31,26 +31,26 @@
     <div class="relative flex flex-col grow">
       <main id="main-content" class="grow">
         {{ block "main" . }}{{ end }}
-        {{ if and (.Site.Params.footer.showScrollToTop | default true) (gt .WordCount 1) }}
+        {{ if and (site.Params.footer.showScrollToTop | default true) (gt .WordCount 1) }}
           {{- partial "scroll-to-top.html" . -}}
         {{ end }}
       </main>
       {{- partial "footer.html" . -}}
-      {{ if .Site.Params.enableSearch | default false }}
+      {{ if site.Params.enableSearch | default false }}
         {{- partial "search.html" . -}}
       {{ end }}
     </div>
   </body>
-  {{ if .Site.Params.buymeacoffee.globalWidget | default false }}
+  {{ if site.Params.buymeacoffee.globalWidget | default false }}
     <script
       data-name="BMC-Widget"
       data-cfasync="false"
       src="https://cdnjs.buymeacoffee.com/1.0.0/widget.prod.min.js"
-      data-id="{{ .Site.Params.buymeacoffee.identifier }}"
+      data-id="{{ site.Params.buymeacoffee.identifier }}"
       data-description="Support me on Buy me a coffee!"
-      data-message="{{ .Site.Params.buymeacoffee.globalWidgetMessage | default "" }}"
-      data-color="{{ .Site.Params.buymeacoffee.globalWidgetColor | default "#FFDD00" }}"
-      data-position="{{ .Site.Params.buymeacoffee.globalWidgetPosition | default "Left" }}"
+      data-message="{{ site.Params.buymeacoffee.globalWidgetMessage | default "" }}"
+      data-color="{{ site.Params.buymeacoffee.globalWidgetColor | default "#FFDD00" }}"
+      data-position="{{ site.Params.buymeacoffee.globalWidgetPosition | default "Left" }}"
       data-x_margin="18"
       data-y_margin="18"></script>
   {{ end }}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -17,11 +17,10 @@
     <div id="the-top" class="absolute flex self-center">
       <a
         class="px-3 py-1 text-sm -translate-y-8 rounded-b-lg bg-primary-200 focus:translate-y-0 dark:bg-neutral-600"
-        href="#main-content"
-        ><span class="font-bold text-primary-600 ltr:pr-2 rtl:pl-2 dark:text-primary-400">&darr;</span>{{ i18n
-          "nav.skip_to_main"
-        }}</a
-      >
+        href="#main-content">
+        <span class="font-bold text-primary-600 ltr:pr-2 rtl:pl-2 dark:text-primary-400">&darr;</span>
+        {{ i18n "nav.skip_to_main" }}
+      </a>
     </div>
     {{ $header := print "header/" .Site.Params.header.layout ".html" }}
     {{ if templates.Exists ( printf "partials/%s" $header ) }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,5 +1,9 @@
 {{ define "main" }}
   {{ .Scratch.Set "scope" "list" }}
+  {{ $enableToc := .Params.showTableOfContents | default (.Site.Params.list.showTableOfContents | default false) }}
+  {{ $showToc := and $enableToc (in .TableOfContents "<ul") }}
+
+  {{/* Hero */}}
   {{ if .Site.Params.list.showHero | default false }}
     {{ $heroStyle := print "hero/" .Site.Params.list.heroStyle ".html" }}
     {{ if templates.Exists ( printf "partials/%s" $heroStyle ) }}
@@ -7,10 +11,9 @@
     {{ else }}
       {{ partial "hero/basic.html" . }}
     {{ end }}
-  {{- end -}}
+  {{ end }}
 
-  {{ $enableToc := .Params.showTableOfContents | default (.Site.Params.list.showTableOfContents | default false) }}
-  {{ $showToc := and $enableToc (in .TableOfContents "<ul") }}
+  {{/* Header */}}
   <header>
     {{ if .Params.showBreadcrumbs | default (.Site.Params.list.showBreadcrumbs | default false) }}
       {{ partial "breadcrumbs.html" . }}
@@ -36,10 +39,12 @@
         data-oid-likes="likes_{{ $path }}"></script>
     {{ end }}
   </header>
-  {{ $tocMargin := cond $toc "mt-12" "mt-0" -}}
+
+  {{/* Description (markdown content) */}}
+  {{ $tocMargin := cond $showToc "mt-12" "mt-0" }}
   {{ $topClass := cond (hasPrefix .Site.Params.header.layout "fixed") "lg:top-[140px]" "lg:top-10" }}
   <section class="{{ $tocMargin }} prose flex max-w-full flex-col dark:prose-invert lg:flex-row">
-    {{ if $toc }}
+    {{ if $showToc }}
       <div class="order-first px-0 lg:order-last lg:max-w-xs ltr:lg:pl-8 rtl:lg:pr-8">
         <div class="toc ltr:pl-5 rtl:pr-5 lg:sticky {{ $topClass }}">
           {{ partial "toc.html" . }}
@@ -51,6 +56,7 @@
     </div>
   </section>
 
+  {{/* Article Grid */}}
   {{ if gt .Pages 0 }}
     {{ $cardView := .Params.cardView | default (.Site.Params.list.cardView | default false) }}
     {{ $cardViewScreenWidth := .Params.cardViewScreenWidth | default (.Site.Params.list.cardViewScreenWidth | default false) }}
@@ -77,8 +83,8 @@
           {{ end }}
         {{ end }}
       </section>
+    {{/* else: is cardView */}}
     {{ else }}
-
       {{ if $groupByYear }}
         {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
           {{ if $cardViewScreenWidth }}
@@ -86,8 +92,7 @@
               <h2 class="mt-12 mb-3 text-2xl font-bold text-neutral-700 first:mt-8 dark:text-neutral-300">
                 {{ .Key }}
               </h2>
-              <section
-                class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
+              <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
                 {{ range .Pages }}
                   {{ partial "article-link/card.html" . }}
                 {{ end }}
@@ -97,8 +102,7 @@
             <h2 class="mt-12 mb-3 text-2xl font-bold text-neutral-700 first:mt-8 dark:text-neutral-300">
               {{ .Key }}
             </h2>
-            <section
-              class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+            <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3">
               {{ range .Pages }}
                 {{ partial "article-link/card.html" . }}
               {{ end }}
@@ -106,6 +110,7 @@
           {{ end }}
         {{ end }}
 
+      {{/* else: not groupByYear */}}
       {{ else }}
         {{ if $cardViewScreenWidth }}
           <div class="relative w-screen max-w-[1600px] px-[30px] left-[calc(max(-50vw,-800px)+50%)]">
@@ -137,10 +142,10 @@
               {{ end }}
             {{ end }}
           </section>
-        {{ end }}
-      {{ end }}
-
-    {{ end }}
+        {{ end }}{{/* End of cardViewScreenWidth */}}
+      {{ end }}{{/* End of groupByYear */}}
+    {{ end }}{{/* End of cardView */}}
+  {{/* else: .Pages not greater to zero */}}
   {{ else }}
     <section class="mt-10 prose dark:prose-invert">
       <p class="py-8 border-t">

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -81,17 +81,24 @@
             {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
               {{ if $cardViewScreenWidth }}
                 <div class="relative w-screen max-w-[1600px] px-[30px] left-[calc(max(-50vw,-800px)+50%)]">
-              {{ end }}
-              <h2 class="mt-12 mb-3 text-2xl font-bold text-neutral-700 first:mt-8 dark:text-neutral-300">
-                {{ .Key }}
-              </h2>
-              <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3 {{ if $cardViewScreenWidth }} xl:grid-cols-4 2xl:grid-cols-5 {{ end }}">
-                {{ range .Pages }}
-                  {{ partial "article-link/card.html" . }}
-                {{ end }}
-              </section>
-              {{ if $cardViewScreenWidth }}
+                  <h2 class="mt-12 mb-3 text-2xl font-bold text-neutral-700 first:mt-8 dark:text-neutral-300">
+                    {{ .Key }}
+                  </h2>
+                  <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3 {{ if $cardViewScreenWidth }} xl:grid-cols-4 2xl:grid-cols-5 {{ end }}">
+                    {{ range .Pages }}
+                      {{ partial "article-link/card.html" . }}
+                    {{ end }}
+                  </section>
                 </div>
+              {{ else }}
+                <h2 class="mt-12 mb-3 text-2xl font-bold text-neutral-700 first:mt-8 dark:text-neutral-300">
+                  {{ .Key }}
+                </h2>
+                <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3 {{ if $cardViewScreenWidth }} xl:grid-cols-4 2xl:grid-cols-5 {{ end }}">
+                  {{ range .Pages }}
+                    {{ partial "article-link/card.html" . }}
+                  {{ end }}
+                </section>
               {{ end }}
             {{ end }}
 
@@ -99,24 +106,34 @@
 
             {{ if $cardViewScreenWidth }}
               <div class="relative w-screen max-w-[1600px] px-[30px] left-[calc(max(-50vw,-800px)+50%)]">
-              <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
+                <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
+                  {{ if not $orderByWeight }}
+                    {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
+                      {{ range .Pages }}
+                        {{ partial "article-link/card.html" . }}
+                      {{ end }}
+                    {{ end }}
+                  {{ else }}
+                    {{ range (.Paginate (.Pages.ByWeight)).Pages }}
+                      {{ partial "article-link/card.html" . }}
+                    {{ end }}
+                  {{ end }}
+                </section>
+              </div>
             {{ else }}
               <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3">
-            {{ end }}  
-            {{ if not $orderByWeight }}
-              {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
-                {{ range .Pages }}
-                  {{ partial "article-link/card.html" . }}
+                {{ if not $orderByWeight }}
+                  {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
+                    {{ range .Pages }}
+                      {{ partial "article-link/card.html" . }}
+                    {{ end }}
+                  {{ end }}
+                {{ else }}
+                  {{ range (.Paginate (.Pages.ByWeight)).Pages }}
+                    {{ partial "article-link/card.html" . }}
+                  {{ end }}
                 {{ end }}
-              {{ end }}
-            {{ else }}
-              {{ range (.Paginate (.Pages.ByWeight)).Pages }}
-                {{ partial "article-link/card.html" . }}
-              {{ end }}
-            {{ end }}
-            </section>
-            {{ if $cardViewScreenWidth }}
-              </div>
+              </section>
             {{ end }}
           {{ end }}
 

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -25,125 +25,139 @@
         {{ $lang := print "."  .Lang  ".md" }}
         {{ $path = replace $path $lang ".md" }}
       {{ end }}
-    {{ $jsPage := resources.Get "js/page.js" }}
-    {{ $jsPage = $jsPage | resources.Minify | resources.Fingerprint ($.Site.Params.fingerprintAlgorithm | default "sha512") }}
-    <script type="text/javascript" src="{{ $jsPage.RelPermalink }}" integrity="{{ $jsPage.Data.Integrity }}" data-oid="views_{{ $path }}" data-oid-likes="likes_{{ $path }}"></script>
+      {{ $jsPage := resources.Get "js/page.js" }}
+      {{ $jsPage = $jsPage | resources.Minify | resources.Fingerprint ($.Site.Params.fingerprintAlgorithm | default "sha512") }}
+      <script
+        type="text/javascript"
+        src="{{ $jsPage.RelPermalink }}"
+        integrity="{{ $jsPage.Data.Integrity }}"
+        data-oid="views_{{ $path }}"
+        data-oid-likes="likes_{{ $path }}"></script>
     {{ end }}
   </header>
-    <section class="{{ if $toc -}}
-        mt-12
-      {{- else -}}
-        mt-0
-      {{- end }} prose flex max-w-full flex-col dark:prose-invert lg:flex-row">
-      {{ if $toc }}
+  <section
+    class="{{ if $toc -}}
+      mt-12
+    {{- else -}}
+      mt-0
+    {{- end }} prose flex max-w-full flex-col dark:prose-invert lg:flex-row">
+    {{ if $toc }}
       <div class="order-first px-0 lg:order-last lg:max-w-xs ltr:lg:pl-8 rtl:lg:pr-8">
-        <div class="toc ltr:pl-5 rtl:pr-5 lg:sticky {{ if hasPrefix .Site.Params.header.layout "fixed" -}}
-        lg:top-[140px]{{ else }}lg:top-10{{ end }}">
+        <div
+          class="toc ltr:pl-5 rtl:pr-5 lg:sticky {{ if hasPrefix .Site.Params.header.layout "fixed" -}}
+            lg:top-[140px]
+          {{ else }}
+            lg:top-10
+          {{ end }}">
           {{ partial "toc.html" . }}
         </div>
       </div>
-      {{ end }}
-      <div class="min-w-0 min-h-0 max-w-prose">
-        {{ .Content }}
-      </div>
-    </section>
+    {{ end }}
+    <div class="min-w-0 min-h-0 max-w-prose">
+      {{ .Content }}
+    </div>
+  </section>
 
-    {{ if gt .Pages 0 }}
-      {{ $cardView := .Params.cardView | default (.Site.Params.list.cardView | default false) }}
-      {{ $cardViewScreenWidth := .Params.cardViewScreenWidth | default (.Site.Params.list.cardViewScreenWidth | default false) }}
-      {{ $groupByYear := .Params.groupByYear | default ($.Site.Params.list.groupByYear | default false) }}
-      {{ $orderByWeight := .Params.orderByWeight | default ($.Site.Params.list.orderByWeight | default false) }}
-      {{ $groupByYear := and (not $orderByWeight) $groupByYear }}
+  {{ if gt .Pages 0 }}
+    {{ $cardView := .Params.cardView | default (.Site.Params.list.cardView | default false) }}
+    {{ $cardViewScreenWidth := .Params.cardViewScreenWidth | default (.Site.Params.list.cardViewScreenWidth | default false) }}
+    {{ $groupByYear := .Params.groupByYear | default ($.Site.Params.list.groupByYear | default false) }}
+    {{ $orderByWeight := .Params.orderByWeight | default ($.Site.Params.list.orderByWeight | default false) }}
+    {{ $groupByYear := and (not $orderByWeight) $groupByYear }}
 
-      {{ if not $cardView }}
-        <section class="space-y-10 w-full">
-          {{ if not $orderByWeight }}
-            {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
-              {{ if $groupByYear }}
-                <h2 class="mt-12 text-2xl font-bold text-neutral-700 first:mt-8 dark:text-neutral-300">
-                  {{ .Key }}
-                </h2>
-              {{ end }}
-              {{ range .Pages }}
-                {{ partial "article-link/simple.html" . }}
-              {{ end }}
+    {{ if not $cardView }}
+      <section class="space-y-10 w-full">
+        {{ if not $orderByWeight }}
+          {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
+            {{ if $groupByYear }}
+              <h2 class="mt-12 text-2xl font-bold text-neutral-700 first:mt-8 dark:text-neutral-300">
+                {{ .Key }}
+              </h2>
             {{ end }}
-          {{ else }}
-            {{ range (.Paginate (.Pages.ByWeight)).Pages }}
+            {{ range .Pages }}
               {{ partial "article-link/simple.html" . }}
             {{ end }}
           {{ end }}
-        </section>
-
         {{ else }}
+          {{ range (.Paginate (.Pages.ByWeight)).Pages }}
+            {{ partial "article-link/simple.html" . }}
+          {{ end }}
+        {{ end }}
+      </section>
+    {{ else }}
 
-          {{ if $groupByYear }}
-            {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
-              {{ if $cardViewScreenWidth }}
-                <div class="relative w-screen max-w-[1600px] px-[30px] left-[calc(max(-50vw,-800px)+50%)]">
-                  <h2 class="mt-12 mb-3 text-2xl font-bold text-neutral-700 first:mt-8 dark:text-neutral-300">
-                    {{ .Key }}
-                  </h2>
-                  <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3 {{ if $cardViewScreenWidth }} xl:grid-cols-4 2xl:grid-cols-5 {{ end }}">
-                    {{ range .Pages }}
-                      {{ partial "article-link/card.html" . }}
-                    {{ end }}
-                  </section>
-                </div>
-              {{ else }}
-                <h2 class="mt-12 mb-3 text-2xl font-bold text-neutral-700 first:mt-8 dark:text-neutral-300">
-                  {{ .Key }}
-                </h2>
-                <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3 {{ if $cardViewScreenWidth }} xl:grid-cols-4 2xl:grid-cols-5 {{ end }}">
+      {{ if $groupByYear }}
+        {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
+          {{ if $cardViewScreenWidth }}
+            <div class="relative w-screen max-w-[1600px] px-[30px] left-[calc(max(-50vw,-800px)+50%)]">
+              <h2 class="mt-12 mb-3 text-2xl font-bold text-neutral-700 first:mt-8 dark:text-neutral-300">
+                {{ .Key }}
+              </h2>
+              <section
+                class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3 {{ if $cardViewScreenWidth }}
+                  xl:grid-cols-4 2xl:grid-cols-5
+                {{ end }}">
+                {{ range .Pages }}
+                  {{ partial "article-link/card.html" . }}
+                {{ end }}
+              </section>
+            </div>
+          {{ else }}
+            <h2 class="mt-12 mb-3 text-2xl font-bold text-neutral-700 first:mt-8 dark:text-neutral-300">
+              {{ .Key }}
+            </h2>
+            <section
+              class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3 {{ if $cardViewScreenWidth }}
+                xl:grid-cols-4 2xl:grid-cols-5
+              {{ end }}">
+              {{ range .Pages }}
+                {{ partial "article-link/card.html" . }}
+              {{ end }}
+            </section>
+          {{ end }}
+        {{ end }}
+
+      {{ else }}
+        {{ if $cardViewScreenWidth }}
+          <div class="relative w-screen max-w-[1600px] px-[30px] left-[calc(max(-50vw,-800px)+50%)]">
+            <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
+              {{ if not $orderByWeight }}
+                {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
                   {{ range .Pages }}
                     {{ partial "article-link/card.html" . }}
                   {{ end }}
-                </section>
+                {{ end }}
+              {{ else }}
+                {{ range (.Paginate (.Pages.ByWeight)).Pages }}
+                  {{ partial "article-link/card.html" . }}
+                {{ end }}
+              {{ end }}
+            </section>
+          </div>
+        {{ else }}
+          <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+            {{ if not $orderByWeight }}
+              {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
+                {{ range .Pages }}
+                  {{ partial "article-link/card.html" . }}
+                {{ end }}
+              {{ end }}
+            {{ else }}
+              {{ range (.Paginate (.Pages.ByWeight)).Pages }}
+                {{ partial "article-link/card.html" . }}
               {{ end }}
             {{ end }}
-
-          {{ else }}
-
-            {{ if $cardViewScreenWidth }}
-              <div class="relative w-screen max-w-[1600px] px-[30px] left-[calc(max(-50vw,-800px)+50%)]">
-                <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
-                  {{ if not $orderByWeight }}
-                    {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
-                      {{ range .Pages }}
-                        {{ partial "article-link/card.html" . }}
-                      {{ end }}
-                    {{ end }}
-                  {{ else }}
-                    {{ range (.Paginate (.Pages.ByWeight)).Pages }}
-                      {{ partial "article-link/card.html" . }}
-                    {{ end }}
-                  {{ end }}
-                </section>
-              </div>
-            {{ else }}
-              <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3">
-                {{ if not $orderByWeight }}
-                  {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
-                    {{ range .Pages }}
-                      {{ partial "article-link/card.html" . }}
-                    {{ end }}
-                  {{ end }}
-                {{ else }}
-                  {{ range (.Paginate (.Pages.ByWeight)).Pages }}
-                    {{ partial "article-link/card.html" . }}
-                  {{ end }}
-                {{ end }}
-              </section>
-            {{ end }}
-          {{ end }}
-
+          </section>
+        {{ end }}
       {{ end }}
-    {{ else }}
-      <section class="mt-10 prose dark:prose-invert">
-        <p class="py-8 border-t">
-          <em>{{ i18n "list.no_articles" | emojify }}</em>
-        </p>
-      </section>
+
     {{ end }}
+  {{ else }}
+    <section class="mt-10 prose dark:prose-invert">
+      <p class="py-8 border-t">
+        <em>{{ i18n "list.no_articles" | emojify }}</em>
+      </p>
+    </section>
+  {{ end }}
   {{ partial "pagination.html" . }}
 {{ end }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,11 +1,11 @@
 {{ define "main" }}
   {{ .Scratch.Set "scope" "list" }}
-  {{ $enableToc := .Params.showTableOfContents | default (.Site.Params.list.showTableOfContents | default false) }}
+  {{ $enableToc := .Params.showTableOfContents | default (site.Params.list.showTableOfContents | default false) }}
   {{ $showToc := and $enableToc (in .TableOfContents "<ul") }}
 
   {{/* Hero */}}
-  {{ if .Site.Params.list.showHero | default false }}
-    {{ $heroStyle := print "hero/" .Site.Params.list.heroStyle ".html" }}
+  {{ if site.Params.list.showHero | default false }}
+    {{ $heroStyle := print "hero/" site.Params.list.heroStyle ".html" }}
     {{ if templates.Exists ( printf "partials/%s" $heroStyle ) }}
       {{ partial $heroStyle . }}
     {{ else }}
@@ -15,7 +15,7 @@
 
   {{/* Header */}}
   <header>
-    {{ if .Params.showBreadcrumbs | default (.Site.Params.list.showBreadcrumbs | default false) }}
+    {{ if .Params.showBreadcrumbs | default (site.Params.list.showBreadcrumbs | default false) }}
       {{ partial "breadcrumbs.html" . }}
     {{ end }}
     <h1 class="mt-5 text-4xl font-extrabold text-neutral-900 dark:text-neutral">{{ .Title }}</h1>
@@ -30,7 +30,7 @@
         {{ $path = replace $path $lang ".md" }}
       {{ end }}
       {{ $jsPage := resources.Get "js/page.js" }}
-      {{ $jsPage = $jsPage | resources.Minify | resources.Fingerprint ($.Site.Params.fingerprintAlgorithm | default "sha512") }}
+      {{ $jsPage = $jsPage | resources.Minify | resources.Fingerprint (site.Params.fingerprintAlgorithm | default "sha512") }}
       <script
         type="text/javascript"
         src="{{ $jsPage.RelPermalink }}"
@@ -42,7 +42,7 @@
 
   {{/* Description (markdown content) */}}
   {{ $tocMargin := cond $showToc "mt-12" "mt-0" }}
-  {{ $topClass := cond (hasPrefix .Site.Params.header.layout "fixed") "lg:top-[140px]" "lg:top-10" }}
+  {{ $topClass := cond (hasPrefix site.Params.header.layout "fixed") "lg:top-[140px]" "lg:top-10" }}
   <section class="{{ $tocMargin }} prose flex max-w-full flex-col dark:prose-invert lg:flex-row">
     {{ if $showToc }}
       <div class="order-first px-0 lg:order-last lg:max-w-xs ltr:lg:pl-8 rtl:lg:pr-8">
@@ -58,10 +58,10 @@
 
   {{/* Article Grid */}}
   {{ if gt .Pages 0 }}
-    {{ $cardView := .Params.cardView | default (.Site.Params.list.cardView | default false) }}
-    {{ $cardViewScreenWidth := .Params.cardViewScreenWidth | default (.Site.Params.list.cardViewScreenWidth | default false) }}
-    {{ $groupByYear := .Params.groupByYear | default ($.Site.Params.list.groupByYear | default false) }}
-    {{ $orderByWeight := .Params.orderByWeight | default ($.Site.Params.list.orderByWeight | default false) }}
+    {{ $cardView := .Params.cardView | default (site.Params.list.cardView | default false) }}
+    {{ $cardViewScreenWidth := .Params.cardViewScreenWidth | default (site.Params.list.cardViewScreenWidth | default false) }}
+    {{ $groupByYear := .Params.groupByYear | default (site.Params.list.groupByYear | default false) }}
+    {{ $orderByWeight := .Params.orderByWeight | default (site.Params.list.orderByWeight | default false) }}
     {{ $groupByYear := and (not $orderByWeight) $groupByYear }}
 
     {{ if not $cardView }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,139 +1,132 @@
 {{ define "main" }}
-
-{{ .Scratch.Set "scope" "list" }}
-{{ if .Site.Params.list.showHero | default false }}
-{{ $heroStyle := print "hero/" .Site.Params.list.heroStyle ".html" }}
-{{ if templates.Exists ( printf "partials/%s" $heroStyle ) }}
-{{ partial $heroStyle . }}
-{{ else }}
-{{ partial "hero/basic.html" . }}
-{{ end }}
-{{- end -}}
-
-{{ $toc := and (.Params.showTableOfContents | default (.Site.Params.list.showTableOfContents | default false)) (in
-.TableOfContents "<ul") }} <header>
-  {{ if .Params.showBreadcrumbs | default (.Site.Params.list.showBreadcrumbs | default false) }}
-  {{ partial "breadcrumbs.html" . }}
-  {{ end }}
-  <h1 class="mt-5 text-4xl font-extrabold text-neutral-900 dark:text-neutral">{{ .Title }}</h1>
-  <div class="mt-1 mb-2 text-base text-neutral-500 dark:text-neutral-400 print:hidden">
-    {{ partial "article-meta/list.html" (dict "context" . "scope" "single") }}
-  </div>
-  {{ $translations := .AllTranslations }}
-  {{ with .File }}
-    {{ $path := .Path }}
-    {{range $translations}}
-      {{ $lang := print "."  .Lang  ".md" }}
-      {{ $path = replace $path $lang ".md" }}
-    {{end}}
-  {{ $jsPage := resources.Get "js/page.js" }}
-  {{ $jsPage = $jsPage | resources.Minify | resources.Fingerprint ($.Site.Params.fingerprintAlgorithm | default "sha512") }}
-  <script type="text/javascript" src="{{ $jsPage.RelPermalink }}" integrity="{{ $jsPage.Data.Integrity }}" data-oid="views_{{ $path }}" data-oid-likes="likes_{{ $path }}"></script>
-  {{ end }}
-  </header>
-  <section class="{{ if $toc -}}
-      mt-12
-    {{- else -}}
-      mt-0
-    {{- end }} prose flex max-w-full flex-col dark:prose-invert lg:flex-row">
-    {{ if $toc }}
-    <div class="order-first px-0 lg:order-last lg:max-w-xs ltr:lg:pl-8 rtl:lg:pr-8">
-      <div class="toc ltr:pl-5 rtl:pr-5 lg:sticky {{ if hasPrefix .Site.Params.header.layout "fixed" -}}
-      lg:top-[140px]{{ else }}lg:top-10{{ end }}">
-        {{ partial "toc.html" . }}
-      </div>
-    </div>
+  {{ .Scratch.Set "scope" "list" }}
+  {{ if .Site.Params.list.showHero | default false }}
+    {{ $heroStyle := print "hero/" .Site.Params.list.heroStyle ".html" }}
+    {{ if templates.Exists ( printf "partials/%s" $heroStyle ) }}
+      {{ partial $heroStyle . }}
+    {{ else }}
+      {{ partial "hero/basic.html" . }}
     {{ end }}
-    <div class="min-w-0 min-h-0 max-w-prose">
-      {{ .Content }}
+  {{- end -}}
+
+  {{ $toc := and (.Params.showTableOfContents | default (.Site.Params.list.showTableOfContents | default false)) (in .TableOfContents "<ul") }}
+  <header>
+    {{ if .Params.showBreadcrumbs | default (.Site.Params.list.showBreadcrumbs | default false) }}
+      {{ partial "breadcrumbs.html" . }}
+    {{ end }}
+    <h1 class="mt-5 text-4xl font-extrabold text-neutral-900 dark:text-neutral">{{ .Title }}</h1>
+    <div class="mt-1 mb-2 text-base text-neutral-500 dark:text-neutral-400 print:hidden">
+      {{ partial "article-meta/list.html" (dict "context" . "scope" "single") }}
     </div>
-
-
-
-
-  </section>
-  {{ if gt .Pages 0 }}
-
-    {{ $cardView := .Params.cardView | default (.Site.Params.list.cardView | default false) }}
-    {{ $cardViewScreenWidth := .Params.cardViewScreenWidth | default (.Site.Params.list.cardViewScreenWidth | default false) }}
-    {{ $groupByYear := .Params.groupByYear | default ($.Site.Params.list.groupByYear | default false) }}
-    {{ $orderByWeight := .Params.orderByWeight | default ($.Site.Params.list.orderByWeight | default false) }}
-    {{ $groupByYear := and (not $orderByWeight) $groupByYear }}
-
-    {{ if not $cardView }}
-
-    <section class="space-y-10 w-full">
-      {{ if not $orderByWeight }}
-        {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
-        {{ if $groupByYear }}
-        <h2 class="mt-12 text-2xl font-bold text-neutral-700 first:mt-8 dark:text-neutral-300">
-          {{ .Key }}
-        </h2>
-        {{ end }}
-        {{ range .Pages }}
-        {{ partial "article-link/simple.html" . }}
-        {{ end }}
-        {{ end }}
-      {{ else }}
-        {{ range (.Paginate (.Pages.ByWeight)).Pages }}
-        {{ partial "article-link/simple.html" . }}
-        {{ end }}
+    {{ $translations := .AllTranslations }}
+    {{ with .File }}
+      {{ $path := .Path }}
+      {{ range $translations }}
+        {{ $lang := print "."  .Lang  ".md" }}
+        {{ $path = replace $path $lang ".md" }}
       {{ end }}
+    {{ $jsPage := resources.Get "js/page.js" }}
+    {{ $jsPage = $jsPage | resources.Minify | resources.Fingerprint ($.Site.Params.fingerprintAlgorithm | default "sha512") }}
+    <script type="text/javascript" src="{{ $jsPage.RelPermalink }}" integrity="{{ $jsPage.Data.Integrity }}" data-oid="views_{{ $path }}" data-oid-likes="likes_{{ $path }}"></script>
+    {{ end }}
+  </header>
+    <section class="{{ if $toc -}}
+        mt-12
+      {{- else -}}
+        mt-0
+      {{- end }} prose flex max-w-full flex-col dark:prose-invert lg:flex-row">
+      {{ if $toc }}
+      <div class="order-first px-0 lg:order-last lg:max-w-xs ltr:lg:pl-8 rtl:lg:pr-8">
+        <div class="toc ltr:pl-5 rtl:pr-5 lg:sticky {{ if hasPrefix .Site.Params.header.layout "fixed" -}}
+        lg:top-[140px]{{ else }}lg:top-10{{ end }}">
+          {{ partial "toc.html" . }}
+        </div>
+      </div>
+      {{ end }}
+      <div class="min-w-0 min-h-0 max-w-prose">
+        {{ .Content }}
+      </div>
     </section>
 
-    {{ else }}
+    {{ if gt .Pages 0 }}
+      {{ $cardView := .Params.cardView | default (.Site.Params.list.cardView | default false) }}
+      {{ $cardViewScreenWidth := .Params.cardViewScreenWidth | default (.Site.Params.list.cardViewScreenWidth | default false) }}
+      {{ $groupByYear := .Params.groupByYear | default ($.Site.Params.list.groupByYear | default false) }}
+      {{ $orderByWeight := .Params.orderByWeight | default ($.Site.Params.list.orderByWeight | default false) }}
+      {{ $groupByYear := and (not $orderByWeight) $groupByYear }}
 
-      {{ if $groupByYear }}
-
-      {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
-        {{ if $cardViewScreenWidth }}
-        <div class="relative w-screen max-w-[1600px] px-[30px] left-[calc(max(-50vw,-800px)+50%)]">
-        {{ end }}
-          <h2 class="mt-12 mb-3 text-2xl font-bold text-neutral-700 first:mt-8 dark:text-neutral-300">
-            {{ .Key }}
-          </h2>
-        <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3 {{ if $cardViewScreenWidth }} xl:grid-cols-4 2xl:grid-cols-5 {{ end }}">
-          {{ range .Pages }}
-          {{ partial "article-link/card.html" . }}
+      {{ if not $cardView }}
+        <section class="space-y-10 w-full">
+          {{ if not $orderByWeight }}
+            {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
+              {{ if $groupByYear }}
+                <h2 class="mt-12 text-2xl font-bold text-neutral-700 first:mt-8 dark:text-neutral-300">
+                  {{ .Key }}
+                </h2>
+              {{ end }}
+              {{ range .Pages }}
+                {{ partial "article-link/simple.html" . }}
+              {{ end }}
+            {{ end }}
+          {{ else }}
+            {{ range (.Paginate (.Pages.ByWeight)).Pages }}
+              {{ partial "article-link/simple.html" . }}
+            {{ end }}
           {{ end }}
         </section>
-        {{ if $cardViewScreenWidth }} </div> {{ end }}
+
+        {{ else }}
+
+          {{ if $groupByYear }}
+            {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
+              {{ if $cardViewScreenWidth }}
+                <div class="relative w-screen max-w-[1600px] px-[30px] left-[calc(max(-50vw,-800px)+50%)]">
+              {{ end }}
+              <h2 class="mt-12 mb-3 text-2xl font-bold text-neutral-700 first:mt-8 dark:text-neutral-300">
+                {{ .Key }}
+              </h2>
+              <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3 {{ if $cardViewScreenWidth }} xl:grid-cols-4 2xl:grid-cols-5 {{ end }}">
+                {{ range .Pages }}
+                  {{ partial "article-link/card.html" . }}
+                {{ end }}
+              </section>
+              {{ if $cardViewScreenWidth }}
+                </div>
+              {{ end }}
+            {{ end }}
+
+          {{ else }}
+
+            {{ if $cardViewScreenWidth }}
+              <div class="relative w-screen max-w-[1600px] px-[30px] left-[calc(max(-50vw,-800px)+50%)]">
+              <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
+            {{ else }}
+              <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+            {{ end }}  
+            {{ if not $orderByWeight }}
+              {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
+                {{ range .Pages }}
+                  {{ partial "article-link/card.html" . }}
+                {{ end }}
+              {{ end }}
+            {{ else }}
+              {{ range (.Paginate (.Pages.ByWeight)).Pages }}
+                {{ partial "article-link/card.html" . }}
+              {{ end }}
+            {{ end }}
+            </section>
+            {{ if $cardViewScreenWidth }}
+              </div>
+            {{ end }}
+          {{ end }}
+
       {{ end }}
-
-      {{ else }}
-
-        {{ if $cardViewScreenWidth }}
-        <div class="relative w-screen max-w-[1600px] px-[30px] left-[calc(max(-50vw,-800px)+50%)]">
-        <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
-        {{ else }}
-        <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3">
-        {{ end }}
-        {{ if not $orderByWeight }}
-          {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
-          {{ range .Pages }}
-          {{ partial "article-link/card.html" . }}
-          {{ end }}
-          {{ end }}
-        {{ else }}
-          {{ range (.Paginate (.Pages.ByWeight)).Pages }}
-          {{ partial "article-link/card.html" . }}
-          {{ end }}
-        {{ end }}
-        </section>
-        {{ if $cardViewScreenWidth }} </div> {{ end }}
-
+    {{ else }}
+      <section class="mt-10 prose dark:prose-invert">
+        <p class="py-8 border-t">
+          <em>{{ i18n "list.no_articles" | emojify }}</em>
+        </p>
+      </section>
     {{ end }}
-
-    {{end}}
-
-  {{ else }}
-  <section class="mt-10 prose dark:prose-invert">
-    <p class="py-8 border-t">
-      <em>{{ i18n "list.no_articles" | emojify }}</em>
-    </p>
-  </section>
-  {{ end }}
-
-    {{ partial "pagination.html" . }}
-
-  {{ end }}
+  {{ partial "pagination.html" . }}
+{{ end }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -9,7 +9,8 @@
     {{ end }}
   {{- end -}}
 
-  {{ $toc := and (.Params.showTableOfContents | default (.Site.Params.list.showTableOfContents | default false)) (in .TableOfContents "<ul") }}
+  {{ $enableToc := .Params.showTableOfContents | default (.Site.Params.list.showTableOfContents | default false) }}
+  {{ $showToc := and $enableToc (in .TableOfContents "<ul") }}
   <header>
     {{ if .Params.showBreadcrumbs | default (.Site.Params.list.showBreadcrumbs | default false) }}
       {{ partial "breadcrumbs.html" . }}
@@ -35,20 +36,12 @@
         data-oid-likes="likes_{{ $path }}"></script>
     {{ end }}
   </header>
-  <section
-    class="{{ if $toc -}}
-      mt-12
-    {{- else -}}
-      mt-0
-    {{- end }} prose flex max-w-full flex-col dark:prose-invert lg:flex-row">
+  {{ $tocMargin := cond $toc "mt-12" "mt-0" -}}
+  {{ $topClass := cond (hasPrefix .Site.Params.header.layout "fixed") "lg:top-[140px]" "lg:top-10" }}
+  <section class="{{ $tocMargin }} prose flex max-w-full flex-col dark:prose-invert lg:flex-row">
     {{ if $toc }}
       <div class="order-first px-0 lg:order-last lg:max-w-xs ltr:lg:pl-8 rtl:lg:pr-8">
-        <div
-          class="toc ltr:pl-5 rtl:pr-5 lg:sticky {{ if hasPrefix .Site.Params.header.layout "fixed" -}}
-            lg:top-[140px]
-          {{ else }}
-            lg:top-10
-          {{ end }}">
+        <div class="toc ltr:pl-5 rtl:pr-5 lg:sticky {{ $topClass }}">
           {{ partial "toc.html" . }}
         </div>
       </div>
@@ -94,9 +87,7 @@
                 {{ .Key }}
               </h2>
               <section
-                class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3 {{ if $cardViewScreenWidth }}
-                  xl:grid-cols-4 2xl:grid-cols-5
-                {{ end }}">
+                class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
                 {{ range .Pages }}
                   {{ partial "article-link/card.html" . }}
                 {{ end }}
@@ -107,9 +98,7 @@
               {{ .Key }}
             </h2>
             <section
-              class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3 {{ if $cardViewScreenWidth }}
-                xl:grid-cols-4 2xl:grid-cols-5
-              {{ end }}">
+              class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3">
               {{ range .Pages }}
                 {{ partial "article-link/card.html" . }}
               {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -26,48 +26,8 @@
         {{ partial "article-meta/basic.html" (dict "context" . "scope" "single") }}
       </div>
 
-      {{ $authorsData := .Site.Data.authors }}
-      {{ $taxonomies := .Site.Taxonomies.authors }}
-      {{ $baseURL := .Site.BaseURL }}
-      {{ $taxonomyLink := 0 }}
-      {{ $showAuthor := 0 }}
-
-      {{ if not (strings.HasSuffix $baseURL "/") }}
-        {{ $baseURL = delimit (slice $baseURL "/") "" }}
-      {{ end }}
-
       {{ if not (.Params.showAuthorBottom | default ( .Site.Params.article.showAuthorBottom | default false)) }}
-
-        {{ if .Params.showAuthor | default (.Site.Params.article.showAuthor | default true) }}
-          {{ $showAuthor = 1 }}
-          {{ partial "author.html" . }}
-        {{ end }}
-
-        {{ range $author := .Page.Params.authors }}
-          {{ $authorData := index $authorsData $author }}
-          {{- if $authorData -}}
-            {{ range $taxonomyname, $taxonomy := $taxonomies }}
-              {{ if (eq $taxonomyname $author) }}
-                {{ $taxonomyLink = delimit (slice $baseURL "authors/" $author "/") "" }}
-              {{ end }}
-            {{ end }}
-
-            {{ $finalLink := $taxonomyLink }}
-            {{ $currentLang := $.Site.Language.Lang }}
-            {{ if eq $.Site.LanguagePrefix "" }}
-              {{ $finalLink = printf "%sauthors/%s/" $baseURL $author }}
-            {{ else }}
-              {{ $finalLink = printf "%s%s/authors/%s/" $baseURL $currentLang $author }}
-            {{ end }}
-
-            {{ partial "author-extra.html" (dict "context" . "data" $authorData "link" $finalLink) }}
-          {{- end -}}
-        {{ end }}
-
-        {{ if or $taxonomyLink $showAuthor }}
-          <div class="mb-5"></div>
-        {{ end }}
-
+        {{ template "SingleAuthor" . }}
       {{ end }}
 
     </header>
@@ -120,28 +80,7 @@
         </div>
 
         {{ if (.Params.showAuthorBottom | default ( .Site.Params.article.showAuthorBottom | default false)) }}
-
-          {{ if .Params.showAuthor | default (.Site.Params.article.showAuthor | default true) }}
-            {{ $showAuthor = 1 }}
-            {{ partial "author.html" . }}
-          {{ end }}
-
-          {{ range $author := .Page.Params.authors }}
-            {{ $authorData := index $authorsData $author }}
-            {{- if $authorData -}}
-              {{ range $taxonomyname, $taxonomy := $taxonomies }}
-                {{ if (eq $taxonomyname $author) }}
-                  {{ $taxonomyLink = delimit (slice $baseURL "authors/" $author "/") "" }}
-                {{ end }}
-              {{ end }}
-              {{ partial "author-extra.html" (dict "context" . "data" $authorData "link" $taxonomyLink) }}
-            {{- end -}}
-          {{ end }}
-
-          {{ if or $taxonomyLink $showAuthor }}
-            <div class="mb-10"></div>
-          {{ end }}
-
+          {{ template "SingleAuthor" . }}
         {{ end }}
 
         {{ partial "series/series-closed.html" . }}
@@ -183,4 +122,47 @@
       {{ end }}
     </footer>
   </article>
+{{ end }}
+
+{{ define "SingleAuthor" }}
+  {{ $authorsData := .Site.Data.authors }}
+  {{ $taxonomies := .Site.Taxonomies.authors }}
+  {{ $baseURL := .Site.BaseURL }}
+  {{ $taxonomyLink := 0 }}
+  {{ $showAuthor := 0 }}
+  {{ $isAuthorBottom := (.Params.showAuthorBottom | default ( .Site.Params.article.showAuthorBottom | default false)) }}
+
+  {{ if not (strings.HasSuffix $baseURL "/") }}
+    {{ $baseURL = delimit (slice $baseURL "/") "" }}
+  {{ end }}
+
+  {{ if .Params.showAuthor | default (.Site.Params.article.showAuthor | default true) }}
+    {{ $showAuthor = 1 }}
+    {{ partial "author.html" . }}
+  {{ end }}
+
+  {{ range $author := .Page.Params.authors }}
+    {{ $authorData := index $authorsData $author }}
+    {{- if $authorData -}}
+      {{ range $taxonomyname, $taxonomy := $taxonomies }}
+        {{ if (eq $taxonomyname $author) }}
+          {{ $taxonomyLink = delimit (slice $baseURL "authors/" $author "/") "" }}
+        {{ end }}
+      {{ end }}
+
+      {{ $finalLink := $taxonomyLink }}
+      {{ $currentLang := $.Site.Language.Lang }}
+      {{ if eq $.Site.LanguagePrefix "" }}
+        {{ $finalLink = printf "%sauthors/%s/" $baseURL $author }}
+      {{ else }}
+        {{ $finalLink = printf "%s%s/authors/%s/" $baseURL $currentLang $author }}
+      {{ end }}
+
+      {{ partial "author-extra.html" (dict "context" . "data" $authorData "link" $finalLink) }}
+    {{- end -}}
+  {{ end }}
+
+  {{ if or $taxonomyLink $showAuthor }}
+    <div class="{{ cond $isAuthorBottom "mb-10" "mb-5" }}"></div>
+  {{ end }}
 {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,11 +1,10 @@
 {{ define "main" }}
   {{ .Scratch.Set "scope" "single" }}
-
-
   <article>
-    {{ if .Params.showHero | default (.Site.Params.article.showHero | default false) }}
+    {{/* Hero */}}
+    {{ if .Params.showHero | default (site.Params.article.showHero | default false) }}
       {{ $heroStyle := .Params.heroStyle }}
-      {{ if not $heroStyle }}{{ $heroStyle = .Site.Params.article.heroStyle }}{{ end }}
+      {{ if not $heroStyle }}{{ $heroStyle = site.Params.article.heroStyle }}{{ end }}
       {{ $heroStyle := print "hero/" $heroStyle ".html" }}
       {{ if templates.Exists ( printf "partials/%s" $heroStyle ) }}
         {{ partial $heroStyle . }}
@@ -14,9 +13,9 @@
       {{ end }}
     {{ end }}
 
-
+    {{/* Header */}}
     <header id="single_header" class="mt-5 max-w-prose">
-      {{ if .Params.showBreadcrumbs | default (.Site.Params.article.showBreadcrumbs | default false) }}
+      {{ if .Params.showBreadcrumbs | default (site.Params.article.showBreadcrumbs | default false) }}
         {{ partial "breadcrumbs.html" . }}
       {{ end }}
       <h1 class="mt-0 text-4xl font-extrabold text-neutral-900 dark:text-neutral">
@@ -25,33 +24,24 @@
       <div class="mt-1 mb-6 text-base text-neutral-500 dark:text-neutral-400 print:hidden">
         {{ partial "article-meta/basic.html" (dict "context" . "scope" "single") }}
       </div>
-
-      {{ if not (.Params.showAuthorBottom | default ( .Site.Params.article.showAuthorBottom | default false)) }}
+      {{ if not (.Params.showAuthorBottom | default (site.Params.article.showAuthorBottom | default false)) }}
         {{ template "SingleAuthor" . }}
       {{ end }}
-
     </header>
 
+    {{/* Body */}}
     <section class="flex flex-col max-w-full mt-0 prose dark:prose-invert lg:flex-row">
-      {{ if or (and (.Params.showTableOfContents | default (.Site.Params.article.showTableOfContents | default false)) (in
-        .TableOfContents "<ul")) (.Site.Params.article.showRelatedPosts | default false)
-      }}
+      {{ $enableToc := .Params.showTableOfContents | default (site.Params.list.showTableOfContents | default false) }}
+      {{ $showToc := and $enableToc (in .TableOfContents "<ul") }}
+      {{ $showRelated := site.Params.article.showRelatedPosts | default false }}
+      {{ $topClass := cond (hasPrefix site.Params.header.layout "fixed") "lg:top-[140px]" "lg:top-10" }}
+      {{ if or $showToc $showRelated }}
         <div class="order-first lg:ml-auto px-0 lg:order-last ltr:lg:pl-8 rtl:lg:pr-8">
-          <div
-            class="toc ltr:pl-5 rtl:pr-5 print:hidden lg:sticky {{ if hasPrefix .Site.Params.header.layout "fixed" -}}
-              lg:top-[140px]
-            {{ else }}
-              lg:top-10
-            {{ end }}
-            ">
-            {{ if and (.Params.showTableOfContents | default (.Site.Params.article.showTableOfContents | default false)) (in
-              .TableOfContents "<ul")
-            }}
+          <div class="toc ltr:pl-5 rtl:pr-5 print:hidden lg:sticky {{ $topClass }}">
+            {{ if $showToc }}
               {{ partial "toc.html" . }}
             {{ end }}
-            {{ if .Site.Params.article.showRelatedPosts |
-              default false
-            }}
+            {{ if $showRelated }}
               sd
             {{ end }}
           </div>
@@ -61,28 +51,24 @@
 
       <div class="min-w-0 min-h-0 max-w-fit">
         {{ partial "series/series.html" . }}
-
-
         <div class="article-content max-w-prose mb-20">
           {{ .Content }}
-          {{ $defaultReplyByEmail := .Site.Params.replyByEmail }}
+          {{ $defaultReplyByEmail := site.Params.replyByEmail }}
           {{ $replyByEmail := default $defaultReplyByEmail .Params.replyByEmail }}
           {{ if $replyByEmail }}
             <strong class="block mt-8">
               <a
                 target="_blank"
                 class="m-1 rounded bg-neutral-300 p-1.5 text-neutral-700 hover:bg-primary-500 hover:text-neutral dark:bg-neutral-700 dark:text-neutral-300 dark:hover:bg-primary-400 dark:hover:text-neutral-800"
-                href="mailto:{{ .Site.Params.Author.email }}?subject={{ replace (printf "Reply to %s" .Title) "\"" "'" }}">
+                href="mailto:{{ site.Params.Author.email }}?subject={{ replace (printf "Reply to %s" .Title) "\"" "'" }}">
                 Reply by Email
               </a>
             </strong>
           {{ end }}
         </div>
-
-        {{ if (.Params.showAuthorBottom | default ( .Site.Params.article.showAuthorBottom | default false)) }}
+        {{ if (.Params.showAuthorBottom | default (site.Params.article.showAuthorBottom | default false)) }}
           {{ template "SingleAuthor" . }}
         {{ end }}
-
         {{ partial "series/series-closed.html" . }}
         {{ partial "sharing-links.html" . }}
         {{ partial "related.html" . }}
@@ -96,7 +82,7 @@
           {{ $path = replace $path $lang ".md" }}
         {{ end }}
         {{ $jsPage := resources.Get "js/page.js" }}
-        {{ $jsPage = $jsPage | resources.Minify | resources.Fingerprint ($.Site.Params.fingerprintAlgorithm | default "sha512") }}
+        {{ $jsPage = $jsPage | resources.Minify | resources.Fingerprint (site.Params.fingerprintAlgorithm | default "sha512") }}
         <script
           type="text/javascript"
           src="{{ $jsPage.RelPermalink }}"
@@ -104,11 +90,12 @@
           data-oid="views_{{ $path }}"
           data-oid-likes="likes_{{ $path }}"></script>
       {{ end }}
-
     </section>
+
+    {{/* Footer */}}
     <footer class="pt-8 max-w-prose print:hidden">
       {{ partial "article-pagination.html" . }}
-      {{ if .Params.showComments | default (.Site.Params.article.showComments | default false) }}
+      {{ if .Params.showComments | default (site.Params.article.showComments | default false) }}
         {{ if templates.Exists "partials/comments.html" }}
           <div class="pt-3">
             <hr class="border-dotted border-neutral-300 dark:border-neutral-600">
@@ -125,18 +112,18 @@
 {{ end }}
 
 {{ define "SingleAuthor" }}
-  {{ $authorsData := .Site.Data.authors }}
-  {{ $taxonomies := .Site.Taxonomies.authors }}
-  {{ $baseURL := .Site.BaseURL }}
+  {{ $authorsData := site.Data.authors }}
+  {{ $taxonomies := site.Taxonomies.authors }}
+  {{ $baseURL := site.BaseURL }}
   {{ $taxonomyLink := 0 }}
   {{ $showAuthor := 0 }}
-  {{ $isAuthorBottom := (.Params.showAuthorBottom | default ( .Site.Params.article.showAuthorBottom | default false)) }}
+  {{ $isAuthorBottom := (.Params.showAuthorBottom | default ( site.Params.article.showAuthorBottom | default false)) }}
 
   {{ if not (strings.HasSuffix $baseURL "/") }}
     {{ $baseURL = delimit (slice $baseURL "/") "" }}
   {{ end }}
 
-  {{ if .Params.showAuthor | default (.Site.Params.article.showAuthor | default true) }}
+  {{ if .Params.showAuthor | default (site.Params.article.showAuthor | default true) }}
     {{ $showAuthor = 1 }}
     {{ partial "author.html" . }}
   {{ end }}
@@ -151,13 +138,12 @@
       {{ end }}
 
       {{ $finalLink := $taxonomyLink }}
-      {{ $currentLang := $.Site.Language.Lang }}
-      {{ if eq $.Site.LanguagePrefix "" }}
+      {{ $currentLang := site.Language.Lang }}
+      {{ if eq site.LanguagePrefix "" }}
         {{ $finalLink = printf "%sauthors/%s/" $baseURL $author }}
       {{ else }}
         {{ $finalLink = printf "%s%s/authors/%s/" $baseURL $currentLang $author }}
       {{ end }}
-
       {{ partial "author-extra.html" (dict "context" . "data" $authorData "link" $finalLink) }}
     {{- end -}}
   {{ end }}

--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
   {{ .Scratch.Set "scope" "term" }}
-  {{ if .Site.Params.term.showHero | default false }}
-    {{ $heroStyle := print "hero/" .Site.Params.term.heroStyle ".html" }}
+  {{ if site.Params.term.showHero | default false }}
+    {{ $heroStyle := print "hero/" site.Params.term.heroStyle ".html" }}
     {{ if templates.Exists ( printf "partials/%s" $heroStyle ) }}
       {{ partial $heroStyle . }}
     {{ else }}
@@ -9,11 +9,9 @@
     {{ end }}
   {{- end -}}
 
-  {{ $toc := and (.Params.showTableOfContents | default (.Site.Params.term.showTableOfContents | default false)) (in
-    .TableOfContents "<ul")
-  }}
+
   <header>
-    {{ if .Params.showBreadcrumbs | default (.Site.Params.term.showBreadcrumbs | default false) }}
+    {{ if .Params.showBreadcrumbs | default (site.Params.term.showBreadcrumbs | default false) }}
       {{ partial "breadcrumbs.html" . }}
     {{ end }}
     <h1 class="mt-5 text-4xl font-extrabold text-neutral-900 dark:text-neutral">{{ .Title }}</h1>
@@ -28,7 +26,7 @@
         {{ .Content }}
       </div>
       {{ $jsPage := resources.Get "js/page.js" }}
-      {{ $jsPage = $jsPage | resources.Minify | resources.Fingerprint (.Site.Params.fingerprintAlgorithm | default "sha512") }}
+      {{ $jsPage = $jsPage | resources.Minify | resources.Fingerprint (site.Params.fingerprintAlgorithm | default "sha512") }}
       <script
         type="text/javascript"
         src="{{ $jsPage.RelPermalink }}"
@@ -39,9 +37,9 @@
   </section>
 
   {{ if gt .Pages 0 }}
-    {{ $cardView := .Params.cardView | default (.Site.Params.term.cardView | default false) }}
-    {{ $cardViewScreenWidth := .Site.Params.term.cardViewScreenWidth | default false }}
-    {{ $groupByYear := .Params.groupByYear | default ($.Site.Params.term.groupByYear | default false) }}
+    {{ $cardView := .Params.cardView | default (site.Params.term.cardView | default false) }}
+    {{ $cardViewScreenWidth := site.Params.term.cardViewScreenWidth | default false }}
+    {{ $groupByYear := .Params.groupByYear | default (site.Params.term.groupByYear | default false) }}
 
     {{ if not $cardView }}
 
@@ -124,5 +122,4 @@
   {{ end }}
 
   {{ partial "pagination.html" . }}
-
 {{ end }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
   {{ .Scratch.Set "scope" "list" }}
-  {{ if .Site.Params.taxonomy.showHero | default false }}
-    {{ $heroStyle := print "hero/" .Site.Params.taxonomy.heroStyle ".html" }}
+  {{ if site.Params.taxonomy.showHero | default false }}
+    {{ $heroStyle := print "hero/" site.Params.taxonomy.heroStyle ".html" }}
     {{ if templates.Exists ( printf "partials/%s" $heroStyle ) }}
       {{ partial $heroStyle . }}
     {{ else }}
@@ -9,13 +9,9 @@
     {{ end }}
   {{- end -}}
 
-  {{ $toc := and (.Params.showTableOfContents | default (.Site.Params.taxonomy.showTableOfContents | default false)) (in
-    .TableOfContents "<ul")
-  }}
-
 
   <header>
-    {{ if .Params.showBreadcrumbs | default (.Site.Params.taxonomy.showBreadcrumbs | default false) }}
+    {{ if .Params.showBreadcrumbs | default (site.Params.taxonomy.showBreadcrumbs | default false) }}
       {{ partial "breadcrumbs.html" . }}
     {{ end }}
     <h1 class="mt-5 text-4xl font-extrabold text-neutral-900 dark:text-neutral">{{ .Title }}</h1>
@@ -30,7 +26,7 @@
       </div>
     </section>
     {{ $jsPage := resources.Get "js/page.js" }}
-    {{ $jsPage = $jsPage | resources.Minify | resources.Fingerprint (.Site.Params.fingerprintAlgorithm | default "sha512") }}
+    {{ $jsPage = $jsPage | resources.Minify | resources.Fingerprint (site.Params.fingerprintAlgorithm | default "sha512") }}
     <script
       type="text/javascript"
       src="{{ $jsPage.RelPermalink }}"
@@ -39,7 +35,7 @@
       data-oid-likes="likes_taxonomy_{{ .Data.Plural }}"></script>
   {{ end }}
 
-  {{ if .Site.Params.taxonomy.cardView }}
+  {{ if site.Params.taxonomy.cardView }}
     <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3">
       {{ range .Data.Terms }}
         {{ partial "term-link/card.html" . }}


### PR DESCRIPTION
This PR includes:

1. Using the global [`site`](https://gohugo.io/functions/global/site) function instead of `.Site`
    > To simplify your templates, use the global site function regardless of whether the Site object is in context.
2. Adding comments to improve readability
3. Making `list.html` formattable
4. Modularize the author section in `single.html`

I originally want to modularize everything (#2346 #2347), but decided to keep it minimal to avoid unnecessary coupling.
