### PR TITLE
Fix(link-title): Add missing English title for the share to Mastodon link.

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -76,6 +76,7 @@ sharing:
   bluesky: "Post on Bluesky"
   whatsapp: "Share via WhatsApp"
   telegram: "Share via Telegram"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Recent"


### PR DESCRIPTION
Adding missing title for the "Share to Mastodon" link in the English language. Currently, hover over the Mastodon sharing link at the bottom of single pages doesn't do anything. With the proposed changes, a tooltip with `Share via Mastodon` appears upon hover, which is consistent with the behavior observed with the other share links.