### PR TITLE
🐛 Fix: make bold text inherit parent color 

### DIFF
--- a/assets/css/compiled/main.css
+++ b/assets/css/compiled/main.css
@@ -743,7 +743,7 @@
     --tw-prose-headings: rgba(var(--color-neutral-800), 1);
     --tw-prose-lead: rgba(var(--color-neutral-500), 1);
     --tw-prose-links: rgba(var(--color-primary-600), 1);
-    --tw-prose-bold: rgba(var(--color-neutral-900), 1);
+    --tw-prose-bold: inherit;
     --tw-prose-counters: rgba(var(--color-neutral-800), 1);
     --tw-prose-bullets: rgba(var(--color-neutral-500), 1);
     --tw-prose-hr: oklch(92.8% 0.006 264.531);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -65,7 +65,7 @@ module.exports = {
             "--tw-prose-headings": theme("colors.neutral.800 / 1"),
             "--tw-prose-lead": theme("colors.neutral.500 / 1"),
             "--tw-prose-links": theme("colors.primary.600 / 1"),
-            "--tw-prose-bold": theme("colors.neutral.900 / 1"),
+            "--tw-prose-bold": "inherit",
             "--tw-prose-counters": theme("colors.neutral.800 / 1"),
             "--tw-prose-bullets": theme("colors.neutral.500 / 1"),
             "--tw-prose-quotes": theme("colors.neutral.700 / 1"),


### PR DESCRIPTION
For example, given the following HTML:

```html
<p class="text-primary-500"><strong>Hello</strong> world</p>
```

The rendered result shows `Hello` in the neutral color, while `world` is rendered in the primary color.

This change applies `color: inherit` to bold text so that both uses the primary color.