### PR TITLE
Fix: make accordian chevron behaviour match admonition

### DIFF
--- a/layouts/shortcodes/accordion.html
+++ b/layouts/shortcodes/accordion.html
@@ -27,6 +27,15 @@
   }
 </style>
 {{ end }}
+<style>
+  #{{ $id }} details[data-accordion-item] > summary .accordion-chevron {
+    transform: rotate(-90deg);
+    transition: transform 200ms ease-in-out;
+  }
+  #{{ $id }} details[data-accordion-item][open] > summary .accordion-chevron {
+    transform: rotate(0deg);
+  }
+</style>
 {{ if eq $mode "collapse" }}
 <script>
   (() => {

--- a/layouts/shortcodes/accordionItem.html
+++ b/layouts/shortcodes/accordionItem.html
@@ -12,7 +12,7 @@
 {{ $isOpen := or (eq $open true) (eq $open "true") }}
 
 <details
-  class="{{ if $isSeparated }}rounded-lg border border-neutral-200 dark:border-neutral-700 overflow-hidden{{ else }}border-none{{ end }}"
+  class="group {{ if $isSeparated }}rounded-lg border border-neutral-200 dark:border-neutral-700 overflow-hidden{{ else }}border-none{{ end }}"
   data-accordion-item
   {{ if $isOpen }}open{{ end }}
 >
@@ -23,8 +23,8 @@
       {{ end }}
       <span>{{ $title }}</span>
     </span>
-    <span>
-      {{ partial "icon" "chevron-down" }}
+    <span class="accordion-chevron ms-auto flex h-5 w-5 items-center justify-center print:hidden">
+      {{ partial "icon.html" "chevron-down" }}
     </span>
   </summary>
   <div class="px-4 pb-4 text-neutral-700 dark:text-neutral-300">


### PR DESCRIPTION
Small fix to polish the accordion shortcode. The chevron now rotates when the element is open, so that it matches the admonition shortcode.

See example below:

<img width="688" height="351" alt="Screenshot 2026-02-15 at 21 57 28" src="https://github.com/user-attachments/assets/9c4d12e8-c99a-4a27-a206-8e2e529708ef" />
