### PR TITLE
Add Paraguay4Life to users list

### DIFF
--- a/exampleSite/content/users/users.json
+++ b/exampleSite/content/users/users.json
@@ -1035,13 +1035,23 @@
       "Personal site",
       "Blog"
     ]
-  }
+  },
   {
     "title": "Robin Fairchild",
     "url": "https://fairchild26.github.io/",
     "tags": [
       "Personal site",
       "Blog"
+    ]
+  },
+  {
+    "title": "Paraguay4Life",
+    "url": "https://paraguay4life.com/",
+    "source": "n/a",
+    "tags": [
+        "Blog",
+        "Travel",
+        "Paraguay",
     ]
   }
 ]

--- a/exampleSite/content/users/users.json
+++ b/exampleSite/content/users/users.json
@@ -1049,9 +1049,9 @@
     "url": "https://paraguay4life.com/",
     "source": "n/a",
     "tags": [
-        "Blog",
-        "Travel",
-        "Paraguay",
+      "Blog",
+      "Travel",
+      "Paraguay"
     ]
   }
 ]


### PR DESCRIPTION
## Summary

This adds Paraguay4Life to the Blowfish users list.

## Site

- Title: Paraguay4Life
- URL: https://paraguay4life.com/

## Notes

The site is built with Blowfish and should be included in `exampleSite/content/users/users.json`.