### PR TITLE
🐛 Fix(icon): trim white space and line break

### DIFF
--- a/layouts/partials/icon.html
+++ b/layouts/partials/icon.html
@@ -1,6 +1,6 @@
-{{ $icon := resources.Get (print "icons/" . ".svg") }}
-{{ if $icon }}
+{{- $icon := resources.Get (print "icons/" . ".svg") -}}
+{{- if $icon -}}
   <span class="relative block icon">
-    {{ $icon.Content | safeHTML }}
+    {{- $icon.Content | safeHTML -}}
   </span>
-{{ end }}
+{{- end -}}

--- a/layouts/shortcodes/icon.html
+++ b/layouts/shortcodes/icon.html
@@ -1,8 +1,10 @@
-{{ $icon := resources.Get (printf "icons/%s.svg" ($.Get 0)) }}
-{{ if $icon }}
+{{- /* Avoid extra whitespace */ -}}
+{{- /* https://discourse.gohugo.io/t/55399/5 */ -}}
+{{- $icon := resources.Get (printf "icons/%s.svg" ($.Get 0)) -}}
+{{- if $icon -}}
   <span class="relative inline-block align-text-bottom icon">
-    {{ $icon.Content | safeHTML }}
+    {{- strings.Replace $icon.Content "\n" "" | safeHTML -}}
   </span>
-{{ else }}
-  {{ errorf `[BLOWFISH] Shortcode "icon" error in "%s": Resource "%s" not found. Check the path is correct or remove the shortcode.` .Page.Path (printf "icons/%s.svg" ($.Get 0)) }}
-{{ end }}
+{{- else -}}
+  {{- errorf `icon shortcode: resource "%s" not found. Check the path is correct or remove the shortcode: %s` (printf "icons/%s.svg" ($.Get 0)) .Position -}}
+{{- end -}}


### PR DESCRIPTION
Closes #2371, see [this](https://discourse.gohugo.io/t/tableofcontents-doesnt-render-headings-correctly-that-contains-shortcode/55399/5). Also aligns the error message with other repo cards.