### PR TITLE
Add optional align parameter to accordion items shortcode.

### DIFF
--- a/exampleSite/content/docs/shortcodes/index.md
+++ b/exampleSite/content/docs/shortcodes/index.md
@@ -116,6 +116,7 @@ The alert sign (`+` or `-`) is optional to control whether the admonition is fol
 | `open`    | **Optional.** Set to `true` to have the item open by default.                                       |
 | `header`  | **Optional.** Alias for `title`, kept for compatibility with other shortcodes.                      |
 | `icon`    | **Optional.** Icon name to display before the title.                                                |
+| `align`   | **Optional.** Align text within the item: `left`, `center`, `right`                                 |
 <!-- prettier-ignore-end -->
 
 **Example 1: `mode="open"` (multiple items can be open) + `separated=true`**

--- a/layouts/shortcodes/accordionItem.html
+++ b/layouts/shortcodes/accordionItem.html
@@ -10,6 +10,7 @@
 {{ $md := .Get "md" | default true }}
 {{ $open := .Get "open" | default false }}
 {{ $isOpen := or (eq $open true) (eq $open "true") }}
+{{ $align := .Get "align" }}
 
 <details
   class="{{ if $isSeparated }}rounded-lg border border-neutral-200 dark:border-neutral-700 overflow-hidden{{ else }}border-none{{ end }}"
@@ -27,7 +28,7 @@
       {{ partial "icon" "chevron-down" }}
     </span>
   </summary>
-  <div class="px-4 pb-4 text-neutral-700 dark:text-neutral-300">
+<div class="px-4 pb-4 text-neutral-700 dark:text-neutral-300{{ if $align }} text-{{ $align }}{{ end }}">
     {{ if $md }}
       {{- .Inner | markdownify -}}
     {{ else }}


### PR DESCRIPTION
On the Blowfish homepage, the accordion / accordion-item shortcode currently inherits the text alignment from the surrounding container for its inner Markdown content. This can lead to unsatisfactory rendering, at least for lists.

I added an optional align parameter to accordion items, allowing explicit control of text alignment (left, center, right) for the content inside each item.

If align is not set, the content inherits the outer container’s alignment (no default is forced).

Please see the attached images for examples:
Before:
<img width="625" height="329" alt="Screenshot_20260225_201543" src="https://github.com/user-attachments/assets/2350c1b7-bd71-4e0c-834e-5318f722370f" />

After:
<img width="621" height="332" alt="Screenshot_20260225_202037" src="https://github.com/user-attachments/assets/202962fe-c744-41c6-8495-1bf14f253687" />
