### PR TITLE
💄 Style(header): highlightCurrentMenuArea in desktop menu (#2381)

### DIFF
--- a/layouts/partials/header/header-option-nested.html
+++ b/layouts/partials/header/header-option-nested.html
@@ -14,7 +14,9 @@
       {{ end }}
       class="text-base font-medium text-gray-500 hover:text-primary-600 dark:hover:text-primary-400"
       title="{{ .Title }}">
-      {{ .Name | markdownify }}
+      <p>
+        {{ .Name | markdownify }}
+      </p>
     </a>
     <span>
       {{ partial "icon.html" "chevron-down" }}


### PR DESCRIPTION
Closes #2381.