### PR TITLE
Fix deprecated .Site.LanguageCode references (Hugo v0.158.0+)

### DIFF
--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -17,7 +17,7 @@
     <link>{{ .Permalink }}</link>
     <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
     <generator>Hugo -- gohugo.io</generator>
-    <language>{{ site.LanguageCode }}</language>{{ with .Site.Params.Author.email }}
+    <language>{{ site.Language.Locale }}</language>{{ with .Site.Params.Author.email }}
     <managingEditor>{{.}}{{ with $.Site.Params.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Params.Author.email }}
     <webMaster>{{.}}{{ with $.Site.Params.Author.name }} ({{.}}){{end}}</webMaster>{{end}}
     {{ if .Site.Params.footer.showCopyright | default true -}}

--- a/layouts/_default/sitemap.xml
+++ b/layouts/_default/sitemap.xml
@@ -15,7 +15,7 @@
     />{{ end }}
     <xhtml:link
       rel="alternate"
-      hreflang="{{ .Language.LanguageCode }}"
+      hreflang="{{ .Language.Locale }}"
       href="{{ $link }}"
     />{{ end }}
   </url>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -32,7 +32,7 @@
   <link rel="canonical" href="{{ .Permalink }}">
   {{ if .IsTranslated }}
     {{ range .AllTranslations }}
-      {{ $hreflang := .Language.LanguageCode | default .Language.Lang }}
+      {{ $hreflang := .Language.Locale | default .Language.Lang }}
       {{ if $hreflang }}
         <link rel="alternate" hreflang="{{ $hreflang }}" href="{{ .Permalink }}">
       {{ end }}


### PR DESCRIPTION
## Summary
- Replace deprecated `.Site.LanguageCode` / `.Language.LanguageCode` with `.Site.Language.Locale` / `.Language.Locale`
- Fixes deprecation warnings on Hugo v0.158.0+

## Files changed
- `layouts/_default/rss.xml` — `site.LanguageCode` → `site.Language.Locale`
- `layouts/_default/sitemap.xml` — `.Language.LanguageCode` → `.Language.Locale`
- `layouts/partials/head.html` — `.Language.LanguageCode` → `.Language.Locale`

## Test plan
- [x] RSS feed (`/index.xml`) renders with correct `<language>` tag
- [x] Sitemap hreflang attributes render correctly
- [x] `<head>` hreflang links render correctly
- [x] No deprecation warnings from Hugo
