### PR TITLE
✨ Feat: Add option for external link in new tab

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -93,6 +93,7 @@ forgejoDefaultServer = "https://v11.next.forgejo.org"
   showWordCount = true
   # sharingLinks = [ "linkedin", "twitter", "bluesky", "mastodon", "reddit", "pinterest", "facebook", "email", "whatsapp", "telegram", "line"]
   showZenMode = false
+  # externalLinkForceNewTab = false # disable to allow external links in the same tab (defaults to true)
 
 [list]
   showHero = false

--- a/exampleSite/content/docs/configuration/index.it.md
+++ b/exampleSite/content/docs/configuration/index.it.md
@@ -258,6 +258,7 @@ Many of the article defaults here can be overridden on a per article basis by sp
 | `article.showComments` | `false` | Whether or not the [comments partial]({{< ref "partials#comments" >}}) is included after the article footer. |
 | `article.sharingLinks` | _Not set_ | Which sharing links to display at the end of each article. When not provided, or set to `false` no links will be displayed. Available values are: "bluesky", "email", "facebook", "line", "linkedin", "mastodon", "pinterest", "reddit", "telegram", "twitter", and "whatsapp" |
 | `article.showZenMode` | `false` | Flag to activate Zen Mode reading feature for articles. |
+| `article.externalLinkForceNewTab` | `true` | Flag per aprire i link esterni nel markdown in una nuova scheda. |
 
 ### List
 

--- a/exampleSite/content/docs/configuration/index.ja.md
+++ b/exampleSite/content/docs/configuration/index.ja.md
@@ -258,6 +258,7 @@ Blowfish は、テーマの機能を制御する多数の設定パラメータ�
 | `article.showComments` | `false` | 記事のフッターの後に [コメントパーシャル]({{< ref "partials#コメント" >}}) を含めるかどうかです。 |
 | `article.sharingLinks` | _未設定_ | 各記事の最後に表示する共有リンクです。指定されていないか、`false` に設定されている場合、リンクは表示されません。使用可能な値は、"bluesky"、"email"、"facebook"、"line"、"linkedin"、"mastodon"、"pinterest"、"reddit"、"telegram"、"twitter"、"whatsapp"です。 |
 | `article.showZenMode` | `false` | 記事のZenモードリーダー機能を有効にするフラグです。 |
+| `article.externalLinkForceNewTab` | `true` | マークダウン内の外部リンクを新しいタブで開くかどうかです。 |
 
 ### リスト(List)
 

--- a/exampleSite/content/docs/configuration/index.md
+++ b/exampleSite/content/docs/configuration/index.md
@@ -266,6 +266,7 @@ Many of the article defaults here can be overridden on a per article basis by sp
 | `article.showComments` | `false` | Whether or not the [comments partial]({{< ref "partials#comments" >}}) is included after the article footer. |
 | `article.sharingLinks` | _Not set_ | Which sharing links to display at the end of each article. When not provided, or set to `false` no links will be displayed.  Available values are: "bluesky", "email", "facebook", "line", "linkedin", "mastodon", "pinterest", "reddit", "telegram", "twitter", and "whatsapp" |
 | `article.showZenMode` | `false` | Flag to activate Zen Mode reading feature for articles. |
+| `article.externalLinkForceNewTab` | `true` | Should external links in markdown open in a new tab. |
 
 ### List
 

--- a/exampleSite/content/docs/configuration/index.zh-cn.md
+++ b/exampleSite/content/docs/configuration/index.zh-cn.md
@@ -262,6 +262,7 @@ Blowfish 提供了大量控制主题功能的配置参数，下面的表格中�
 | `article.showComments` | `false` | 是否在文章末尾添加 [评论部分]({{< ref "partials#comments" >}})。 |
 | `article.sharingLinks` | _无_ | 在文章末尾显示的分享链接。如果没有提供或设置为 `false`，则不会显示任何分享链接。可用的值包括："bluesky"、"email"、"facebook"、"line"、"linkedin"、"mastodon"、"pinterest"、"reddit"、"telegram"、"twitter"和"whatsapp" |
 | `article.showZenMode` | `false` | 指定是否激活文章阅读的禅模式，即隐藏常规的界面元素。 |
+| `article.externalLinkForceNewTab` | `true` | 是否强制 Markdown 中的外部链接在新标签页中打开。 |
 
 ### 列表页
 

