### PR TITLE
Add support for llms.txt

### DIFF
--- a/layouts/_default/llms.txt
+++ b/layouts/_default/llms.txt
@@ -1,0 +1,41 @@
+{{- /* Recursive printer for sections */ -}}
+{{- define "llms_print_section" -}}
+{{- $section := .section -}}
+{{- $depth := .depth -}}
+{{- if or (gt (len $section.RegularPages) 0) (gt (len $section.Sections) 0) -}}
+{{- $hashes := strings.Repeat (add $depth 1) "#" }}
+
+{{ printf "%s %s" $hashes $section.Title }}
+
+{{- /* Pages in this section */ -}}
+{{- range $p := $section.RegularPages }}
+  {{- if and (not $p.Params.searchHidden) (ne $p.Layout `archives`) (ne $p.Layout `search`) }}
+- [{{ $p.Title }}]({{ $p.Permalink }})
+  {{- end -}}
+{{- end -}}
+
+{{- /* Recurse into subsections */ -}}
+{{- range $s := $section.Sections -}}
+{{- template "llms_print_section" (dict "section" $s "depth" (add $depth 1)) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- /* Main template starts here */ -}}
+# {{ site.Title }}
+
+{{- /* Pages not in any section */ -}}
+{{- $orphans := where site.RegularPages "Section" "" -}}
+{{ if gt (len $orphans) 0 }}
+
+{{- range $p := $orphans -}}
+  {{ if and (not $p.Params.searchHidden) (ne $p.Layout `archives`) (ne $p.Layout `search`) (not $p.IsHome) }}
+- [{{ $p.Title }}]({{ $p.Permalink }})
+  {{- end -}}
+{{- end -}}
+
+{{- end -}}
+
+{{- range site.Sections -}}
+{{- template "llms_print_section" (dict "section" . "depth" 1) -}}
+{{- end }}


### PR DESCRIPTION
The llms.txt file is an industry standard that helps LLMs index content more efficiently, see https://llmstxt.org/

/config/_default/hugo.toml =>
```toml
[outputFormats]
  [outputFormats.llms]
    mediaType = "text/plain"
    baseName = "llms"
    isPlainText = true
    notAlternative = true

[outputs]
  home = ["HTML", "RSS", "JSON", "llms"]
```

From https://github.com/adityatelange/hugo-PaperMod/commit/3bb0ca281fd17eff8e3489011a444f326d7c4c72