### PR TITLE
Shortcode for obfuscated mailto email link

### DIFF
--- a/.vscode/blowfish.code-snippets
+++ b/.vscode/blowfish.code-snippets
@@ -79,7 +79,14 @@
       "{{< /chart >}}"
     ],
     "description": "Use the Chart.js library to embed charts into articles using simple structured data. Blowfish chart Shortcode. Documentation: https://blowfish.page/docs/shortcodes/#chart ",
-  },  
+  },
+  "email": {
+    "prefix": ["BFS-email", "HSC-email", "email"],
+    "body": [
+      "{{< email email=\"mailto:${1:hello@test.com}\" text=\"${2:text}\" subject=\"${3:Reply to awesome article}\" >}}$0",
+    ],
+    "description": "Creates an obfuscated mailto link. Documentation: https://blowfish.page/docs/shortcodes/#email ",
+  },
   "figure": {
     "prefix": ["BFS-figure", "HSC-figure", "figure"],
     "body": [

--- a/exampleSite/content/docs/shortcodes/index.md
+++ b/exampleSite/content/docs/shortcodes/index.md
@@ -375,6 +375,18 @@ This shortcode is for importing code from external sources easily without copyin
 
 <br/><br/><br/>
 
+## Email
+
+Creates an obfuscated mailto link:
+
+```md
+{{</* email email="mailto:hello@test.com" text="text" subject="Reply to awesome article" */>}}
+```
+
+{{< email email="mailto:hello@test.com" text="text" subject="Reply to awesome article" >}}
+
+<br/><br/><br/>
+
 ## Figure
 
 Blowfish includes a `figure` shortcode for adding images to content. The shortcode replaces the base Hugo functionality in order to provide additional performance benefits.

--- a/layouts/shortcodes/email.html
+++ b/layouts/shortcodes/email.html
@@ -1,0 +1,8 @@
+<a 
+  class="email-link"
+  href="#"
+  data-email="{{ .Get "email" | base64Encode }}"
+  {{ with .Get "subject" }}data-subject="{{ . }}"{{ end }}>
+  {{- .Get "text" -}}
+</a>
+{{- /**/ -}}


### PR DESCRIPTION
I've tried to implement a new shortcode that supports the new feature of obfuscated email links introduced in [`v.2.99.0`](https://github.com/nunocoracao/blowfish/releases/tag/v2.99.0) based on [this discussion](https://github.com/nunocoracao/blowfish/discussions/2828#discussioncomment-16096040).

The shortcode code was provided by @ZhenShuo2021.

A new snipped is included in this PR as well as an update to the english docs.