### PR TITLE
feat(comments): add new CSS for nested comments, avatars, and metadata

### DIFF
--- a/assets/css/components/comments.css
+++ b/assets/css/components/comments.css
@@ -1,0 +1,56 @@
+#comments,
+#comments ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+#comments li {
+  position: relative;
+  padding-left: 1rem;
+}
+
+.children-comments {
+  margin-left: 2rem;
+  padding-left: 1.5rem;
+  border-left: 2px dotted rgb(var(--color-neutral-600));
+}
+
+.comment-meta {
+  font-weight: bold;
+  margin-top: 0.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+  color: rgb(var(--color-neutral-300));
+}
+
+.comment-meta a {
+  color: rgb(var(--color-primary-400));
+}
+
+.comment-meta time {
+  font-weight: normal;
+  font-size: 12px;
+  color: rgb(var(--color-neutral-400));
+}
+
+.comment-meta img {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+}
+
+.comment-content {
+  padding: 0.5rem;
+  color: rgb(var(--color-neutral-300));
+  border-radius: 10px;
+  line-height: 1.5;
+  transition: background 0.2s ease;
+  font-size: 15px;
+}
+
+.comment-content:hover {
+  background: rgb(var(--color-neutral-700));
+}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -7,6 +7,7 @@
 @import "./components/tabs.css" layer(utilities);
 @import "./components/zen-mode.css";
 @import "./components/a11y.css";
+@import "./components/comments.css" layer(components);
 @import "./components/admonition.css" layer(components);
 
 html:not(.dark) {


### PR DESCRIPTION
Hi there,
Just to be upfront, I feel much more comfortable with system/backend stuff than frontend, so I hope what I’ve put together here isn’t a total disaster :)

In short: I used a neat WordPress-to-Hugo importer ([wp2hugo](https://github.com/ashishb/wp2hugo)) that can import comments from WordPress. Unfortunately, it doesn’t include any styles, so you have to handle that yourself. This PR takes care of that.

Here’s what it looks like before:
<img width="1670" height="1810" alt="image" src="https://github.com/user-attachments/assets/b7315444-25e0-4d0a-8e19-db80d6872b33" />

…and after applying this PR:
<img width="1638" height="1510" alt="image" src="https://github.com/user-attachments/assets/0d903bb1-6de6-4f83-afdc-ae9ff95a2c81" />

I hope you also like it like me :)
Colors adapts to the color scheme configured in blowfish.

I’d really appreciate it if this could be included in your beautiful theme :)
That way others can benefit from it too.