### PR TITLE
feat: Allow configurable thumbnail aspect ratio for article cards

### DIFF
--- a/assets/css/compiled/main.css
+++ b/assets/css/compiled/main.css
@@ -4676,10 +4676,12 @@ pre {
 }
 .thumbnail_card {
   min-width: 300px;
-  height: 200px;
+  aspect-ratio: var(--thumbnail-aspect-ratio, 1.5);
+  height: auto;
 }
 .thumbnail_card_related {
-  height: 150px;
+  aspect-ratio: var(--thumbnail-aspect-ratio, 1.5);
+  height: auto;
 }
 .thumbnail {
   width: 300px;

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -183,11 +183,13 @@ pre {
 
 .thumbnail_card {
   min-width: 300px;
-  height: 200px;
+  aspect-ratio: var(--thumbnail-aspect-ratio, 1.5);
+  height: auto;
 }
 
 .thumbnail_card_related {
-  height: 150px;
+  aspect-ratio: var(--thumbnail-aspect-ratio, 1.5);
+  height: auto;
 }
 
 .thumbnail {

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -29,6 +29,8 @@ disableTextInHeader = false
 # defaultFeaturedImage = "IMAGE.jpg" # used as default for featured images in all articles
 # defaultSocialImage = "/android-chrome-512x512.png" # used as default for social media sharing (Open Graph and Twitter)
 hotlinkFeatureImage = false
+# Thumbnail aspect ratio as a number (e.g., "1.5", "1.0", "1.777")
+# thumbnailAspectRatio = "1.5"
 # imagePosition = "50% 50%"
 
 # highlightCurrentMenuArea = true

--- a/layouts/partials/article-link/card-related.html
+++ b/layouts/partials/article-link/card-related.html
@@ -6,6 +6,9 @@
 {{ $page := .Page }}
 {{ $featured := "" }}
 {{ $featuredURL := "" }}
+{{ $thumbnailAspectRatio := site.Params.thumbnailAspectRatio | default "1.5" }}
+{{ $thumbnailAspectRatio = replaceRE "[^0-9.]" "" $thumbnailAspectRatio }}
+{{ if eq $thumbnailAspectRatio "" }}{{ $thumbnailAspectRatio = "1.5" }}{{ end }}
 {{/* frontmatter */}}
 {{ with $page }}
   {{ with .Params.featureimage }}
@@ -53,7 +56,7 @@
 <article
   class="article-link--related relative min-h-full min-w-full overflow-hidden rounded-lg border border-neutral-300 dark:border-neutral-600">
   {{ with $featuredURL }}
-    <div class="flex-none relative overflow-hidden thumbnail_card_related">
+    <div class="flex-none relative overflow-hidden thumbnail_card_related" style="--thumbnail-aspect-ratio: {{ $thumbnailAspectRatio }}">
       <img
         src="{{ . }}"
         role="presentation"

--- a/layouts/partials/article-link/card.html
+++ b/layouts/partials/article-link/card.html
@@ -8,6 +8,9 @@
 {{ $page := .Page }}
 {{ $featured := "" }}
 {{ $featuredURL := "" }}
+{{ $thumbnailAspectRatio := site.Params.thumbnailAspectRatio | default "1.5" }}
+{{ $thumbnailAspectRatio = replaceRE "[^0-9.]" "" $thumbnailAspectRatio }}
+{{ if eq $thumbnailAspectRatio "" }}{{ $thumbnailAspectRatio = "1.5" }}{{ end }}
 {{ if not .Params.hideFeatureImage }}
   {{/* frontmatter */}}
   {{ with $page }}
@@ -57,7 +60,7 @@
 <article
   class="article-link--card relative min-h-full min-w-full overflow-hidden rounded-lg border border-neutral-300 dark:border-neutral-600">
   {{ with $featuredURL }}
-    <div class="flex-none relative overflow-hidden thumbnail_card">
+    <div class="flex-none relative overflow-hidden thumbnail_card" style="--thumbnail-aspect-ratio: {{ $thumbnailAspectRatio }}">
       <img
         src="{{ . }}"
         role="presentation"

--- a/layouts/partials/term-link/card.html
+++ b/layouts/partials/term-link/card.html
@@ -2,6 +2,9 @@
 
 {{ $featured := "" }}
 {{ $featuredURL := "" }}
+{{ $thumbnailAspectRatio := site.Params.thumbnailAspectRatio | default "1.5" }}
+{{ $thumbnailAspectRatio = replaceRE "[^0-9.]" "" $thumbnailAspectRatio }}
+{{ if eq $thumbnailAspectRatio "" }}{{ $thumbnailAspectRatio = "1.5" }}{{ end }}
 {{ with .Page.Params.featureimage }}
   {{ if or (strings.HasPrefix . "http:") (strings.HasPrefix . "https:") }}
     {{ $featured = resources.GetRemote . }}
@@ -28,7 +31,7 @@
 <div class="min-w-full">
   <div class="border-neutral-200 dark:border-neutral-700 border-2 rounded overflow-hidden shadow-2xl relative">
     {{ with $featuredURL }}
-      <figure class="not-prose flex-none relative overflow-hidden thumbnail_card">
+      <figure class="not-prose flex-none relative overflow-hidden thumbnail_card" style="--thumbnail-aspect-ratio: {{ $thumbnailAspectRatio }}">
         <img
           src="{{ . }}"
           alt="{{ $.Page.Title }}"


### PR DESCRIPTION
 Closes #2839                                                                                                                        
                                                                                                                                                                                                        
 ## Motivation                                                                                                                                                                                         
                                                                                                                                                                                                        
 Currently, Blowfish uses fixed pixel heights for thumbnail images in article cards (height: 200px for cards, height: 150px for related cards). This causes images with non-3:2 aspect ratios (e.g.,    
 3:1, 16:9) to be cropped awkwardly. Users migrating from other themes who have feature images in different aspect ratios have no way to adjust the display without editing the theme's source code.    
                                                                                                                                                                                                        
 ## Solution                                                                                                                                                                                           
                                                                                                                                                                                                        
 This PR introduces a thumbnailAspectRatio site parameter that allows users to configure the aspect ratio globally via params.toml.                                                                     
                                                                                                                                                                                                        
 Key design decisions:                                                                                                                                                                                  
                                                                                                                                                                                                        
 - CSS variable approach: Uses a CSS custom property (--thumbnail-aspect-ratio) set via inline style on each thumbnail container. This keeps the logic in the template layer while CSS handles the      
 rendering.                                                                                                                                                                                             
 - Decimal values: Uses decimal numbers (e.g., "1.5") instead of fraction notation (e.g., "3/2") for compatibility — Hugo/Go templates cannot parse fractions as valid numeric values for aspect-ratio. 
 - Input sanitization: Strips any non-numeric characters from the user-provided value to prevent malformed CSS output.                                                                                  
 - Global only: Per-page override was intentionally omitted to keep the configuration simple and consistent across the site.                                                                            
                                                                                                                                                                                                        
 ## Usage                                                                                                                                                                                              
                                                                                                                                                                                                        
 Uncomment the following in `config/_default/params.toml`:                                                                                                                                                      
                                                                                                                                                                                                        
 ```toml                                                                                                                                                                                                
   # Thumbnail aspect ratio as a number (e.g., "1.5" for 3:2, "1.77" for 16:9, "3.0" for 3:1)                                                                                                           
   thumbnailAspectRatio = "1.5"                                                                                                                                                                         
 ```                                                                                                                                                                                                    
                                                                                                                                                                                                        
 If not set, the default 1.5 (3:2) is used, preserving the current behavior.                                                                                                                            
                                                                                                                                                                                                        
 ## Changes                                                                                                                                                                                            
                                                                                                                                                                                                        
 | File | Change |                                                                                                                                                                                      
 |--------|--------|                                                                                                                                                                                             
 | `assets/css/main.css` | Replace fixed height with aspect-ratio using CSS variable (1.5 fallback) |                                                                                                     
 | `assets/css/compiled/main.css` | Same — compiled output for immediate effect |                                                                                                                         
 | `config/_default/params.toml` | Add thumbnailAspectRatio parameter (commented out by default) |                                                                                                        
 | `layouts/partials/article-link/card.html` | Read param, sanitize, set CSS variable |                                                                                                                   
 | `layouts/partials/article-link/card-related.html` | Same |                                                                                                                                             
 | `layouts/partials/term-link/card.html` | Same |                                                                                                                                                        
                                                                                                                                                                                                        
 ## Effect

**Before** (if the thumbnail image / featured image's aspect ratio is around 3/1):

<img width="696" height="436" alt="Image" src="https://github.com/user-attachments/assets/ca2ed07a-171b-429e-8c21-32beca14c11e" />

**After** (specify `thumbnailAspectRatio = "3.0"` in `params.toml`):

<img width="697" height="352" alt="Image" src="https://github.com/user-attachments/assets/6a7fa49b-1d32-4220-991f-b61bc98f85c6" />