### PR TITLE
fix bug: (🐛) adding me instead of mr and compiling tailwind

### DIFF
--- a/assets/css/compiled/main.css
+++ b/assets/css/compiled/main.css
@@ -2964,14 +2964,14 @@ body.zen-mode-enable {
       margin-inline-end: calc(var(--spacing) * -16);
     }
   }
+  .md\:me-7 {
+    @media (width >= 853px) {
+      margin-inline-end: calc(var(--spacing) * 7);
+    }
+  }
   .md\:mt-0 {
     @media (width >= 853px) {
       margin-top: calc(var(--spacing) * 0);
-    }
-  }
-  .md\:mr-7 {
-    @media (width >= 853px) {
-      margin-right: calc(var(--spacing) * 7);
     }
   }
   .md\:ml-12 {
@@ -3237,11 +3237,6 @@ body.zen-mode-enable {
   .ltr\:inline {
     &:where(:dir(ltr), [dir="ltr"], [dir="ltr"] *) {
       display: inline;
-    }
-  }
-  .ltr\:text-right {
-    &:where(:dir(ltr), [dir="ltr"], [dir="ltr"] *) {
-      text-align: right;
     }
   }
   .rtl\:left-0 {

--- a/layouts/partials/article-link/_shortcode.html
+++ b/layouts/partials/article-link/_shortcode.html
@@ -15,7 +15,7 @@
 {{ if site.Params.list.showCards }}
   {{ $articleImageClasses = delimit (slice $articleImageClasses "") " " }}
 {{ else }}
-  {{ $articleImageClasses = delimit (slice $articleImageClasses "thumbnailshadow md:mr-7") " " }}
+  {{ $articleImageClasses = delimit (slice $articleImageClasses "thumbnailshadow md:me-7") " " }}
 {{ end }}
 
 {{ $articleInnerClasses := "" }}

--- a/layouts/partials/article-link/simple.html
+++ b/layouts/partials/article-link/simple.html
@@ -11,7 +11,7 @@
 {{ if .Site.Params.list.showCards }}
   {{ $articleImageClasses = delimit (slice $articleImageClasses "") " " }}
 {{ else }}
-  {{ $articleImageClasses = delimit (slice $articleImageClasses "thumbnailshadow md:mr-7") " " }}
+  {{ $articleImageClasses = delimit (slice $articleImageClasses "thumbnailshadow md:me-7") " " }}
 {{ end }}
 
 {{ $disableImageOptimization := .Page.Site.Params.disableImageOptimization | default false }}


### PR DESCRIPTION
this PR is based on #2393 where they used logical properties instead of ltr and rtl i just extended that to simple.html which had an issue where there was no margin between the image and the link partial


fix:
- simple.html article image padding

resolves #2393 