### PR TITLE
🐛 Fix: author image stretch when zooming

### DIFF
--- a/layouts/partials/author-extra.html
+++ b/layouts/partials/author-extra.html
@@ -9,15 +9,18 @@
     {{ end }}
     {{ if $authorImage }}
       {{ $final := $authorImage }}
+      {{ $squareImage := $authorImage }}
       {{ if not $disableImageOptimization }}
         {{ $final = $authorImage.Fill "192x192" }}
+        {{ $shortSide := int (math.Min $authorImage.Width $authorImage.Height) }}
+        {{ $squareImage = $authorImage.Crop (printf "%dx%d" $shortSide $shortSide ) }}
       {{ end }}
       <img
         class="!mt-0 !mb-0 h-24 w-24 rounded-full me-4"
         width="96"
         height="96"
         src="{{ $final.RelPermalink }}"
-        data-zoom-src="{{ $authorImage.RelPermalink }}">
+        data-zoom-src="{{ $squareImage.RelPermalink }}">
     {{ end }}
   {{ end }}
   <div class="place-self-center">

--- a/layouts/partials/author.html
+++ b/layouts/partials/author.html
@@ -9,8 +9,11 @@
     {{ end }}
     {{ if $authorImage }}
       {{ $final := $authorImage }}
+      {{ $squareImage := $authorImage }}
       {{ if not $disableImageOptimization }}
         {{ $final = $authorImage.Fill "192x192" }}
+        {{ $shortSide := int (math.Min $authorImage.Width $authorImage.Height) }}
+        {{ $squareImage = $authorImage.Crop (printf "%dx%d" $shortSide $shortSide ) }}
       {{ end }}
       <img
         class="!mt-0 !mb-0 h-24 w-24 rounded-full me-4"
@@ -18,20 +21,23 @@
         height="96"
         alt="{{ $.Site.Params.Author.name | default " Author" }}"
         src="{{ $final.RelPermalink }}"
-        data-zoom-src="{{ $authorImage.RelPermalink }}">
+        data-zoom-src="{{ $squareImage.RelPermalink }}">
     {{ else }}
       {{ $authorImage := resources.GetRemote . }}
       {{ $final := $authorImage }}
+      {{ $squareImage := $authorImage }}
       {{ if not $disableImageOptimization }}
         {{ $final = $authorImage.Fill "192x192" }}
+        {{ $shortSide := int (math.Min $authorImage.Width $authorImage.Height) }}
+        {{ $squareImage = $authorImage.Crop (printf "%dx%d" $shortSide $shortSide ) }}
       {{ end }}
       <img
         class="!mt-0 !mb-0 h-24 w-24 rounded-full me-4"
         width="96"
         height="96"
         alt="{{ $.Site.Params.Author.name | default " Author" }}"
-        src="{{ $authorImage.RelPermalink }}"
-        data-zoom-src="{{ $authorImage.RelPermalink }}">
+        src="{{ $final.RelPermalink }}"
+        data-zoom-src="{{ $squareImage.RelPermalink }}">
     {{ end }}
   {{ end }}
   <div class="place-self-center">

--- a/layouts/partials/home/background.html
+++ b/layouts/partials/home/background.html
@@ -51,8 +51,11 @@
             {{ end }}
             {{ if $authorImage }}
               {{ $final := $authorImage }}
+              {{ $squareImage := $authorImage }}
               {{ if not $disableImageOptimization }}
                 {{ $final = $authorImage.Fill (print "288x288 q" ( $.Site.Params.Author.imagequality | default "96" )) }}
+                {{ $shortSide := int (math.Min $authorImage.Width $authorImage.Height) }}
+                {{ $squareImage = $authorImage.Crop (printf "%dx%d" $shortSide $shortSide ) }}
               {{ end }}
               <img
                 class="mb-2 h-36 w-36 rounded-full"
@@ -60,7 +63,7 @@
                 height="144"
                 alt="{{ $.Site.Params.Author.name | default `Author` }}"
                 src="{{ $final.RelPermalink }}"
-                data-zoom-src="{{ $authorImage.RelPermalink }}">
+                data-zoom-src="{{ $squareImage.RelPermalink }}">
             {{ end }}
           {{ end }}
           <h1 class="mb-2 text-4xl font-extrabold text-neutral-800 dark:text-neutral-200">

--- a/layouts/partials/home/hero.html
+++ b/layouts/partials/home/hero.html
@@ -54,8 +54,11 @@
             {{ end }}
             {{ if $authorImage }}
               {{ $final := $authorImage }}
+              {{ $squareImage := $authorImage }}
               {{ if not $disableImageOptimization }}
                 {{ $final = $authorImage.Fill (print "288x288 q" ( $.Site.Params.Author.imagequality | default "96" )) }}
+                {{ $shortSide := int (math.Min $authorImage.Width $authorImage.Height) }}
+                {{ $squareImage = $authorImage.Crop (printf "%dx%d" $shortSide $shortSide ) }}
               {{ end }}
               <img
                 class="mb-2 h-36 w-36 rounded-full"
@@ -63,7 +66,7 @@
                 height="144"
                 alt="{{ $.Site.Params.Author.name | default `Author` }}"
                 src="{{ $final.RelPermalink }}"
-                data-zoom-src="{{ $authorImage.RelPermalink }}">
+                data-zoom-src="{{ $squareImage.RelPermalink }}">
             {{ end }}
           {{ end }}
           {{ if not $disableHeroImageFilter }}

--- a/layouts/partials/home/profile.html
+++ b/layouts/partials/home/profile.html
@@ -13,8 +13,11 @@
       {{ end }}
       {{ if $authorImage }}
         {{ $final := $authorImage }}
+        {{ $squareImage := $authorImage }}
         {{ if not $disableImageOptimization }}
           {{ $final = $authorImage.Fill (print "288x288 q" ( $.Site.Params.Author.imagequality | default "96" )) }}
+          {{ $shortSide := int (math.Min $authorImage.Width $authorImage.Height) }}
+          {{ $squareImage = $authorImage.Crop (printf "%dx%d" $shortSide $shortSide ) }}
         {{ end }}
         <img
           class="mb-2 h-36 w-36 rounded-full"
@@ -22,7 +25,7 @@
           height="144"
           alt="{{ $.Site.Params.Author.name | default `Author` }}"
           src="{{ $final.RelPermalink }}"
-          data-zoom-src="{{ $authorImage.RelPermalink }}">
+          data-zoom-src="{{ $squareImage.RelPermalink }}">
       {{ end }}
     {{ end }}
     <h1 class="text-4xl font-extrabold">


### PR DESCRIPTION
751856fcc2707ab14a6d65c6d8058aaae70a0601 uses the original image as the zoom source for the author image, but medium-zoom scales it according to the thumbnail's aspect ratio, which stretches non-square images.

Using a square image for `data-zoom-src` ensures the zoomed image maintains square.
