### PR TITLE
🐛 Fix(mobile-menu): body not scrollable

### DIFF
--- a/assets/css/compiled/main.css
+++ b/assets/css/compiled/main.css
@@ -1063,9 +1063,6 @@
   .table-cell {
     display: table-cell;
   }
-  .aspect-\[\.\.\.\] {
-    aspect-ratio: ...;
-  }
   .aspect-\[4\/3\] {
     aspect-ratio: 4/3;
   }
@@ -4658,8 +4655,8 @@ body:has(#mobile-menu-toggle:checked) {
   overflow: hidden;
 }
 @media (min-width: 853px) {
-  body {
-    position: static !important;
+  body:has(#mobile-menu-toggle:checked) {
+    overflow: visible;
   }
 }
 #bmc-wbtn {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -276,8 +276,8 @@ body:has(#mobile-menu-toggle:checked) {
 
 /* Reset body position for desktop after it was modified on mobile */
 @media (min-width: 853px) {
-  body {
-    position: static !important;
+  body:has(#mobile-menu-toggle:checked) {
+    overflow: visible;
   }
 }
 


### PR DESCRIPTION
This occurs when the mobile menu has been toggled and the viewport is subsequently resized to desktop.
