### PR TITLE
✨ feat: add config to disable styled scrollbar

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -13,6 +13,7 @@ enableA11y = false
 enableSearch = true
 enableCodeCopy = false
 enableStructuredBreadcrumbs = false
+# enableStyledScrollbar = true # disable to use native scrollbar style (defaults to true)
 
 replyByEmail = false
 

--- a/exampleSite/content/docs/configuration/index.md
+++ b/exampleSite/content/docs/configuration/index.md
@@ -177,6 +177,7 @@ Many of the article defaults here can be overridden on a per article basis by sp
 | `enableSearch` | `false` | Whether site search is enabled. Set to `true` to enable search functionality. Note that the search feature depends on the `outputs.home` setting in the [site configuration](#site-configuration) being set correctly. |
 | `enableCodeCopy` | `false` | Whether copy-to-clipboard buttons are enabled for `<code>` blocks. The `highlight.noClasses` parameter must be set to `false` for code copy to function correctly. Read more about [other configuration files](#other-configuration-files) below. |
 | `enableStructuredBreadcrumbs` | `false` | Whether to add [BreadcrumbList](https://developers.google.com/search/docs/appearance/structured-data/breadcrumb) for SEO. Do NOT enable this if your content path does not match the URL, i.e., complex [URL setting](https://gohugo.io/content-management/urls/). |
+| `enableStyledScrollbar` | `true` | Whether to enable styled scrollbar via tailwind-scrollbar. Set to `false` to use the browser's default scrollbar styling. |
 | `replyByEmail` | `false` | Whether the reply-by-email link is enabled after post. The `params.author.email` parameter in `config/_default/languages.en.toml` must be set. |
 | `forgejoDefaultServer` | _Not set_ | The default `server` parameter for the `forgejo` shortcode. |
 | `giteaDefaultServer` | _Not set_ | The default `server` parameter for the `gitea` shortcode. |

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -11,7 +11,7 @@
   {{ $bodyLayout := "flex flex-col h-screen m-auto leading-7 max-w-7xl px-6 sm:px-14 md:px-24 lg:px-32" }}
   {{ $bodyColor := "text-lg bg-neutral text-neutral-900 dark:bg-neutral-800 dark:text-neutral" }}
   {{ $bodyScrollbar := "scrollbar-thin scrollbar-track-neutral-200 scrollbar-thumb-neutral-400 dark:scrollbar-track-neutral-800 dark:scrollbar-thumb-neutral-600" }}
-  <body class="{{ $bodyLayout }} {{ $bodyColor }} {{ $bodyScrollbar }}">
+  <body class="{{ $bodyLayout }} {{ $bodyColor }} {{ if site.Params.enableStyledScrollbar | default true }}{{ $bodyScrollbar }}{{ end }}">
     <div id="the-top" class="absolute flex self-center">
       <a
         class="px-3 py-1 text-sm -translate-y-8 rounded-b-lg bg-primary-200 focus:translate-y-0 dark:bg-neutral-600"


### PR DESCRIPTION
# What

Adds config param `.Site.Params.enableStyledScrollbar` to conditionally apply the tailwind-scrollbar classes to the body tag in `layouts/_default/baseof.html`. The change is fully backwards compatible as the param falls back to `true` if omitted.

Also documents the new param in both the default `params.toml` as well as in the docs site.

# Why

There's currently no way to disable this styled scrollbar apart from overriding the `baseof.html` layout file, which seems a little overkill to be honest and potentially breaks upgrade path/theme updates. Theme users may want native scrollbars for accessibility, performance, or added design consistency.