### PR TITLE
🐛 fix: race condition in search query execution

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -151,6 +151,12 @@ function buildIndex() {
 }
 
 function executeQuery(term) {
+  if (!indexed) {
+    buildIndex();
+  }
+  if (!fuse) {
+    return;
+  }
   let results = fuse.search(term);
   let resultsHTML = "";
 
@@ -193,7 +199,7 @@ function executeQuery(term) {
   }
 
   output.innerHTML = resultsHTML;
-  if (results.length > 0) {
+  if (results.length > 0 && output.firstChild) {
     first = output.firstChild.firstElementChild;
     last = output.lastChild.firstElementChild;
   }


### PR DESCRIPTION
### Problem
When a user opens the search modal and starts typing immediately, `executeQuery()` is triggered. Since `buildIndex()` is asynchronous (fetching `index.json`), the `fuse` variable might still be `undefined` when `.search()` is called, resulting in `Uncaught TypeError: Cannot read properties of undefined (reading 'search')`.

### Solution
 - Added a safety check in `executeQuery()` to ensure `indexed` is true and `fuse` is initialized before proceeding.
 - Added a check to `output.firstChild` before attempting to set focus targets for keyboard navigation, preventing secondary errors when results are empty or still rendering.