### PR TITLE
:ambulance: Hotfix: Fix incorrect href in article shortcode

### DIFF
--- a/layouts/partials/article-link/_shortcode.html
+++ b/layouts/partials/article-link/_shortcode.html
@@ -30,7 +30,7 @@
 {{ end }}
 
 
-<a class="{{ $articleClasses }}" {{ partial "article-link/_external-link.html" . | safeHTMLAttr }}>
+<a class="{{ $articleClasses }}" {{ partial "article-link/_external-link.html" $target | safeHTMLAttr }}>
   {{- with $target.Params.images -}}
     {{- range first 6 . }}
       <meta property="og:image" content="{{ . | absURL }}">


### PR DESCRIPTION
Without this, the `href` in the article shortcode will be to the current page not the specified `link=`.

Also see: https://github.com/nunocoracao/blowfish/pull/2297#issuecomment-3085165961

@nunocoracao please merge this before publishing the next release. Thanks in advance!

:warning: There are probably merge conflicts with https://github.com/nunocoracao/blowfish/pull/2351 . To fix without me just merge https://github.com/nunocoracao/blowfish/pull/2351 first and then merge only the change to `$target` from this.