### PR TITLE
fix archetypes

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,6 +1,6 @@
 ---
-title: "{{ replace .Name "-" " " | title }}"
-date: {{ .Date }}
+title: '{{ replace .Name "-" " " | title }}'
+date: '{{ .Date }}'
 draft: true
 description: ""
 ---

--- a/archetypes/external.md
+++ b/archetypes/external.md
@@ -1,10 +1,10 @@
 ---
-title: "{{ replace .Name "-" " " | title }}"
-date: {{ .Date }}
+title: '{{ replace .Name "-" " " | title }}'
+date: '{{ .Date }}'
 externalUrl: ""
 summary: ""
 showReadingTime: false
-_build:
-  render: "false"
-  list: "local"
+build:
+  render: false
+  list: local
 ---


### PR DESCRIPTION
## Describe your changes

Fix for archetype files replacing double quotes with single quotes and the build that is deprecated in future versions of Hugo.

default file generated by Hugo latest
``` yaml
+++
date = '{{ .Date }}'
draft = true
title = '{{ replace .File.ContentBaseName "-" " " | title }}'
+++
```

 [build REf](https://gohugo.io/content-management/build-options/)

## Issue ticket number and link

- [ ] 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.