--- a/exampleSite/content/docs/front-matter/index.de.md
+++ b/exampleSite/content/docs/front-matter/index.de.md
@@ -57,4 +57,5 @@ Die Standardwerte der Front-Matter-Parameter werden von der [Basiskonfiguration]
 | `excludeFromSearch` | `false` | Ob dieser Artikel von der Sitemap und dem Suchindex ausgeschlossen werden soll. Wenn `true`, erscheint die Seite nicht in `sitemap.xml` oder `index.json`. |
 | `layoutBackgroundBlur` | `true` | Lässt das Hintergrundbild im background heroStyle beim Scrollen verschwimmen |
 | `layoutBackgroundHeaderSpace` | `true` | Fügt Abstand zwischen Header und Body hinzu. |
+| `externalLinkForceNewTab` | `article.externalLinkForceNewTab` | Sollen externe Links im Markdown in einem neuen Tab geöffnet werden? |
 <!-- prettier-ignore-end -->

--- a/exampleSite/content/docs/front-matter/index.es.md
+++ b/exampleSite/content/docs/front-matter/index.es.md
@@ -57,4 +57,5 @@ Los valores predeterminados de los parámetros de front matter se heredan de la 
 | `excludeFromSearch` | `false` | Si este artículo debe excluirse del sitemap y el índice de búsqueda. Cuando es `true`, la página no aparecerá en `sitemap.xml` ni `index.json`. |
 | `layoutBackgroundBlur` | `true` | Hace que la imagen de fondo en el heroStyle background se difumine con el desplazamiento |
 | `layoutBackgroundHeaderSpace` | `true` | Añade espacio entre el encabezado y el cuerpo. |
+| `externalLinkForceNewTab` | `article.externalLinkForceNewTab` | ¿Deben los enlaces externos en markdown abrirse en una nueva pestaña? |
 <!-- prettier-ignore-end -->

