### PR TITLE
:bug: Fix(render-heading): prevent colour flicker on anchor links

### DIFF
--- a/layouts/_default/_markup/render-heading.html
+++ b/layouts/_default/_markup/render-heading.html
@@ -1,10 +1,10 @@
 {{ $anchor := anchorize .Anchor }}
-<h{{ .Level }} class="relative group">{{ .Text | safeHTML }} 
+<h{{ .Level }} class="relative group">{{ .Text | safeHTML }}
     <div id="{{ $anchor }}" class="anchor"></div>
     {{ if .Page.Params.showHeadingAnchors | default (.Page.Site.Params.article.showHeadingAnchors | default true) }}
     <span
         class="absolute top-0 w-6 transition-opacity opacity-0 -start-6 not-prose group-hover:opacity-100 select-none">
-        <a class="group-hover:text-primary-300 dark:group-hover:text-neutral-700 !no-underline" href="#{{ $anchor }}" aria-label="{{ i18n "article.anchor_label" }}">#</a>
-    </span>        
+        <a class="text-primary-300 dark:text-neutral-700 !no-underline" href="#{{ $anchor }}" aria-label="{{ i18n "article.anchor_label" }}">#</a>
+    </span>
     {{ end }}
 </h{{ .Level }}>


### PR DESCRIPTION
The group-hover prefix is redundant and causes the colour to flicker for the anchor link tag - the colour should actually stay the same and only have it's opacity (visibility really) controlled via group-hover.

Example of flicker:

https://github.com/user-attachments/assets/502c471c-fd65-458a-ae6f-6a749a7f313f

