### PR TITLE
:speech_balloon: Translate article-related phrases to Italian

### DIFF
--- a/i18n/it.yaml
+++ b/i18n/it.yaml
@@ -15,10 +15,10 @@ article:
   word_count:
     one: "{{ .Count }} parola"
     other: "{{ .Count }} parole"
-  part_of_series: "This article is part of a series."
-  part: "Part"
-  this_article: "This Article"
-  related_articles: "Related"
+  part_of_series: "Questo articolo fa parte di una serie."
+  part: "Parte"
+  this_article: "Questo articolo"
+  related_articles: "Articoli correlati"
   reply_by_email: "Rispondi via email"
 
 a11y:


### PR DESCRIPTION
In i18n/it.yaml, translated article->part_of_series, part, this_article, related_articles to Italian, which were previously in English.