### PR TITLE
♻️ Refactor(CSS): use logical properties for language direction

### DIFF
--- a/assets/css/compiled/main.css
+++ b/assets/css/compiled/main.css
@@ -425,6 +425,12 @@ body.zen-mode-enable {
   .inset-x-0 {
     inset-inline: calc(var(--spacing) * 0);
   }
+  .-start-6 {
+    inset-inline-start: calc(var(--spacing) * -6);
+  }
+  .end-0 {
+    inset-inline-end: calc(var(--spacing) * 0);
+  }
   .top-0 {
     top: calc(var(--spacing) * 0);
   }
@@ -550,6 +556,24 @@ body.zen-mode-enable {
   }
   .my-3 {
     margin-block: calc(var(--spacing) * 3);
+  }
+  .-ms-5 {
+    margin-inline-start: calc(var(--spacing) * -5);
+  }
+  .ms-0 {
+    margin-inline-start: calc(var(--spacing) * 0);
+  }
+  .ms-2 {
+    margin-inline-start: calc(var(--spacing) * 2);
+  }
+  .me-1 {
+    margin-inline-end: calc(var(--spacing) * 1);
+  }
+  .me-2 {
+    margin-inline-end: calc(var(--spacing) * 2);
+  }
+  .me-4 {
+    margin-inline-end: calc(var(--spacing) * 4);
   }
   .prose {
     color: var(--tw-prose-body);
@@ -1068,9 +1092,6 @@ body.zen-mode-enable {
   }
   .mr-5 {
     margin-right: calc(var(--spacing) * 5);
-  }
-  .mr-\[10px\] {
-    margin-right: 10px;
   }
   .mr-auto {
     margin-right: auto;
@@ -1658,6 +1679,10 @@ body.zen-mode-enable {
     border-inline-start-style: var(--tw-border-style);
     border-inline-start-width: 0px;
   }
+  .border-s-1 {
+    border-inline-start-style: var(--tw-border-style);
+    border-inline-start-width: 1px;
+  }
   .border-s-\[0\.125rem\] {
     border-inline-start-style: var(--tw-border-style);
     border-inline-start-width: 0.125rem;
@@ -1929,6 +1954,15 @@ body.zen-mode-enable {
   .py-\[1px\] {
     padding-block: 1px;
   }
+  .ps-5 {
+    padding-inline-start: calc(var(--spacing) * 5);
+  }
+  .pe-2 {
+    padding-inline-end: calc(var(--spacing) * 2);
+  }
+  .pe-3 {
+    padding-inline-end: calc(var(--spacing) * 3);
+  }
   .pt-1 {
     padding-top: calc(var(--spacing) * 1);
   }
@@ -1994,6 +2028,9 @@ body.zen-mode-enable {
   }
   .text-center {
     text-align: center;
+  }
+  .text-end {
+    text-align: end;
   }
   .text-left {
     text-align: left;
@@ -2740,6 +2777,11 @@ body.zen-mode-enable {
       transition-property: none;
     }
   }
+  .sm\:me-7 {
+    @media (width >= 640px) {
+      margin-inline-end: calc(var(--spacing) * 7);
+    }
+  }
   .sm\:mt-16 {
     @media (width >= 640px) {
       margin-top: calc(var(--spacing) * 16);
@@ -2794,6 +2836,13 @@ body.zen-mode-enable {
     @media (width >= 640px) {
       font-size: var(--text-lg);
       line-height: var(--tw-leading, var(--text-lg--line-height));
+    }
+  }
+  .sm\:last\:me-0 {
+    @media (width >= 640px) {
+      &:last-child {
+        margin-inline-end: calc(var(--spacing) * 0);
+      }
     }
   }
   .md\:mt-0 {
@@ -3031,6 +3080,11 @@ body.zen-mode-enable {
       padding-block: calc(var(--spacing) * 32);
     }
   }
+  .lg\:ps-8 {
+    @media (width >= 1024px) {
+      padding-inline-start: calc(var(--spacing) * 8);
+    }
+  }
   .xl\:w-1\/4 {
     @media (width >= 1280px) {
       width: calc(1/4 * 100%);
@@ -3044,41 +3098,6 @@ body.zen-mode-enable {
   .\32 xl\:grid-cols-5 {
     @media (width >= 1536px) {
       grid-template-columns: repeat(5, minmax(0, 1fr));
-    }
-  }
-  .ltr\:right-0 {
-    &:where(:dir(ltr), [dir="ltr"], [dir="ltr"] *) {
-      right: calc(var(--spacing) * 0);
-    }
-  }
-  .ltr\:-left-6 {
-    &:where(:dir(ltr), [dir="ltr"], [dir="ltr"] *) {
-      left: calc(var(--spacing) * -6);
-    }
-  }
-  .ltr\:mr-1 {
-    &:where(:dir(ltr), [dir="ltr"], [dir="ltr"] *) {
-      margin-right: calc(var(--spacing) * 1);
-    }
-  }
-  .ltr\:mr-4 {
-    &:where(:dir(ltr), [dir="ltr"], [dir="ltr"] *) {
-      margin-right: calc(var(--spacing) * 4);
-    }
-  }
-  .ltr\:-ml-5 {
-    &:where(:dir(ltr), [dir="ltr"], [dir="ltr"] *) {
-      margin-left: calc(var(--spacing) * -5);
-    }
-  }
-  .ltr\:ml-0 {
-    &:where(:dir(ltr), [dir="ltr"], [dir="ltr"] *) {
-      margin-left: calc(var(--spacing) * 0);
-    }
-  }
-  .ltr\:ml-2 {
-    &:where(:dir(ltr), [dir="ltr"], [dir="ltr"] *) {
-      margin-left: calc(var(--spacing) * 2);
     }
   }
   .ltr\:block {
@@ -3096,88 +3115,9 @@ body.zen-mode-enable {
       display: inline;
     }
   }
-  .ltr\:border-l {
-    &:where(:dir(ltr), [dir="ltr"], [dir="ltr"] *) {
-      border-left-style: var(--tw-border-style);
-      border-left-width: 1px;
-    }
-  }
-  .ltr\:pr-2 {
-    &:where(:dir(ltr), [dir="ltr"], [dir="ltr"] *) {
-      padding-right: calc(var(--spacing) * 2);
-    }
-  }
-  .ltr\:pr-3 {
-    &:where(:dir(ltr), [dir="ltr"], [dir="ltr"] *) {
-      padding-right: calc(var(--spacing) * 3);
-    }
-  }
-  .ltr\:pl-5 {
-    &:where(:dir(ltr), [dir="ltr"], [dir="ltr"] *) {
-      padding-left: calc(var(--spacing) * 5);
-    }
-  }
   .ltr\:text-right {
     &:where(:dir(ltr), [dir="ltr"], [dir="ltr"] *) {
       text-align: right;
-    }
-  }
-  .ltr\:sm\:mr-7 {
-    &:where(:dir(ltr), [dir="ltr"], [dir="ltr"] *) {
-      @media (width >= 640px) {
-        margin-right: calc(var(--spacing) * 7);
-      }
-    }
-  }
-  .ltr\:sm\:last\:mr-0 {
-    &:where(:dir(ltr), [dir="ltr"], [dir="ltr"] *) {
-      @media (width >= 640px) {
-        &:last-child {
-          margin-right: calc(var(--spacing) * 0);
-        }
-      }
-    }
-  }
-  .ltr\:lg\:pl-8 {
-    &:where(:dir(ltr), [dir="ltr"], [dir="ltr"] *) {
-      @media (width >= 1024px) {
-        padding-left: calc(var(--spacing) * 8);
-      }
-    }
-  }
-  .rtl\:-right-6 {
-    &:where(:dir(rtl), [dir="rtl"], [dir="rtl"] *) {
-      right: calc(var(--spacing) * -6);
-    }
-  }
-  .rtl\:left-0 {
-    &:where(:dir(rtl), [dir="rtl"], [dir="rtl"] *) {
-      left: calc(var(--spacing) * 0);
-    }
-  }
-  .rtl\:-mr-5 {
-    &:where(:dir(rtl), [dir="rtl"], [dir="rtl"] *) {
-      margin-right: calc(var(--spacing) * -5);
-    }
-  }
-  .rtl\:mr-0 {
-    &:where(:dir(rtl), [dir="rtl"], [dir="rtl"] *) {
-      margin-right: calc(var(--spacing) * 0);
-    }
-  }
-  .rtl\:mr-2 {
-    &:where(:dir(rtl), [dir="rtl"], [dir="rtl"] *) {
-      margin-right: calc(var(--spacing) * 2);
-    }
-  }
-  .rtl\:ml-1 {
-    &:where(:dir(rtl), [dir="rtl"], [dir="rtl"] *) {
-      margin-left: calc(var(--spacing) * 1);
-    }
-  }
-  .rtl\:ml-4 {
-    &:where(:dir(rtl), [dir="rtl"], [dir="rtl"] *) {
-      margin-left: calc(var(--spacing) * 4);
     }
   }
   .rtl\:block {
@@ -3193,55 +3133,6 @@ body.zen-mode-enable {
   .rtl\:inline {
     &:where(:dir(rtl), [dir="rtl"], [dir="rtl"] *) {
       display: inline;
-    }
-  }
-  .rtl\:border-r {
-    &:where(:dir(rtl), [dir="rtl"], [dir="rtl"] *) {
-      border-right-style: var(--tw-border-style);
-      border-right-width: 1px;
-    }
-  }
-  .rtl\:pr-5 {
-    &:where(:dir(rtl), [dir="rtl"], [dir="rtl"] *) {
-      padding-right: calc(var(--spacing) * 5);
-    }
-  }
-  .rtl\:pl-2 {
-    &:where(:dir(rtl), [dir="rtl"], [dir="rtl"] *) {
-      padding-left: calc(var(--spacing) * 2);
-    }
-  }
-  .rtl\:pl-3 {
-    &:where(:dir(rtl), [dir="rtl"], [dir="rtl"] *) {
-      padding-left: calc(var(--spacing) * 3);
-    }
-  }
-  .rtl\:text-left {
-    &:where(:dir(rtl), [dir="rtl"], [dir="rtl"] *) {
-      text-align: left;
-    }
-  }
-  .rtl\:sm\:ml-7 {
-    &:where(:dir(rtl), [dir="rtl"], [dir="rtl"] *) {
-      @media (width >= 640px) {
-        margin-left: calc(var(--spacing) * 7);
-      }
-    }
-  }
-  .rtl\:sm\:last\:ml-0 {
-    &:where(:dir(rtl), [dir="rtl"], [dir="rtl"] *) {
-      @media (width >= 640px) {
-        &:last-child {
-          margin-left: calc(var(--spacing) * 0);
-        }
-      }
-    }
-  }
-  .rtl\:lg\:pr-8 {
-    &:where(:dir(rtl), [dir="rtl"], [dir="rtl"] *) {
-      @media (width >= 1024px) {
-        padding-right: calc(var(--spacing) * 8);
-      }
     }
   }
   .dark\:flex {

--- a/exampleSite/content/_index.it.md
+++ b/exampleSite/content/_index.it.md
@@ -3,7 +3,7 @@ title: "Benvenuti a Blowfish!"
 description: "Questa pagina è stata creata utilizzando il tema Blowfish per Hugo."
 ---
 <div class="flex px-4 py-2 mb-8 text-base rounded-md bg-primary-100 dark:bg-primary-900">
-  <span class="flex items-center ltr:pr-3 rtl:pl-3 text-primary-400">
+  <span class="flex items-center pe-3 text-primary-400">
     {{< icon "triangle-exclamation" >}}
   </span>
   <span class="flex items-center justify-between grow dark:text-neutral-300">

--- a/exampleSite/content/_index.ja.md
+++ b/exampleSite/content/_index.ja.md
@@ -5,7 +5,7 @@ description: "このページは Hugo の Blowfish テーマを利用して構�
 
 
 <div class="flex px-4 py-2 mb-8 text-base rounded-md bg-primary-100 dark:bg-primary-900">
-  <span class="flex items-center ltr:pr-3 rtl:pl-3 text-primary-400">
+  <span class="flex items-center pe-3 text-primary-400">
     {{< icon "triangle-exclamation" >}}
   </span>
   <span class="flex items-center justify-between grow dark:text-neutral-300">

--- a/exampleSite/content/_index.md
+++ b/exampleSite/content/_index.md
@@ -5,7 +5,7 @@ description: "This page was built using the Blowfish theme for Hugo."
 
 
 <div class="flex px-4 py-2 mb-8 text-base rounded-md bg-primary-100 dark:bg-primary-900">
-  <span class="flex items-center ltr:pr-3 rtl:pl-3 text-primary-400">
+  <span class="flex items-center pe-3 text-primary-400">
     {{< icon "triangle-exclamation" >}}
   </span>
   <span class="flex items-center justify-between grow dark:text-neutral-300">

--- a/exampleSite/content/_index.zh-cn.md
+++ b/exampleSite/content/_index.zh-cn.md
@@ -5,7 +5,7 @@ description: "此页面是使用 Hugo 的 Blowfish 主题搭建的"
 
 
 <div class="flex px-4 py-2 mb-8 text-base rounded-md bg-primary-100 dark:bg-primary-900">
-  <span class="flex items-center ltr:pr-3 rtl:pl-3 text-primary-400">
+  <span class="flex items-center pe-3 text-primary-400">
     {{< icon "triangle-exclamation" >}}
   </span>
   <span class="flex items-center justify-between grow dark:text-neutral-300">

--- a/layouts/_default/_markup/render-heading.html
+++ b/layouts/_default/_markup/render-heading.html
@@ -3,7 +3,7 @@
     <div id="{{ $anchor }}" class="anchor"></div>
     {{ if .Page.Params.showHeadingAnchors | default (.Page.Site.Params.article.showHeadingAnchors | default true) }}
     <span
-        class="absolute top-0 w-6 transition-opacity opacity-0 ltr:-left-6 rtl:-right-6 not-prose group-hover:opacity-100 select-none">
+        class="absolute top-0 w-6 transition-opacity opacity-0 -start-6 not-prose group-hover:opacity-100 select-none">
         <a class="group-hover:text-primary-300 dark:group-hover:text-neutral-700 !no-underline" href="#{{ $anchor }}" aria-label="{{ i18n "article.anchor_label" }}">#</a>
     </span>        
     {{ end }}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -18,7 +18,7 @@
       <a
         class="px-3 py-1 text-sm -translate-y-8 rounded-b-lg bg-primary-200 focus:translate-y-0 dark:bg-neutral-600"
         href="#main-content">
-        <span class="font-bold text-primary-600 ltr:pr-2 rtl:pl-2 dark:text-primary-400">&darr;</span>
+        <span class="font-bold text-primary-600 pe-2 dark:text-primary-400">&darr;</span>
         {{ i18n "nav.skip_to_main" }}
       </a>
     </div>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -45,8 +45,8 @@
   {{ $topClass := cond (hasPrefix site.Params.header.layout "fixed") "lg:top-[140px]" "lg:top-10" }}
   <section class="{{ $tocMargin }} prose flex max-w-full flex-col dark:prose-invert lg:flex-row">
     {{ if $showToc }}
-      <div class="order-first px-0 lg:order-last lg:max-w-xs ltr:lg:pl-8 rtl:lg:pr-8">
-        <div class="toc ltr:pl-5 rtl:pr-5 lg:sticky {{ $topClass }}">
+      <div class="order-first px-0 lg:order-last lg:max-w-xs lg:ps-8">
+        <div class="toc ps-5 lg:sticky {{ $topClass }}">
           {{ partial "toc.html" . }}
         </div>
       </div>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -36,8 +36,8 @@
       {{ $showRelated := site.Params.article.showRelatedPosts | default false }}
       {{ $topClass := cond (hasPrefix site.Params.header.layout "fixed") "lg:top-[140px]" "lg:top-10" }}
       {{ if or $showToc $showRelated }}
-        <div class="order-first lg:ml-auto px-0 lg:order-last ltr:lg:pl-8 rtl:lg:pr-8">
-          <div class="toc ltr:pl-5 rtl:pr-5 print:hidden lg:sticky {{ $topClass }}">
+        <div class="order-first lg:ml-auto px-0 lg:order-last lg:ps-8">
+          <div class="toc ps-5 print:hidden lg:sticky {{ $topClass }}">
             {{ if $showToc }}
               {{ partial "toc.html" . }}
             {{ end }}

--- a/layouts/partials/article-link/_shortcode.html
+++ b/layouts/partials/article-link/_shortcode.html
@@ -86,7 +86,7 @@
         </div>
       {{ end }}
       {{ if and $target.Draft site.Params.article.showDraftLabel }}
-        <div class="ltr:ml-2 rtl:mr-2">
+        <div class="ms-2">
           {{ partial "badge.html" (i18n "article.draft" | emojify) }}
         </div>
       {{ end }}

--- a/layouts/partials/article-link/simple.html
+++ b/layouts/partials/article-link/simple.html
@@ -85,7 +85,7 @@
         </div>
       {{ end }}
       {{ if and .Draft .Site.Params.article.showDraftLabel }}
-        <div class="ltr:ml-2 rtl:mr-2">{{ partial "badge.html" (i18n "article.draft" | emojify) }}</div>
+        <div class="ms-2">{{ partial "badge.html" (i18n "article.draft" | emojify) }}</div>
       {{ end }}
       {{ if templates.Exists "partials/extend-article-link.html" }}
         {{ partial "extend-article-link.html" . }}

--- a/layouts/partials/author-extra.html
+++ b/layouts/partials/author-extra.html
@@ -12,7 +12,7 @@
         {{ $authorImage = $authorImage.Fill "192x192" }}
       {{ end }}
       <img
-        class="!mt-0 !mb-0 h-24 w-24 rounded-full ltr:mr-4 rtl:ml-4"
+        class="!mt-0 !mb-0 h-24 w-24 rounded-full me-4"
         width="96"
         height="96"
         src="{{ $authorImage.RelPermalink }}">

--- a/layouts/partials/author.html
+++ b/layouts/partials/author.html
@@ -12,7 +12,7 @@
         {{ $authorImage = $authorImage.Fill "192x192" }}
       {{ end }}
       <img
-        class="!mt-0 !mb-0 h-24 w-24 rounded-full ltr:mr-4 rtl:ml-4"
+        class="!mt-0 !mb-0 h-24 w-24 rounded-full me-4"
         width="96"
         height="96"
         alt="{{ $.Site.Params.Author.name | default " Author" }}"
@@ -23,7 +23,7 @@
         {{ $authorImage = $authorImage.Fill "192x192" }}
       {{ end }}
       <img
-        class="!mt-0 !mb-0 h-24 w-24 rounded-full ltr:mr-4 rtl:ml-4"
+        class="!mt-0 !mb-0 h-24 w-24 rounded-full me-4"
         width="96"
         height="96"
         alt="{{ $.Site.Params.Author.name | default " Author" }}"

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -6,7 +6,7 @@
         <ul class="flex flex-col list-none sm:flex-row">
           {{ range .Site.Menus.footer }}
             <li
-              class="flex mb-1 ltr:text-right rtl:text-left sm:mb-0 ltr:sm:mr-7 ltr:sm:last:mr-0 rtl:sm:ml-7 rtl:sm:last:ml-0">
+              class="flex mb-1 text-end sm:mb-0 sm:me-7 sm:last:me-0">
               <a
                 class="decoration-primary-500 hover:underline hover:decoration-2 hover:underline-offset-2 flex items-center"
                 href="{{ .URL }}"

--- a/layouts/partials/header/basic.html
+++ b/layouts/partials/header/basic.html
@@ -85,7 +85,7 @@
         id="appearance-switcher-mobile"
         aria-label="Dark mode switcher"
         type="button"
-        class="text-base hover:text-primary-600 dark:hover:text-primary-400 ltr:mr-1 rtl:ml-1">
+        class="text-base hover:text-primary-600 dark:hover:text-primary-400 me-1">
         <div class="flex items-center justify-center dark:hidden">
           {{ partial "icon.html" "moon" }}
         </div>
@@ -108,7 +108,7 @@
           id="menu-wrapper"
           class="fixed inset-0 z-30 invisible w-screen h-screen m-0 overflow-auto transition-opacity opacity-0 cursor-default bg-neutral-100/50 backdrop-blur-sm dark:bg-neutral-900/50 pt-[5px]">
           <ul
-            class="flex space-y-2 mt-3 flex-col items-end w-full px-6 py-6 mx-auto overflow-visible list-none ltr:text-right rtl:text-left max-w-7xl">
+            class="flex space-y-2 mt-3 flex-col items-end w-full px-6 py-6 mx-auto overflow-visible list-none text-end max-w-7xl">
             <li id="menu-close-button">
               <span
                 class="cursor-pointer inline-block align-text-bottom hover:text-primary-600 dark:hover:text-primary-400">
@@ -124,7 +124,7 @@
           {{ if .Site.Menus.subnavigation }}
             <hr>
             <ul
-              class="flex mt-4 flex-col items-end w-full px-6 py-6 mx-auto overflow-visible list-none ltr:text-right rtl:text-left max-w-7xl">
+              class="flex mt-4 flex-col items-end w-full px-6 py-6 mx-auto overflow-visible list-none text-end max-w-7xl">
               {{ range .Site.Menus.subnavigation }}
                 <li class="mb-1">
                   <a

--- a/layouts/partials/scroll-to-top.html
+++ b/layouts/partials/scroll-to-top.html
@@ -1,4 +1,4 @@
-<div id="top-scroller" class="pointer-events-none absolute top-[110vh] bottom-0 w-12 ltr:right-0 rtl:left-0">
+<div id="top-scroller" class="pointer-events-none absolute top-[110vh] bottom-0 w-12 end-0">
   <a
     href="#the-top"
     class="pointer-events-auto sticky top-[calc(100vh-5.5rem)] flex h-12 w-12 mb-16 items-center justify-center rounded-full bg-neutral/50 text-xl text-neutral-700 hover:text-primary-600 dark:bg-neutral-800/50 dark:text-neutral dark:hover:text-primary-400"

--- a/layouts/partials/series/series-closed.html
+++ b/layouts/partials/series/series-closed.html
@@ -1,5 +1,5 @@
 {{ if .Params.series }}
-  <details class="mt-2 mb-5 overflow-hidden rounded-lg ltr:ml-0 ltr:pl-5 rtl:mr-0 rtl:pr-5">
+  <details class="mt-2 mb-5 overflow-hidden rounded-lg ms-0 ps-5">
     {{ partial "series/series_base.html" . }}
   </details>
 {{ end }}

--- a/layouts/partials/series/series.html
+++ b/layouts/partials/series/series.html
@@ -1,6 +1,6 @@
 {{ if .Params.series }}
   <details
-    class="mt-2 mb-5 overflow-hidden rounded-lg ltr:ml-0 ltr:pl-5 rtl:mr-0 rtl:pr-5"
+    class="mt-2 mb-5 overflow-hidden rounded-lg ms-0 ps-5"
     {{ if .Params.seriesOpened | default (.Site.Params.article.seriesOpened | default false) }}open{{ end }}>
     {{ partial "series/series_base.html" . }}
   </details>

--- a/layouts/partials/series/series_base.html
+++ b/layouts/partials/series/series_base.html
@@ -1,6 +1,6 @@
 {{ if .Params.series }}
   <summary
-    class="py-1 text-lg font-semibold cursor-pointer bg-primary-200 text-neutral-800 ltr:-ml-5 ltr:pl-5 rtl:-mr-5 rtl:pr-5 dark:bg-primary-800 dark:text-neutral-100">
+    class="py-1 text-lg font-semibold cursor-pointer bg-primary-200 text-neutral-800 -ms-5 ps-5 dark:bg-primary-800 dark:text-neutral-100">
     {{ index .Params.series 0 }} -
     {{ i18n "article.part_of_series" }}
   </summary>
@@ -8,13 +8,13 @@
   {{ range $post := sort (index .Site.Taxonomies.series $seriesName) "Params.series_order" }}
     {{ if eq $post.Permalink $.Page.Permalink }}
       <div
-        class="py-1 border-dotted border-neutral-300 ltr:-ml-5 ltr:border-l ltr:pl-5 rtl:-mr-5 rtl:border-r rtl:pr-5 dark:border-neutral-600">
+        class="py-1 border-dotted border-neutral-300 border-s-1 -ms-5 ps-5 dark:border-neutral-600">
         {{ i18n "article.part" }} {{ $post.Params.series_order }}:
         {{ i18n "article.this_article" }}
       </div>
     {{ else }}
       <div
-        class="py-1 border-dotted border-neutral-300 ltr:-ml-5 ltr:border-l ltr:pl-5 rtl:-mr-5 rtl:border-r rtl:pr-5 dark:border-neutral-600">
+        class="py-1 border-dotted border-neutral-300 border-s-1 -ms-5 ps-5 dark:border-neutral-600">
         <a href="{{ $post.RelPermalink }}">
           {{ i18n "article.part" }} {{ $post.Params.series_order }}:
           {{ $post.Params.title }}

--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -1,7 +1,7 @@
 <details
   open
   id="TOCView"
-  class="toc-right mt-0 overflow-y-auto overscroll-contain scrollbar-thin scrollbar-track-neutral-200 scrollbar-thumb-neutral-400 dark:scrollbar-track-neutral-800 dark:scrollbar-thumb-neutral-600 rounded-lg -ms-5 ps-5 hidden lg:block">
+  class="toc-right mt-0 overflow-y-auto overscroll-contain scrollbar-thin scrollbar-track-neutral-200 scrollbar-thumb-neutral-400 dark:scrollbar-track-neutral-800 dark:scrollbar-thumb-neutral-600 rounded-lg -ms-5 ps-5 pe-2 hidden lg:block">
   <summary
     class="block py-1 text-lg font-semibold cursor-pointer bg-neutral-100 text-neutral-800 -ms-5 ps-5 dark:bg-neutral-700 dark:text-neutral-100 lg:hidden">
     {{ i18n "article.table_of_contents" }}

--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -1,23 +1,23 @@
 <details
   open
   id="TOCView"
-  class="toc-right mt-0 overflow-y-auto overscroll-contain scrollbar-thin scrollbar-track-neutral-200 scrollbar-thumb-neutral-400 dark:scrollbar-track-neutral-800 dark:scrollbar-thumb-neutral-600 rounded-lg ltr:-ml-5 ltr:pl-5 rtl:-mr-5 rtl:pr-5 hidden lg:block">
+  class="toc-right mt-0 overflow-y-auto overscroll-contain scrollbar-thin scrollbar-track-neutral-200 scrollbar-thumb-neutral-400 dark:scrollbar-track-neutral-800 dark:scrollbar-thumb-neutral-600 rounded-lg -ms-5 ps-5 hidden lg:block">
   <summary
-    class="block py-1 text-lg font-semibold cursor-pointer bg-neutral-100 text-neutral-800 ltr:-ml-5 ltr:pl-5 rtl:-mr-5 rtl:pr-5 dark:bg-neutral-700 dark:text-neutral-100 lg:hidden">
+    class="block py-1 text-lg font-semibold cursor-pointer bg-neutral-100 text-neutral-800 -ms-5 ps-5 dark:bg-neutral-700 dark:text-neutral-100 lg:hidden">
     {{ i18n "article.table_of_contents" }}
   </summary>
   <div
-    class="min-w-[220px] py-2 border-dotted ltr:-ml-5 ltr:border-l ltr:pl-5 rtl:-mr-5 rtl:border-r rtl:pr-5 dark:border-neutral-600">
+    class="min-w-[220px] py-2 border-dotted border-s-1 -ms-5 ps-5 dark:border-neutral-600">
     {{ .TableOfContents | emojify }}
   </div>
 </details>
-<details class="toc-inside mt-0 overflow-hidden rounded-lg ltr:-ml-5 ltr:pl-5 rtl:-mr-5 rtl:pr-5 lg:hidden">
+<details class="toc-inside mt-0 overflow-hidden rounded-lg -ms-5 ps-5 lg:hidden">
   <summary
-    class="py-1 text-lg font-semibold cursor-pointer bg-neutral-100 text-neutral-800 ltr:-ml-5 ltr:pl-5 rtl:-mr-5 rtl:pr-5 dark:bg-neutral-700 dark:text-neutral-100 lg:hidden">
+    class="py-1 text-lg font-semibold cursor-pointer bg-neutral-100 text-neutral-800 -ms-5 ps-5 dark:bg-neutral-700 dark:text-neutral-100 lg:hidden">
     {{ i18n "article.table_of_contents" }}
   </summary>
   <div
-    class="py-2 border-dotted border-neutral-300 ltr:-ml-5 ltr:border-l ltr:pl-5 rtl:-mr-5 rtl:border-r rtl:pr-5 dark:border-neutral-600">
+    class="py-2 border-dotted border-neutral-300 border-s-1 -ms-5 ps-5 dark:border-neutral-600">
     {{ .TableOfContents | emojify }}
   </div>
 </details>

--- a/layouts/partials/translations.html
+++ b/layouts/partials/translations.html
@@ -1,7 +1,7 @@
 {{ if .IsTranslated }}
   <div>
     <div class="cursor-pointer flex items-center nested-menu">
-      <span class="ltr:mr-1 rtl:ml-1">
+      <span class="me-1">
         {{ partial "icon.html" "language" }}
       </span>
       <div

--- a/layouts/shortcodes/alert.html
+++ b/layouts/shortcodes/alert.html
@@ -17,9 +17,9 @@
   >
   <span
     {{ if not ($.Scratch.Get "iconColor") }}
-      class="text-primary-400 ltr:pr-3 rtl:pl-3 flex items-center"
+      class="text-primary-400 pe-3 flex items-center"
     {{ else }}
-      class="ltr:pr-3 rtl:pl-3 flex items-center" style="color: {{ $.Scratch.Get "iconColor" }}"
+      class="pe-3 flex items-center" style="color: {{ $.Scratch.Get "iconColor" }}"
     {{ end }}
     >
     {{ partial "icon.html" ($.Scratch.Get "icon") }}

--- a/layouts/shortcodes/codeberg.html
+++ b/layouts/shortcodes/codeberg.html
@@ -18,7 +18,7 @@
       <div
         class="w-full md:w-auto pt-3 p-5 border border-neutral-200 dark:border-neutral-700 border rounded-md shadow-2xl">
         <div class="flex items-center">
-          <span class="text-2xl text-neutral-800 dark:text-neutral mr-[10px]">
+          <span class="text-2xl text-neutral-800 dark:text-neutral me-2">
             {{ partial "icon.html" "codeberg" }}
           </span>
           <div

--- a/layouts/shortcodes/forgejo.html
+++ b/layouts/shortcodes/forgejo.html
@@ -18,7 +18,7 @@
       <div
         class="w-full md:w-auto pt-3 p-5 border border-neutral-200 dark:border-neutral-700 border rounded-md shadow-2xl">
         <div class="flex items-center">
-          <span class="text-2xl text-neutral-800 dark:text-neutral mr-[10px]">
+          <span class="text-2xl text-neutral-800 dark:text-neutral me-2">
             {{ partial "icon.html" "forgejo" }}
           </span>
           <div

--- a/layouts/shortcodes/gitea.html
+++ b/layouts/shortcodes/gitea.html
@@ -18,7 +18,7 @@
       <div
         class="w-full md:w-auto pt-3 p-5 border border-neutral-200 dark:border-neutral-700 border rounded-md shadow-2xl">
         <div class="flex items-center">
-          <span class="text-2xl text-neutral-800 dark:text-neutral mr-[10px]">
+          <span class="text-2xl text-neutral-800 dark:text-neutral me-2">
             {{ partial "icon.html" "gitea" }}
           </span>
           <div

--- a/layouts/shortcodes/github.html
+++ b/layouts/shortcodes/github.html
@@ -31,7 +31,7 @@
 
         <div class="w-full md:w-auto pt-3 p-5">
           <div class="flex items-center">
-            <span class="text-2xl text-neutral-800 dark:text-neutral mr-[10px]">
+            <span class="text-2xl text-neutral-800 dark:text-neutral me-2">
               {{ partial "icon.html" "github" }}
             </span>
             <div

--- a/layouts/shortcodes/gitlab.html
+++ b/layouts/shortcodes/gitlab.html
@@ -17,7 +17,7 @@
       <div
         class="w-full md:w-auto pt-3 p-5 border border-neutral-200 dark:border-neutral-700 border rounded-md shadow-2xl">
         <div class="flex items-center">
-          <span class="text-2xl text-neutral-800 dark:text-neutral mr-[10px]">
+          <span class="text-2xl text-neutral-800 dark:text-neutral me-2">
             {{ partial "icon.html" "gitlab" }}
           </span>
           <div


### PR DESCRIPTION
Replace directional classes with CSS logical properties for cleaner RTL/LTR support.

Example:
```diff
-class="ltr:ml-2 rtl:mr-2"
+class="ms-2"  // margin-inline-start

-class="ltr:mr-2 rtl:ml-2"
+class="me-2"  // margin-inline-end
```

[Logical properties](https://caniuse.com/?search=Logical%20properties) handle direction automatically, eliminating dual class declarations.

While many CSS utilities can be replaced with logical properties, this PR focuses solely on replacing `ltr/rtl` usage to keep the scope manageable.