--- a/exampleSite/content/docs/front-matter/index.fr.md
+++ b/exampleSite/content/docs/front-matter/index.fr.md
@@ -57,4 +57,5 @@ Les valeurs par défaut des paramètres front matter sont héritées de la [conf
 | `excludeFromSearch` | `false` | Si cet article doit être exclu du sitemap et de l'index de recherche. Lorsque `true`, la page n'apparaîtra pas dans `sitemap.xml` ou `index.json`. |
 | `layoutBackgroundBlur` | `true` | Fait flouter l'image d'arrière-plan dans le heroStyle background avec le défilement |
 | `layoutBackgroundHeaderSpace` | `true` | Ajoute de l'espace entre l'en-tête et le corps. |
+| `externalLinkForceNewTab` | `article.externalLinkForceNewTab` | Les liens externes dans le markdown doivent-ils s'ouvrir dans un nouvel onglet? |
 <!-- prettier-ignore-end -->

--- a/exampleSite/content/docs/front-matter/index.it.md
+++ b/exampleSite/content/docs/front-matter/index.it.md
@@ -55,4 +55,5 @@ I valori predefiniti dei parametri del front metter vengono ereditati dalla [con
 | `xml` | `true` unless excluded by `sitemap.excludedKinds` | Se questo articolo è incluso o meno nel file `/sitemap.xml` generato. |
 | `layoutBackgroundBlur` | `true` | Rende l'immagine di sfondo sullo sfondo heroStyle sfocata con lo scorrimento. |
 | `layoutBackgroundHeaderSpace` | `true` | Aggiungi spazio tra l'intestazione e il body. |
+| `externalLinkForceNewTab` | `article.externalLinkForceNewTab` | Flag per aprire i link esterni nel markdown in una nuova scheda. |
 <!-- prettier-ignore-end -->

--- a/exampleSite/content/docs/front-matter/index.ja.md
+++ b/exampleSite/content/docs/front-matter/index.ja.md
@@ -56,4 +56,5 @@ series_order: 7
 | `xml` | `sitemap.excludedKinds` によって除外されない限り `true` | この記事が生成された `/sitemap.xml` ファイルに含まれるかどうか。 |
 | `layoutBackgroundBlur` | `true` | background heroStyle の背景画像をスクロールでぼかします |
 | `layoutBackgroundHeaderSpace` | `true` | ヘッダーと本文の間にスペースを追加します |
+| `externalLinkForceNewTab` | `article.externalLinkForceNewTab` | マークダウン内の外部リンクを新しいタブで開くかどうかです。 |
 <!-- prettier-ignore-end -->

--- a/exampleSite/content/docs/front-matter/index.md
+++ b/exampleSite/content/docs/front-matter/index.md
@@ -57,4 +57,5 @@ Front matter parameter default values are inherited from the theme's [base confi
 | `excludeFromSearch` | `false` | Whether or not this article should be excluded from the sitemap and search index. When `true`, the page will not appear in `sitemap.xml` or `index.json`. |
 | `layoutBackgroundBlur` | `true` | Makes the background image in the background heroStyle blur with the scroll |
 | `layoutBackgroundHeaderSpace` | `true` | Add space between the header and the body. |
+| `externalLinkForceNewTab` | `article.externalLinkForceNewTab` | Should external links in markdown open in a new tab. |
 <!-- prettier-ignore-end -->

--- a/exampleSite/content/docs/front-matter/index.pt-br.md
+++ b/exampleSite/content/docs/front-matter/index.pt-br.md
@@ -57,4 +57,5 @@ Os valores padrão dos parâmetros de front matter são herdados da [configuraç
 | `excludeFromSearch` | `false` | Se este artigo deve ser excluído do sitemap e índice de pesquisa. Quando `true`, a página não aparecerá em `sitemap.xml` ou `index.json`. |
 | `layoutBackgroundBlur` | `true` | Faz a imagem de fundo no heroStyle background desfocar com a rolagem |
 | `layoutBackgroundHeaderSpace` | `true` | Adiciona espaço entre o cabeçalho e o corpo. |
+| `externalLinkForceNewTab` | `article.externalLinkForceNewTab` | Links externos no markdown devem abrir em uma nova aba? |
 <!-- prettier-ignore-end -->

--- a/exampleSite/content/docs/front-matter/index.pt-pt.md
+++ b/exampleSite/content/docs/front-matter/index.pt-pt.md
@@ -57,4 +57,5 @@ Os valores predefinidos dos parâmetros de front matter são herdados da [config
 | `excludeFromSearch` | `false` | Se este artigo deve ser excluído do sitemap e índice de pesquisa. Quando `true`, a página não aparecerá em `sitemap.xml` ou `index.json`. |
 | `layoutBackgroundBlur` | `true` | Faz a imagem de fundo no heroStyle background desfocar com a rolagem |
 | `layoutBackgroundHeaderSpace` | `true` | Adiciona espaço entre o cabeçalho e o corpo. |
+| `externalLinkForceNewTab` | `article.externalLinkForceNewTab` | Links externos no markdown devem abrir em uma nova aba? |
 <!-- prettier-ignore-end -->

--- a/exampleSite/content/docs/front-matter/index.zh-cn.md
+++ b/exampleSite/content/docs/front-matter/index.zh-cn.md
@@ -56,4 +56,5 @@ front matter 参数中的默认值是从[基础配置]({{< ref "configuration" >
 | `xml` | `true` unless excluded by `sitemap.excludedKinds` | 是否将这篇文章包含在生成的 `/sitemap.xml` 文件中。 |
 | `layoutBackgroundBlur` | `true` | 向下滚动主页时，是否模糊背景图。 |
 | `layoutBackgroundHeaderSpace` | `true` | 在标题和正文之间添加空白区域间隔。 |
+| `externalLinkForceNewTab` | `article.externalLinkForceNewTab` | 是否强制 Markdown 中的外部链接在新标签页中打开。 |
 <!-- prettier-ignore-end -->

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -22,9 +22,17 @@
   {{- end -}}
 {{- end -}}
 
+{{/* Open external links in a new tab if
+  configured to do so by the page param externalLinkForceNewTab
+  or site param article.externalLinkForceNewTab
+  and the link starts with http: or https:
+*/}}
+{{- $forceNewTab := .Page.Params.externalLinkForceNewTab | default (.Page.Site.Params.article.externalLinkForceNewTab | default true) -}}
+{{- $isExternal := or (strings.HasPrefix .Destination "http:") (strings.HasPrefix .Destination "https:") -}}
+{{- $newTab := and $forceNewTab $isExternal -}}
 
 <a href="{{ $href }}" {{ with .Title }}title="{{ . }}"{{ end }}
-  {{- if or (strings.HasPrefix .Destination "http:") (strings.HasPrefix .Destination "https:") }} target="_blank"{{ end }}>
+  {{- if $newTab }} target="_blank" rel="noreferrer"{{ end }}>
   {{- .Text | safeHTML -}}
 </a>
 {{- /* Trim EOF */ -}}


### PR DESCRIPTION
Add a property allowing users to set if external links open in a new browser tab.

This PR allows this to be done in the site-wide `article.externalLinkForceNewTab` property, or the front-matter in each post as `externalLinkForceNewTab`.

This configuration maintains the current behaviour (opening a new tab) as the default is `true`.
If users set it to `false` then the browser default behaviour is honoured.

Apologies for the translations if they are incorrect.

See discussion https://github.com/nunocoracao/blowfish/discussions/2687