### PR TITLE
Feat: typeit support for random shuffle with multiple lines

### DIFF
--- a/layouts/shortcodes/typeit.html
+++ b/layouts/shortcodes/typeit.html
@@ -6,6 +6,7 @@
 {{- $breakLines := .Get "breakLines" | default true -}}
 {{- $waitUntilVisible := .Get "waitUntilVisible" | default true -}}
 {{- $loop := .Get "loop" | default false -}}
+{{- $randomLines := .Get "randomLines" | default false -}}
 {{- $classList := slice -}}
 {{- with .Get "class" -}}
   {{- $classList = $classList | append . -}}
@@ -23,8 +24,15 @@
 
 <script>
     document.addEventListener("DOMContentLoaded", function () {
+      var strings = {{ $content }};
+      {{ if $randomLines }}
+      for (var i = strings.length - 1; i > 0; i--) {
+        var j = Math.floor(Math.random() * (i + 1));
+        [strings[i], strings[j]] = [strings[j], strings[i]];
+      }
+      {{ end }}
       new TypeIt("#{{ $id }}", {
-        strings: {{ $content }},
+        strings: strings,
         speed: {{ $speed }},
         lifeLike: {{ $lifeLike }},
         startDelay: {{ $startDelay }},


### PR DESCRIPTION
Hey, first of all thanks for your work with blowfish – I started tinkering with it for my nerdy blog, and it really hits all the right spots :)

So I really like the idea of using the `typeit` shortcode to support some kind of "fortune say" in the homepage of my blog, with multiple sentences. For added freshness, I added this little patch to the shortcode to have it support random shuffling. 

Thought I would share this patch in case it could be deemed useful. If so, I can go through the hassle of updating the docs!