### PR TITLE
:bug: fix: respect value of disableHeroImageFilter for content

### DIFF
--- a/layouts/partials/home/hero.html
+++ b/layouts/partials/home/hero.html
@@ -119,7 +119,11 @@
               </div>
             {{ end }}
           </div>
-          <section class="prose prose-invert w-full">{{ .Content }}</section>
+          {{ if not $disableHeroImageFilter }}
+            <section class="prose prose-invert w-full">{{ .Content }}</section>
+          {{ else }}
+            <section class="prose dark:prose-invert w-full">{{ .Content }}</section>
+          {{ end }}
         </div>
       </div>
     </div>


### PR DESCRIPTION
The Blowfish configuration allows to set the parameter `homepage.disableHeroImageFilter`. If set to `true`, the color of the author name and headline adapts to the light/dark mode.

With this patch, the parameter is also respected for the content.

Before:
<img width="576" height="516" alt="grafik" src="https://github.com/user-attachments/assets/35d6abde-b773-45a5-8935-c14a7823802f" />

After:
<img width="576" height="516" alt="grafik" src="https://github.com/user-attachments/assets/b8ac9bfa-35da-43eb-99d2-a0a71b749c86" />
