### PR TITLE
✨ Add cookie notice core banner and config

### DIFF
--- a/assets/css/cookie-notice.css
+++ b/assets/css/cookie-notice.css
@@ -1,0 +1,124 @@
+.cookie-notice {
+  position: fixed;
+  inset-inline: 1rem;
+  bottom: 1rem;
+  z-index: 100;
+  display: block;
+}
+
+.cookie-notice[hidden] {
+  display: none;
+}
+
+.cookie-notice__inner {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  width: min(100%, 42rem);
+  margin-inline: auto;
+  padding: 1rem 1.125rem;
+  border: 1px solid rgba(115, 115, 115, 0.2);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.12);
+  backdrop-filter: blur(8px);
+}
+
+.dark .cookie-notice__inner {
+  border-color: rgba(163, 163, 163, 0.18);
+  background: rgba(23, 23, 23, 0.94);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
+}
+
+.cookie-notice__media {
+  flex: 0 0 auto;
+}
+
+.cookie-notice__image {
+  width: 2.25rem;
+  height: 2.25rem;
+  object-fit: contain;
+}
+
+.cookie-notice__content {
+  display: flex;
+  flex: 1 1 auto;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.cookie-notice__text {
+  margin: 0;
+  color: rgb(64, 64, 64);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.dark .cookie-notice__text {
+  color: rgb(212, 212, 212);
+}
+
+.cookie-notice__link {
+  color: inherit;
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 0.12em;
+}
+
+.cookie-notice__button {
+  flex: 0 0 auto;
+  cursor: pointer;
+  border: 1px solid rgba(147, 51, 234, 0.45);
+  border-radius: 0.75rem;
+  background: transparent;
+  padding: 0.625rem 1rem;
+  color: rgb(88, 28, 135);
+  font: inherit;
+  font-weight: 600;
+  line-height: 1;
+  transition: transform 120ms ease, box-shadow 120ms ease, background-color 120ms ease;
+}
+
+.cookie-notice__button:hover,
+.cookie-notice__button:focus-visible {
+  background: rgba(147, 51, 234, 0.08);
+  box-shadow: 0 0 0 3px rgba(147, 51, 234, 0.1);
+  outline: none;
+}
+
+.cookie-notice__button:active {
+  transform: translateY(1px);
+}
+
+.dark .cookie-notice__button {
+  border-color: rgba(192, 132, 252, 0.5);
+  color: rgb(216, 180, 254);
+}
+
+.dark .cookie-notice__button:hover,
+.dark .cookie-notice__button:focus-visible {
+  background: rgba(192, 132, 252, 0.1);
+  box-shadow: 0 0 0 3px rgba(192, 132, 252, 0.12);
+}
+
+@media (max-width: 640px) {
+  .cookie-notice {
+    inset-inline: 0.75rem;
+    bottom: 0.75rem;
+  }
+
+  .cookie-notice__inner {
+    padding: 0.9rem 1rem;
+  }
+
+  .cookie-notice__content {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .cookie-notice__button {
+    width: 100%;
+    justify-content: center;
+  }
+}

--- a/assets/js/cookie-notice.js
+++ b/assets/js/cookie-notice.js
@@ -1,0 +1,59 @@
+(function () {
+  function getStorage(storageName) {
+    try {
+      if (storageName === "sessionStorage") {
+        return window.sessionStorage;
+      }
+
+      return window.localStorage;
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function hideBanner(banner) {
+    banner.setAttribute("hidden", "hidden");
+  }
+
+  function showBanner(banner) {
+    banner.removeAttribute("hidden");
+  }
+
+  function initBanner(banner) {
+    var storageName = banner.getAttribute("data-cookie-notice-storage") || "localStorage";
+    var storageKey = banner.getAttribute("data-cookie-notice-key") || "blowfish_cookie_notice_ack_v1";
+    var acceptButton = banner.querySelector("[data-cookie-notice-accept]");
+    var storage = getStorage(storageName);
+
+    if (storage && storage.getItem(storageKey) === "1") {
+      hideBanner(banner);
+      return;
+    }
+
+    showBanner(banner);
+
+    if (!acceptButton) {
+      return;
+    }
+
+    acceptButton.addEventListener("click", function () {
+      if (storage) {
+        try {
+          storage.setItem(storageKey, "1");
+        } catch (error) {
+          // Ignore storage write failures and still hide the banner for this page view.
+        }
+      }
+
+      hideBanner(banner);
+    });
+  }
+
+  document.addEventListener("DOMContentLoaded", function () {
+    var banners = document.querySelectorAll("[data-cookie-notice]");
+
+    banners.forEach(function (banner) {
+      initBanner(banner);
+    });
+  });
+})();

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -188,3 +188,12 @@ forgejoDefaultServer = "https://v11.next.forgejo.org"
 
 [advertisement]
   # adsense = ""
+
+[cookieNotice]
+  enabled = false
+ # style = "simple"
+ # storage = "sessionStorage"   # localStorage or sessionStorage
+ # storageKey = "blowfish_cookie_notice_ack_v1"
+ # privacyPolicyPageRef = "/legal/privacy-policy"
+ # image = "img/cookie-notice/cookie.svg"
+ # imageAlt = ""

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -102,3 +102,10 @@ admonition:
   tip: "Tip"
   todo: "Todo"
   warning: "Warning"
+
+cookie_notice:
+  message_with_link: "This website uses cookies and similar technologies. Read our privacy policy"
+  message: "This website uses cookies and similar technologies. By using this website, you accept this."
+  privacy_policy: "privacy policy"
+  button: "Got it"
+  image_alt: "Cookie icon"

--- a/layouts/partials/cookie-notice/main.html
+++ b/layouts/partials/cookie-notice/main.html
@@ -1,0 +1,63 @@
+{{ with site.Params.cookieNotice }}
+  {{ if .enabled }}
+    {{ $style := .style | default "simple" }}
+    {{ $storage := .storage | default "localStorage" }}
+    {{ if ne $storage "sessionStorage" }}
+      {{ $storage = "localStorage" }}
+    {{ end }}
+
+    {{ $storageKey := .storageKey | default "blowfish_cookie_notice_ack_v1" }}
+
+    {{ $privacyPolicyUrl := "" }}
+    {{ with .privacyPolicyPageRef }}
+      {{ with site.GetPage . }}
+        {{ $privacyPolicyUrl = .RelPermalink }}
+      {{ end }}
+    {{ end }}
+
+    {{ if and (eq $privacyPolicyUrl "") .privacyPolicyUrl }}
+      {{ $privacyPolicyUrl = .privacyPolicyUrl }}
+    {{ end }}
+
+    {{ $image := .image | default "" }}
+    {{ $imageAlt := .imageAlt | default (i18n "cookie_notice.image_alt") }}
+    {{ $alg := site.Params.fingerprintAlgorithm | default "sha512" }}
+    {{ $css := resources.Get "css/cookie-notice.css" | resources.Minify | resources.Fingerprint $alg }}
+    {{ $js := resources.Get "js/cookie-notice.js" | resources.Minify | resources.Fingerprint $alg }}
+    {{ $partial := printf "cookie-notice/%s.html" $style }}
+
+    <link
+      rel="stylesheet"
+      href="{{ $css.RelPermalink }}"
+      integrity="{{ $css.Data.Integrity }}"
+      crossorigin="anonymous"
+    >
+
+    {{ if templates.Exists (printf "partials/%s" $partial) }}
+      {{ partial $partial (dict
+        "context" $
+        "storage" $storage
+        "storageKey" $storageKey
+        "privacyPolicyUrl" $privacyPolicyUrl
+        "image" $image
+        "imageAlt" $imageAlt
+      ) }}
+    {{ else }}
+      {{ partial "cookie-notice/simple.html" (dict
+        "context" $
+        "storage" $storage
+        "storageKey" $storageKey
+        "privacyPolicyUrl" $privacyPolicyUrl
+        "image" $image
+        "imageAlt" $imageAlt
+      ) }}
+    {{ end }}
+
+    <script
+      src="{{ $js.RelPermalink }}"
+      integrity="{{ $js.Data.Integrity }}"
+      crossorigin="anonymous"
+      defer
+    ></script>
+  {{ end }}
+{{ end }}

--- a/layouts/partials/cookie-notice/simple.html
+++ b/layouts/partials/cookie-notice/simple.html
@@ -1,0 +1,38 @@
+<div
+  class="cookie-notice cookie-notice--simple"
+  data-cookie-notice
+  data-cookie-notice-storage="{{ .storage }}"
+  data-cookie-notice-key="{{ .storageKey }}"
+  hidden
+>
+  <div class="cookie-notice__inner">
+    {{ with .image }}
+      <div class="cookie-notice__media">
+        <img
+          class="cookie-notice__image"
+          src="{{ . | relURL }}"
+          alt="{{ $.imageAlt }}"
+          loading="lazy"
+          decoding="async"
+        >
+      </div>
+    {{ end }}
+
+    <div class="cookie-notice__content">
+      <p class="cookie-notice__text">
+        {{ with .privacyPolicyUrl }}
+          {{ i18n "cookie_notice.message_with_link" }}
+          <a class="cookie-notice__link" href="{{ . }}">
+            {{ i18n "cookie_notice.privacy_policy" }}
+          </a>.
+        {{ else }}
+          {{ i18n "cookie_notice.message" }}
+        {{ end }}
+      </p>
+
+      <button type="button" class="cookie-notice__button" data-cookie-notice-accept>
+        {{ i18n "cookie_notice.button" }}
+      </button>
+    </div>
+  </div>
+</div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -69,6 +69,10 @@
       });
     </script>
   {{ end }}
+
+  {{/* Cookie notice */}}
+  {{ partial "cookie-notice/main.html" . }}
+
   {{/* Extend footer - eg. for extra scripts, etc. */}}
   {{ if templates.Exists "partials/extend-footer.html" }}
     {{ partialCached "extend-footer.html" . }}

--- a/static/img/cookie-notice/cookie.svg
+++ b/static/img/cookie-notice/cookie.svg
@@ -1,0 +1,10 @@
+<svg width="128" height="128" viewBox="0 0 128 128" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="64" cy="64" r="52" fill="#E3B169" stroke="#B67A35" stroke-width="6"/>
+  <circle cx="48" cy="44" r="7" fill="#7B4A25"/>
+  <circle cx="77" cy="39" r="6" fill="#7B4A25"/>
+  <circle cx="86" cy="65" r="8" fill="#7B4A25"/>
+  <circle cx="57" cy="73" r="7" fill="#7B4A25"/>
+  <circle cx="36" cy="67" r="5" fill="#7B4A25"/>
+  <circle cx="73" cy="88" r="5" fill="#7B4A25"/>
+  <path d="M24 55C18 44 22 28 34 19" stroke="#F0D5A0" stroke-width="6" stroke-linecap="round" opacity="0.6"/>
+</svg>


### PR DESCRIPTION
Split from closed PR #2871 as part 1 of 3.

This PR contains only the core cookie notice MVP:
- add the built-in cookie notice partials, JS, CSS, and image asset
- add the base `cookieNotice` configuration
- add the English copy used by the banner
- support the current MVP behavior around dismissing the banner, storage selection, optional image, and privacy-policy linking

This keeps the review focused on the implementation itself.

Intentionally excluded from this PR:
- non-English i18n strings
- docs and example site updates

This is still intended as a minimal built-in banner, not a full consent manager or compliance framework.