### PR TITLE
🐛 Common margin for simple and single layouts

### DIFF
--- a/layouts/_default/simple.html
+++ b/layouts/_default/simple.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
   <article class="max-w-full">
-    <header>
+    <header class="mt-5 max-w-prose">
       {{ if .Params.showBreadcrumbs | default (.Site.Params.article.showBreadcrumbs | default false) }}
         {{ partial "breadcrumbs.html" . }}
       {{ end }}


### PR DESCRIPTION
The distance between the title on a page and the header bar, with `layout: simple` and `layout: single`, is different.

This PR updates the simple layout to use the same margin as the single layout.
This is less jarring for a user as the title is consistently positioned between page types.

| Before | After |
| ------ | ----- |
| <img width="622" height="618" alt="image" src="https://github.com/user-attachments/assets/75e66e69-1d99-4c54-b3cf-1425b73092d9" /> | <img width="622" height="618" alt="image" src="https://github.com/user-attachments/assets/e9e5028c-66a6-4dfb-8a50-a671ca753439" /> |

The CSS class definitions were copied from [layouts/_default/single.html](https://github.com/nunocoracao/blowfish/blob/main/layouts/_default/single.html#L17)

