### PR TITLE
Localization for `article` shortcut

### DIFF
--- a/layouts/shortcodes/article.html
+++ b/layouts/shortcodes/article.html
@@ -1,4 +1,4 @@
-{{ $link := .Get "link" }}
+{{ $link := printf "%s%s" site.LanguagePrefix (.Get "link") }}
 {{ $showSummary := .Get "showSummary" }}
 {{ $compactSummary := .Get "compactSummary" | default false }}
 {{ $target := .Page }}


### PR DESCRIPTION
I made some adjustments to support multiple languages, since I noticed on my blog that these fields weren't being localized