### PR TITLE
relLangUrl in $showMoreLinkDest

### DIFF
--- a/layouts/partials/recent-articles/main.html
+++ b/layouts/partials/recent-articles/main.html
@@ -19,7 +19,7 @@
       {{ $showMoreLinkDest = .Site.Params.homepage.showMoreLinkDest }}
     {{ end }}
     <div class="mt-10 flex justify-center">
-      <a href="{{ $showMoreLinkDest }}">
+      <a href="{{ $showMoreLinkDest | relLangURL }}">
         <button
           class="bg-transparent hover:text-primary-500 prose dark:prose-invert font-semibold py-2 px-4 border border-primary-500 hover:border-transparent rounded">
           {{ i18n "recent.show_more" | markdownify }}


### PR DESCRIPTION
Currently, the show more button doesnt support multilingual websites. Fixed with "| relLangURL"