### PR TITLE
feat: support pageRef in button shortcode

### DIFF
--- a/exampleSite/content/docs/shortcodes/index.md
+++ b/exampleSite/content/docs/shortcodes/index.md
@@ -229,7 +229,7 @@ New article!
 
 ## Button
 
-`button` outputs a styled button component which can be used to highlight a primary action. It has three optional variables `href`, `target` and `rel` which can be used to specify the URL, target and relation of the link.
+`button` outputs a styled button component which can be used to highlight a primary action. It has four optional variables `pageRef`, `href`, `target` and `rel`. `pageRef` resolves an internal page reference using the current page context, producing a language- and trailing-slash-aware URL that is consistent with the theme's navigation menus. `href` accepts any URL or path. When both are set, `pageRef` takes precedence.
 
 **Example:**
 
@@ -241,6 +241,18 @@ Call to action
 
 {{< button href="#button" target="_self" >}}
 Call to action
+{{< /button >}}
+
+**Example using `pageRef`:**
+
+```md
+{{</* button pageRef="docs/getting-started" */>}}
+Get started
+{{</* /button */>}}
+```
+
+{{< button pageRef="docs/getting-started" >}}
+Get started
 {{< /button >}}
 
 <br/><br/><br/>

--- a/layouts/shortcodes/button.html
+++ b/layouts/shortcodes/button.html
@@ -1,6 +1,12 @@
+{{- $href := "" -}}
+{{- with .Get "pageRef" -}}
+  {{- $href = relref $.Page . -}}
+{{- else -}}
+  {{- $href = $.Get "href" -}}
+{{- end -}}
 <a
   class="!rounded-md bg-primary-600 px-4 py-2 !text-neutral !no-underline hover:!bg-primary-500 dark:bg-primary-800 dark:hover:!bg-primary-700"
-  {{ with .Get "href" }}href="{{ . }}"{{ end }}
+  {{ with $href }}href="{{ . }}"{{ end }}
   {{ with .Get "target" }}target="{{ . }}"{{ end }}
   {{ with .Get "rel" }}rel="{{ . }}"{{ end }}
   role="button">


### PR DESCRIPTION
## Problem

The `button` shortcode only takes `href`, `target` and `rel`. There is no way to link to an internal page that picks up Hugo's language prefix and trailing-slash handling automatically, the way menu entries with `pageRef:` do. Authors end up hand-coding `href="/some/path"`, which drifts from the theme's navigation output on multilingual sites.

## Fix

Add an optional `pageRef` attribute. When set, it is resolved with `relref $.Page .` against the calling page, so language and trailing slash come out correct.

```html
{{- $href := "" -}}
{{- with .Get "pageRef" -}}
  {{- $href = relref $.Page . -}}
{{- else -}}
  {{- $href = $.Get "href" -}}
{{- end -}}
```

`href`, `target` and `rel` are unchanged. When `pageRef` is not set, output is byte-identical to current `main`.

## Smoke test

Built against `exampleSite` and a small EN+DE site:

| Input | EN | DE |
|---|---|---|
| `pageRef="about-me"` | `/about-me/` | `/de/about-me/` |
| `href="https://example.com"` | unchanged | unchanged |
| `href="/some/path"` | unchanged | unchanged |

Docs: `exampleSite/content/docs/shortcodes/index.md` is updated with the new option and an example. Other locales left for follow-up.