### PR TITLE
✨ Feat: adopt Hugo embed render-link logic

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -25,7 +25,7 @@ static
 # 
 # This create an unclose node
 
-layouts/_default/_markup/render-heading.html
+layouts/_default/_markup
 layouts/_default/index.json
 layouts/shortcodes/screenshot.html
 layouts/shortcodes/figure.html

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,11 +1,30 @@
-<a
-  href="{{ .Destination | safeURL }}"
-  {{- with .Title -}}
-    title="{{ . }}"
-  {{- end }}
-  {{- if or (strings.HasPrefix .Destination "http:") (strings.HasPrefix .Destination "https:") }}
-    target="_blank"
-  {{ end }}>
+{{/* From Hugo, Apache v2 license
+  https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/_markup/render-link.html
+*/}}
+{{- $u := urls.Parse .Destination -}}
+{{- $href := $u.String -}}
+{{- if strings.HasPrefix $u.String "#" -}}
+  {{- $href = printf "%s#%s" .PageInner.RelPermalink $u.Fragment -}}
+{{- else if and $href (not $u.IsAbs) -}}
+  {{- $path := strings.TrimPrefix "./" $u.Path -}}
+  {{- with or
+    ($.PageInner.GetPage $path)
+    ($.PageInner.Resources.Get $path)
+    (resources.Get $path)
+  -}}
+    {{- $href = .RelPermalink -}}
+    {{- with $u.RawQuery -}}
+      {{- $href = printf "%s?%s" $href . -}}
+    {{- end -}}
+    {{- with $u.Fragment -}}
+      {{- $href = printf "%s#%s" $href . -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+
+<a href="{{ $href }}" {{ with .Title }}title="{{ . }}"{{ end }}
+  {{- if or (strings.HasPrefix .Destination "http:") (strings.HasPrefix .Destination "https:") }} target="_blank"{{ end }}>
   {{- .Text | safeHTML -}}
 </a>
 {{- /* Trim EOF */ -}}


### PR DESCRIPTION
Use the code from https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/_markup/render-link.html.

The primary benefit is that we can use IDE support for Markdown files. For example, `[page1](../page1.md)` was not previously allowed. This also allows publish files in `assets`, and helps streamline user migration.
