### PR TITLE
fix: skip null colors in repoColors when generating repo-cards CSS

### DIFF
--- a/layouts/partials/vendor.html
+++ b/layouts/partials/vendor.html
@@ -134,7 +134,9 @@
   {{ $cssRules = $cssRules | append ".language-dot[data-language=\"model\"] { background-color: #ff6b35; }" }}
 
   {{ range $lang, $color := $repoColors }}
-    {{ $cssRules = $cssRules | append (printf ".language-dot[data-language=\"%s\"] { background-color: %s; }" $lang $color) }}
+    {{ if $color }}
+      {{ $cssRules = $cssRules | append (printf ".language-dot[data-language=\"%s\"] { background-color: %s; }" $lang $color) }}
+    {{ end }}
   {{ end }}
   {{ $repoCardCSS := resources.FromString "css/repo-cards.css" (delimit $cssRules "\n")
     | minify | resources.Fingerprint (.Site.Params.fingerprintAlgorithm | default "sha512")


### PR DESCRIPTION
## Summary

- `repoColors.json` contains many languages with `null` color values (e.g. `ASL`, `Befunge`, `COBOL`)
- The CSS generation loop in `vendor.html` passed these `null` values directly into `printf` with `%s`, causing Go to emit `%!s(<nil>)` as the color string
- This produced invalid CSS rules like `background-color: %!s(<nil>)` which browsers reject with a parse error

## Fix

Added a `{{ if $color }}` guard to skip `null` entries. Those languages fall back to the `data-language="default"` dot color (`#0077b6`) which is always emitted.

```diff
  {{ range $lang, $color := $repoColors }}
+   {{ if $color }}
      {{ $cssRules = $cssRules | append (printf ".language-dot[data-language=\"%s\"] { background-color: %s; }" $lang $color) }}
+   {{ end }}
  {{ end }}
```

Fixes #2824