### PR TITLE
🐛 Fix(single.html): toc not controlled by frontmatter

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -31,7 +31,8 @@
 
     {{/* Body */}}
     <section class="flex flex-col max-w-full mt-0 prose dark:prose-invert lg:flex-row">
-      {{ $enableToc := site.Params.article.showTableOfContents | default (site.Params.list.showTableOfContents | default false) }}
+      {{ $enableToc := site.Params.article.showTableOfContents | default false }}
+      {{ $enableToc = .Params.showTableOfContents | default $enableToc }}
       {{ $showToc := and $enableToc (in .TableOfContents "<ul") }}
       {{ $showRelated := site.Params.article.showRelatedPosts | default false }}
       {{ $topClass := cond (hasPrefix site.Params.header.layout "fixed") "lg:top-[140px]" "lg:top-10" }}


### PR DESCRIPTION
Closes #2421.

Remove typo `site.Params.list.showTableOfContents` which was introduced in c4e658057eecb4d3547c60eea27611582717c89d.