### PR TITLE
Add configurable meta description fallback order

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -42,6 +42,9 @@ fingerprintAlgorithm = "sha512" # Valid values are "sha512" (default), "sha384",
 giteaDefaultServer = "https://git.fsfe.org"
 forgejoDefaultServer = "https://v11.next.forgejo.org"
 
+[seo]
+# metaDescriptionOrder = ["summary", "description", "site"] # Controls the fallback order for the HTML meta description. Valid values are "summary", "description", and "site".
+
 [header]
   layout = "basic" # valid options: basic, fixed, fixed-fill, fixed-gradient, fixed-fill-blur
 

--- a/exampleSite/content/docs/configuration/index.md
+++ b/exampleSite/content/docs/configuration/index.md
@@ -186,6 +186,7 @@ Many of the article defaults here can be overridden on a per article basis by sp
 | `showViews` | _Not set_ | Whether or not articles and list views are displayed. This requires firebase integrations to be enabled, look below. |
 | `showLikes` | _Not set_ | Whether or not articles and list likes are displayed. This requires firebase integrations to be enabled, look below. |
 | `robots` | _Not set_ | String that indicates how robots should handle your site. If set, it will be output in the page head. Refer to [Google's docs](https://developers.google.com/search/docs/advanced/robots/robots_meta_tag#directives) for valid values. |
+| `seo.metaDescriptionOrder` | `["summary", "description", "site"]` | Controls the fallback order for the HTML meta description. Valid values are `summary`, `description`, and `site`. Use `["description", "summary", "site"]` if you want front matter `description` to take precedence over `summary`. |
 | `disableImageZoom` | `false` | Disables image zoom feature across all the images in the site. |
 | `disableImageOptimization` | `false` | Disables image resize and optimization features across all the images in the site, except images using markdown syntax (`![](image.jpg)`) |
 | `disableImageOptimizationMD` | `false` | Disables image resize and optimization features only for images using markdown syntax (`![](image.jpg)`). |

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -17,8 +17,18 @@
   {{ end }}
 
   {{/* Metadata */}}
-  {{ with (.Params.Summary | default .Params.Description) | default .Site.Params.description }}
-    <meta name="description" content="{{ . }}">
+  {{ $metaDescriptionOrder := .Site.Params.seo.metaDescriptionOrder | default (slice "summary" "description" "site") }}
+  {{ $metaDescriptionSources := dict
+    "summary" .Params.Summary
+    "description" .Params.Description
+    "site" .Site.Params.description
+  }}
+  {{ $metaDescription := "" }}
+  {{ range $metaDescriptionOrder }}
+    {{ $metaDescription = $metaDescription | default (index $metaDescriptionSources (lower .)) }}
+  {{ end }}
+  {{ with $metaDescription }}
+    <meta name="description" content="{{ . | plainify }}">
   {{ end }}
   {{ with  .Params.Tags | default .Site.Params.keywords }}
     <meta name="keywords" content="{{ range . }}{{ . }},{{ end }}">


### PR DESCRIPTION
## Summary

Adds a `seo.metaDescriptionOrder` option to control the fallback order for the HTML meta description.

The default behavior remains unchanged:

```text
summary > description > site
````

Users who want front matter `description` to take precedence can configure:

```toml
[params.seo]
metaDescriptionOrder = ["description", "summary", "site"]
```

This allows separate article summaries and SEO/meta descriptions without overriding `head.html`.

## Changes

* Adds configurable meta description fallback order
* Keeps the existing fallback order as the default
* Documents the new option
* Uses `plainify` when rendering the meta description

## Related

Fixes #2925
Related to #690
