### PR TITLE
Fix HTML for menu items that only have an icon

### DIFF
--- a/layouts/partials/header/header-mobile-option-simple.html
+++ b/layouts/partials/header/header-mobile-option-simple.html
@@ -6,14 +6,17 @@
     }}
       target="_blank"
     {{ end }}
-    class="flex items-center text-gray-500 hover:text-primary-600 dark:hover:text-primary-400">
+    class="flex items-center text-gray-500 hover:text-primary-600 dark:hover:text-primary-400"
+    title="{{ .Title }}">
     {{ if .Pre }}
       <div {{ if and .Pre .Name }}class="mr-2"{{ end }}>
         {{ partial "icon.html" .Pre }}
       </div>
     {{ end }}
-    <p class="text-bg font-bg" title="{{ .Title }}">
-      {{ .Name | markdownify }}
-    </p>
+    {{ if .Name }}
+      <p class="text-bg font-bg">
+        {{ .Name | markdownify }}
+      </p>
+    {{ end }}
   </a>
 </li>

--- a/layouts/partials/header/header-option-simple.html
+++ b/layouts/partials/header/header-option-simple.html
@@ -1,13 +1,16 @@
 <a
   href="{{ .URL }}"
   {{ if or (strings.HasPrefix .URL "http:" ) (strings.HasPrefix .URL "https:" ) }}target="_blank"{{ end }}
-  class="flex items-center text-gray-500 hover:text-primary-600 dark:hover:text-primary-400">
+  class="flex items-center text-gray-500 hover:text-primary-600 dark:hover:text-primary-400"
+  title="{{ .Title }}">
   {{ if .Pre }}
     <span {{ if and .Pre .Name }}class="mr-1"{{ end }}>
       {{ partial "icon.html" .Pre }}
     </span>
   {{ end }}
-  <p class="text-base font-medium" title="{{ .Title }}">
-    {{ .Name | markdownify }}
-  </p>
+  {{ if .Name }}
+    <p class="text-base font-medium">
+      {{ .Name | markdownify }}
+    </p>
+  {{ end }}
 </a>


### PR DESCRIPTION
Menu items with only an icon had an empty `<p>` tag and were missing the `title` attribute.