### PR TITLE
Use Mastodon's official sharing link.

### DIFF
--- a/data/sharing.json
+++ b/data/sharing.json
@@ -52,6 +52,6 @@
   "mastodon": {
     "icon": "mastodon",
     "title": "sharing.mastodon",
-    "url": "https://s2f.kytta.dev/?text=%[2]s %[1]s"
+    "url": "https://share.joinmastodon.org/#text=%[2]s %[1]s"
   }
 }


### PR DESCRIPTION
Use Mastodon's [official sharing link](https://blog.joinmastodon.org/2026/03/a-new-share-button/).