### PR TITLE
Fix Hugo v0.156.0 template deprecations

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -97,7 +97,7 @@
 {{ end }}
 
 {{ define "SingleAuthor" }}
-  {{ $authorsData := site.Data.authors }}
+  {{ $authorsData := hugo.Data.authors }}
   {{ $taxonomies := site.Taxonomies.authors }}
   {{ $baseURL := site.BaseURL }}
   {{ $taxonomyLink := 0 }}

--- a/layouts/partials/contributors.html
+++ b/layouts/partials/contributors.html
@@ -1,4 +1,4 @@
-{{ with site.Data.contributors }}
+{{ with hugo.Data.contributors }}
 <section class="contributors-section mt-12 mb-16">
   <div class="flex flex-col items-center mb-6">
     <div class="flex items-center gap-2 mb-2">

--- a/layouts/partials/sharing-links.html
+++ b/layouts/partials/sharing-links.html
@@ -1,5 +1,5 @@
 {{ with .Params.sharingLinks | default (.Site.Params.article.sharingLinks | default false) }}
-  {{ $links := site.Data.sharing }}
+  {{ $links := hugo.Data.sharing }}
   <section class="flex flex-row flex-wrap justify-center pt-4 text-xl">
     {{ range . }}
       {{ with index $links . }}

--- a/layouts/partials/sponsors.html
+++ b/layouts/partials/sponsors.html
@@ -1,4 +1,4 @@
-{{ with site.Data.sponsors }}
+{{ with hugo.Data.sponsors }}
 <section class="sponsors-section mt-16 mb-8">
   <div class="flex flex-col items-center mb-6">
     <div class="flex items-center gap-2 mb-2">

--- a/layouts/partials/vendor.html
+++ b/layouts/partials/vendor.html
@@ -124,7 +124,7 @@
 {{ end }}
 
 {{ if $hasRepoCards }}
-  {{ $repoColors := site.Data.repoColors }}
+  {{ $repoColors := hugo.Data.repoColors }}
   {{ $cssRules := slice }}
 
   {{/* default color */}}

--- a/layouts/shortcodes/article.html
+++ b/layouts/shortcodes/article.html
@@ -3,7 +3,11 @@
 {{ $compactSummary := .Get "compactSummary" | default false }}
 {{ $target := .Page }}
 {{ if ne $link .Page.RelPermalink }}
-  {{ $target = index (first 1 (where .Site.AllPages "RelPermalink" $link)) 0 }}
+  {{ $pages := slice }}
+  {{ range hugo.Sites }}
+    {{ $pages = $pages | append .Pages }}
+  {{ end }}
+  {{ $target = index (first 1 (where $pages "RelPermalink" $link)) 0 }}
 {{ end }}
 {{ if $target }}
   <section class="space-y-10 w-full">

--- a/layouts/shortcodes/codeberg.html
+++ b/layouts/shortcodes/codeberg.html
@@ -1,6 +1,6 @@
 {{ $id := delimit (slice "codeberg" (partial "functions/uid.html" .)) "-" }}
 {{- $codebergURL := print "https://codeberg.org/api/v1/repos/" (.Get "repo") -}}
-{{- $repoColors := .Site.Data.repoColors -}}
+{{- $repoColors := hugo.Data.repoColors -}}
 {{- $codebergData := dict -}}
 {{- with try (resources.GetRemote $codebergURL) -}}
   {{- with .Err -}}

--- a/layouts/shortcodes/forgejo.html
+++ b/layouts/shortcodes/forgejo.html
@@ -1,6 +1,6 @@
 {{ $id := delimit (slice "forgejo" (partial "functions/uid.html" .)) "-" }}
 {{- $forgejoURL := print (.Get "server" | default .Site.Params.forgejoDefaultServer) "/api/v1/repos/" (.Get "repo") -}}
-{{- $repoColors := .Site.Data.repoColors -}}
+{{- $repoColors := hugo.Data.repoColors -}}
 {{- $forgejoData := dict -}}
 {{- with try (resources.GetRemote $forgejoURL) -}}
   {{- with .Err -}}

--- a/layouts/shortcodes/gitea.html
+++ b/layouts/shortcodes/gitea.html
@@ -1,6 +1,6 @@
 {{ $id := delimit (slice "gitea" (partial "functions/uid.html" .)) "-" }}
 {{- $giteaURL := print (.Get "server" | default .Site.Params.giteaDefaultServer) "/api/v1/repos/" (.Get "repo") -}}
-{{- $repoColors := .Site.Data.repoColors -}}
+{{- $repoColors := hugo.Data.repoColors -}}
 {{- $giteaData := dict -}}
 {{- with try (resources.GetRemote $giteaURL) -}}
   {{- with .Err -}}

--- a/layouts/shortcodes/github.html
+++ b/layouts/shortcodes/github.html
@@ -2,7 +2,7 @@
 {{- $githubURL := print "https://api.github.com/repos/" (.Get "repo") -}}
 {{- $githubThumbnailURL := print "https://opengraph.githubassets.com/0/" (.Get "repo") -}}
 {{- $showThumbnail := .Get "showThumbnail" | default true -}}
-{{- $repoColors := .Site.Data.repoColors -}}
+{{- $repoColors := hugo.Data.repoColors -}}
 {{- $githubData := dict -}}
 {{- with try (resources.GetRemote $githubURL) -}}
   {{- with .Err -}}

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,6 @@
   publish = "exampleSite/public"
 
 [build.environment]
-HUGO_VERSION = "0.155.3"
+HUGO_VERSION = "0.159.1"
 HUGO_THEMESDIR = "../.."
 HUGO_THEME = "repo"


### PR DESCRIPTION
## Summary
- replace deprecated Site.Data access with project-level hugo.Data
- replace deprecated Site.AllPages usage with iteration over hugo.Sites
- remove all template matches for the v0.156.0 deprecations listed by Hugo

fixes #2861

## Reference
- https://discourse.gohugo.io/t/deprecations-in-v0-156-0/56732
