### PR TITLE
fix(i18n): add admonition titles for en

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -85,3 +85,20 @@ shortcode:
 
 recent:
   show_more: "Show More"
+
+admonition:
+  abstract: "Abstract"
+  bug: "Bug"
+  caution: "Caution"
+  danger: "Danger"
+  example: "Example"
+  failure: "Failure"
+  important: "Important"
+  info: "Info"
+  note: "Note"
+  question: "Question"
+  quote: "Quote"
+  success: "Success"
+  tip: "Tip"
+  todo: "Todo"
+  warning: "Warning"


### PR DESCRIPTION
## Background / Issue

In Blowfish admonition rendering, the title is taken from a custom title if provided, otherwise from `i18n`. When the **default language is English**, the missing English `admonition.*` keys do not surface as a problem. The issue only appears when the **default language is non-English** and an **English UI is enabled**: Hugo falls back to the default language, causing English pages to show non-English admonition titles (e.g., Traditional Chinese).

Because Hugo’s `i18n` fallback to the default language is **built-in behavior**, it cannot be disabled or overridden at the theme level. The only practical mitigation is to add the missing English translations.

## Changes

- Add English admonition titles in `i18n/en.yaml` (abstract/bug/caution/…/warning)
- No changes to other languages or to Hugo’s fallback behavior

## Why this approach

- The root cause is missing English translations, so adding them is the smallest, most targeted fix
- Blowfish’s current practice does not require full translation coverage across all languages
- Hugo’s fallback behavior is not controllable from the theme, so this is the safest mitigation

## Impact

- English UI shows English admonition titles even when the default language is non-English
- No changes to existing translations, styles, or admonition behavior

## Testing

- Manually verified: with a non-English default language and English UI enabled, standard admonition titles render in English
