### PR TITLE
Fix: Copy fallback for safari

### DIFF
--- a/assets/js/code.js
+++ b/assets/js/code.js
@@ -32,6 +32,7 @@ async function copyCodeToClipboard(button, highlightDiv) {
     const sel = window.getSelection();
     sel.removeAllRanges();
     sel.addRange(range);
+    textArea.focus();
     textArea.setSelectionRange(0, 999999);
     document.execCommand("copy");
     highlightDiv.removeChild(textArea);


### PR DESCRIPTION
I have [this issue](https://github.com/nunocoracao/blowfish/issues/2225) 

The clipboard fallback was failing in Safari because the temporary `<textarea>` used for copying was never focused.

Safari requires the selected element to have explicit focus for `document.execCommand("copy")` to succeed. Although the text was programmatically selected, the lack of textArea.focus() caused the copy operation to be silently ignored.

This change fixes the issue by ensuring the textarea is focused before selecting the content and executing the copy command, making the fallback reliable in Safari.