### PR TITLE
🐛 Fix(article-link): image flicker in Chrome

### DIFF
--- a/assets/css/compiled/main.css
+++ b/assets/css/compiled/main.css
@@ -2975,9 +2975,9 @@ body.zen-mode-enable {
       grid-template-columns: repeat(3, minmax(0, 1fr));
     }
   }
-  .md\:flex-row {
+  .md\:flex-nowrap {
     @media (width >= 853px) {
-      flex-direction: row;
+      flex-wrap: nowrap;
     }
   }
   .md\:justify-start {
@@ -3686,6 +3686,24 @@ a {
 pre {
   text-align: left;
 }
+.thumbnail, .thumbnail_card, .thumbnail_card_related, .thumbnail_card_term, .single_hero_basic, .single_hero_background {
+  background-repeat: no-repeat;
+  background-size: cover;
+  background-position: center;
+}
+.thumbnail {
+  min-width: 300px;
+  height: 180px;
+}
+.thumbnail_card {
+  height: 200px;
+}
+.thumbnail_card_related {
+  height: 150px;
+}
+.thumbnail_card_term {
+  height: 150px;
+}
 .single_hero_round {
   max-height: 50vh;
   object-fit: cover;
@@ -3698,23 +3716,7 @@ pre {
   width: 100%;
   height: 100%;
 }
-.thumbnail_card {
-  min-width: 300px;
-  height: 200px;
-}
-.thumbnail_card_related {
-  height: 150px;
-}
-.thumbnail {
-  width: 300px;
-  min-height: 180px;
-}
-@media (width < 853px) {
-  .thumbnail {
-    width: 100%;
-  }
-}
-.thumbnail-shadow {
+.thumbnailshadow {
   box-shadow: 5px 5px 20px 1px rgba(0, 0, 0, 0.3);
 }
 .anchor {
@@ -3731,11 +3733,20 @@ pre {
   scroll-margin-top: -125px;
 }
 @media (width >= 640px) {
+  .thumbnail {
+    min-width: 100%;
+    height: 180px;
+  }
   .article {
     flex-wrap: wrap;
   }
 }
 @media (width >= 853px) {
+  .thumbnail {
+    min-width: 300px;
+    min-height: 180px;
+    height: auto;
+  }
   .article {
     flex-wrap: nowrap;
   }

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -159,6 +159,34 @@ pre {
   text-align: left;
 }
 
+.thumbnail,
+.thumbnail_card,
+.thumbnail_card_related,
+.thumbnail_card_term,
+.single_hero_basic,
+.single_hero_background {
+  background-repeat: no-repeat;
+  background-size: cover;
+  background-position: center;
+}
+
+.thumbnail {
+  min-width: 300px;
+  height: 180px;
+}
+
+.thumbnail_card {
+  height: 200px;
+}
+
+.thumbnail_card_related {
+  height: 150px;
+}
+
+.thumbnail_card_term {
+  height: 150px;
+}
+
 .single_hero_round {
   max-height: 50vh;
   object-fit: cover;
@@ -174,27 +202,7 @@ pre {
   height: 100%;
 }
 
-.thumbnail_card {
-  min-width: 300px;
-  height: 200px;
-}
-
-.thumbnail_card_related {
-  height: 150px;
-}
-
-.thumbnail {
-  width: 300px;
-  min-height: 180px;
-}
-
-@variant max-md {
-  .thumbnail {
-    width: 100%;
-  }
-}
-
-.thumbnail-shadow {
+.thumbnailshadow {
   box-shadow: 5px 5px 20px 1px rgba(0, 0, 0, 0.3);
 }
 
@@ -218,12 +226,21 @@ pre {
 }
 
 @variant sm {
+  .thumbnail {
+    min-width: 100%;
+    height: 180px;
+  }
   .article {
     flex-wrap: wrap;
   }
 }
 
 @variant md {
+  .thumbnail {
+    min-width: 300px;
+    min-height: 180px;
+    height: auto;
+  }
   .article {
     flex-wrap: nowrap;
   }

--- a/layouts/partials/article-link/_shortcode.html
+++ b/layouts/partials/article-link/_shortcode.html
@@ -1,7 +1,7 @@
 {{/* Used by
   1. article shortcode
 
-  The four variants of article-link are very similar. Despite appearances, as of df859f:
+  The four variants of article-link are very similar. Despite appearances, as of v2.91.0:
   - _shortcode.html uses $page := $target, while the others use $page := .Page
   - card-related.html does not have the hideFeatureImage option, while the others do
 
@@ -11,24 +11,31 @@
 {{ $shortcodeShowSummary := .showSummary }}
 {{ $shortcodeCompactSummary := .compactSummary }}
 {{ $constrainItemsWidth := site.Params.list.constrainItemsWidth | default false }}
-{{ $disableImageOptimization := site.Store.Get "disableImageOptimization" }}
+{{ $disableImageOptimization := site.Params.disableImageOptimization | default false }}
 
-{{ $cardClasses := "flex flex-col md:flex-row relative" }}
-{{ $imgWrapperClasses := "" }}
-{{ $cardContentClasses := "" }}
-
+{{ $articleClasses := "flex flex-wrap md:flex-nowrap article relative" }}
 {{ if site.Params.list.showCards }}
-  {{ $cardClasses = printf "%s overflow-hidden rounded-md border-2 border-neutral-200 dark:border-neutral-700" $cardClasses }}
-  {{ $imgWrapperClasses = "" }}
-  {{ $cardContentClasses = printf "%s p-4 pt-2" $cardContentClasses }}
+  {{ $articleClasses = delimit (slice $articleClasses "border border-neutral-200 dark:border-neutral-700 border-2 rounded-md overflow-hidden") " " }}
 {{ else }}
-  {{ $cardClasses = printf "%s" $cardClasses }}
-  {{ $imgWrapperClasses = printf "%s thumbnail-shadow md:mr-7" $imgWrapperClasses }}
-  {{ $cardContentClasses = printf "%s mt-3 md:mt-0" $cardContentClasses }}
+  {{ $articleClasses = delimit (slice $articleClasses "") " " }}
+{{ end }}
+
+{{ $articleImageClasses := "w-full md:w-auto h-full thumbnail nozoom" }}
+{{ if site.Params.list.showCards }}
+  {{ $articleImageClasses = delimit (slice $articleImageClasses "") " " }}
+{{ else }}
+  {{ $articleImageClasses = delimit (slice $articleImageClasses "thumbnailshadow md:mr-7") " " }}
+{{ end }}
+
+{{ $articleInnerClasses := "" }}
+{{ if site.Params.list.showCards }}
+  {{ $articleInnerClasses = delimit (slice $articleInnerClasses "p-4 pt-2") " " }}
+{{ else }}
+  {{ $articleInnerClasses = delimit (slice $articleInnerClasses "mt-3 md:mt-0") " " }}
 {{ end }}
 
 {{ if $constrainItemsWidth }}
-  {{ $cardClasses = printf "%s max-w-prose" $cardClasses }}
+  {{ $articleClasses = delimit (slice $articleClasses "max-w-prose") " " }}
 {{ end }}
 
 {{ $page := $target }}
@@ -80,18 +87,11 @@
 {{ end }}
 
 
-<article class="{{ $cardClasses }}">
+<article class="{{ $articleClasses }}">
   {{ with $featuredURL }}
-    <div class="flex-none relative overflow-hidden {{ $imgWrapperClasses }} thumbnail">
-      <img
-        src="{{ . }}"
-        alt="{{ with $target.Params.featuredImageAlt }}{{ . }}{{ else }}{{ $target.Title | emojify }}{{ end }}"
-        loading="lazy"
-        decoding="async"
-        class="not-prose absolute inset-0 w-full h-full object-cover">
-    </div>
+    <div class="{{ $articleImageClasses }}" style="background-image:url({{ . }});"></div>
   {{ end }}
-  <div class="{{ $cardContentClasses }}">
+  <div class="{{ $articleInnerClasses }}">
     <header class="items-center text-start text-xl font-semibold">
       <a
         {{ with .Params.externalUrl }}

--- a/layouts/partials/article-link/card-related.html
+++ b/layouts/partials/article-link/card-related.html
@@ -53,15 +53,7 @@
 <article
   class="relative min-h-full min-w-full overflow-hidden rounded border border-2 border-neutral-200 shadow-2xl dark:border-neutral-700">
   {{ with $featuredURL }}
-    <div class="flex-none relative overflow-hidden thumbnail_card_related">
-      <img
-        src="{{ . }}"
-        alt="{{ $page.Title }}"
-        loading="lazy"
-        decoding="async"
-        fetchpriority="low"
-        class="not-prose absolute inset-0 w-full h-full object-cover">
-    </div>
+    <div class="thumbnail_card_related nozoom w-full" style="background-image:url({{ . }});"></div>
   {{ end }}
   {{ if and .Draft .Site.Params.article.showDraftLabel }}
     <span class="absolute top-0 right-0 m-2">

--- a/layouts/partials/article-link/card.html
+++ b/layouts/partials/article-link/card.html
@@ -57,14 +57,7 @@
 <article
   class="relative min-h-full min-w-full overflow-hidden rounded border border-2 border-neutral-200 shadow-2xl dark:border-neutral-700">
   {{ with $featuredURL }}
-    <div class="flex-none relative overflow-hidden thumbnail_card">
-      <img
-        src="{{ . }}"
-        alt="{{ $page.Title | plainify }}"
-        loading="lazy"
-        decoding="async"
-        class="not-prose absolute inset-0 w-full h-full object-cover">
-    </div>
+    <div class="thumbnail_card nozoom w-full" style="background-image:url({{ . }});"></div>
   {{ end }}
   {{ if and .Draft .Site.Params.article.showDraftLabel }}
     <span class="absolute top-0 right-0 m-2">

--- a/layouts/partials/article-link/simple.html
+++ b/layouts/partials/article-link/simple.html
@@ -3,25 +3,33 @@
   2. Recent articles template (when the cardView option is not enabled)
   3. Shortcode list.html
 */}}
-{{ $constrainItemsWidth := site.Params.list.constrainItemsWidth | default false }}
-{{ $disableImageOptimization := site.Store.Get "disableImageOptimization" }}
+{{ $constrainItemsWidth := .Page.Site.Params.list.constrainItemsWidth | default false }}
 
-{{ $cardClasses := "flex flex-col md:flex-row relative" }}
-{{ $imgWrapperClasses := "" }}
-{{ $cardContentClasses := "" }}
-
-{{ if site.Params.list.showCards }}
-  {{ $cardClasses = printf "%s overflow-hidden rounded-md border-2 border-neutral-200 dark:border-neutral-700" $cardClasses }}
-  {{ $imgWrapperClasses = "" }}
-  {{ $cardContentClasses = printf "%s p-4" $cardContentClasses }}
+{{ $articleClasses := "flex flex-wrap md:flex-nowrap article relative" }}
+{{ if .Site.Params.list.showCards }}
+  {{ $articleClasses = delimit (slice $articleClasses "border border-neutral-200 dark:border-neutral-700 border-2 rounded-md overflow-hidden") " " }}
 {{ else }}
-  {{ $cardClasses = $cardClasses }}
-  {{ $imgWrapperClasses = printf "%s thumbnail-shadow md:mr-7" $imgWrapperClasses }}
-  {{ $cardContentClasses = printf "%s mt-3 md:mt-0" $cardContentClasses }}
+  {{ $articleClasses = delimit (slice $articleClasses "") " " }}
+{{ end }}
+
+{{ $articleImageClasses := "w-full md:w-auto h-full thumbnail nozoom" }}
+{{ if .Site.Params.list.showCards }}
+  {{ $articleImageClasses = delimit (slice $articleImageClasses "") " " }}
+{{ else }}
+  {{ $articleImageClasses = delimit (slice $articleImageClasses "thumbnailshadow md:mr-7") " " }}
+{{ end }}
+
+{{ $disableImageOptimization := .Page.Site.Params.disableImageOptimization | default false }}
+
+{{ $articleInnerClasses := "" }}
+{{ if .Site.Params.list.showCards }}
+  {{ $articleInnerClasses = delimit (slice $articleInnerClasses "p-4") " " }}
+{{ else }}
+  {{ $articleInnerClasses = delimit (slice $articleInnerClasses "mt-3 md:mt-0") " " }}
 {{ end }}
 
 {{ if $constrainItemsWidth }}
-  {{ $cardClasses = printf "%s max-w-prose" $cardClasses }}
+  {{ $articleClasses = delimit (slice $articleClasses "max-w-prose") " " }}
 {{ end }}
 
 {{ $page := .Page }}
@@ -73,18 +81,11 @@
 {{ end }}
 
 
-<article class="{{ $cardClasses }}">
+<article class="{{ $articleClasses }}">
   {{ with $featuredURL }}
-    <div class="flex-none relative overflow-hidden {{ $imgWrapperClasses }} thumbnail">
-      <img
-        src="{{ . }}"
-        alt="{{ $.Params.featuredImageAlt | default ($.Title | emojify) }}"
-        loading="lazy"
-        decoding="async"
-        class="not-prose absolute inset-0 w-full h-full object-cover">
-    </div>
+    <div class="{{ $articleImageClasses }}" style="background-image:url({{ . }});"></div>
   {{ end }}
-  <div class="{{ $cardContentClasses }}">
+  <div class="{{ $articleInnerClasses }}">
     <header class="items-center text-start text-xl font-semibold">
       <a
         {{ with .Params.externalUrl }}


### PR DESCRIPTION
Closes #2545. Fix image flickering in Chrome.

### Changes

Reverts the background image-related changes of commit 01b998e0706add836333359b227141a9a1930e28

### Description

Fix by reverting it because flickering is the first-class issue and should be on top of any other considerations. I've try various approach or workaround but none resolved the flickering.

This occurred because cached images in Chrome (those with 304 responses) lacked image size information. As a result, the `object-fit` attribute was ignored, which only manifested the issue in Chrome. Although this affects cached images, it rarely occurs during local development.

See https://issues.chromium.org/issues/40757070 and [Image size flickers on reload with object-fit: cover CSS property](https://stackoverflow.com/questions/64187659/react-js-image-size-flickers-on-reload-with-object-fit-cover-css-property)