### PR TITLE
🌐 Localize reply-by-email subject

### DIFF
--- a/i18n/ar.yaml
+++ b/i18n/ar.yaml
@@ -26,6 +26,7 @@ article:
   this_article: "هذه المقالة"
   related_articles: "مقالات ذات صلة"
   reply_by_email: "الرد عبر البريد الإلكتروني"
+  reply_to: "رد على {{ .Title }}"
 
 a11y:
   title: "إعدادات إمكانية الوصول"

--- a/i18n/bg.yaml
+++ b/i18n/bg.yaml
@@ -26,6 +26,7 @@ article:
   this_article: "Тази Статия"
   related_articles: "Подобни"
   reply_by_email: "Отговори по имейл"
+  reply_to: "Отговор на {{ .Title }}"
 
 a11y:
   title: "Настройки за достъпност"

--- a/i18n/bn.yaml
+++ b/i18n/bn.yaml
@@ -26,6 +26,7 @@ article:
   this_article: "This Article"
   related_articles: "Related"
   reply_by_email: "ইমেইলে উত্তর দিন"
+  reply_to: "উত্তর: {{ .Title }}"
 
 a11y:
   title: "অ্যাক্সেসিবিলিটি সেটিংস"

--- a/i18n/ca.yaml
+++ b/i18n/ca.yaml
@@ -26,6 +26,7 @@ article:
   this_article: "Aquest article"
   related_articles: "Relacionats"
   reply_by_email: "Respon per correu electrònic"
+  reply_to: "Resposta a {{ .Title }}"
   zen_mode_title:
     enable: "Habilita el mode zen"
     disable: "Inhabilita el mode zen"

--- a/i18n/cs.yaml
+++ b/i18n/cs.yaml
@@ -26,6 +26,7 @@ article:
   this_article: "Tento článek"
   related_articles: "Related"
   reply_by_email: "Odpovědět e-mailem"
+  reply_to: "Odpověď na {{ .Title }}"
 
 a11y:
   title: "Nastavení přístupnosti"

--- a/i18n/da.yaml
+++ b/i18n/da.yaml
@@ -26,6 +26,7 @@ article:
   this_article: "Denne artikel"
   related_articles: "Relateret"
   reply_by_email: "Svar via email"
+  reply_to: "Svar på {{ .Title }}"
   zen_mode_title:
     enable: "Aktiver zen mode"
     disable: "Deaktiver zen mode"

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -25,6 +25,7 @@ article:
   part: "Teil"
   this_article: "Dieser Artikel"
   related_articles: "Verwandte Artikel"
+  reply_by_email: "Per E-Mail antworten"
   reply_to: "Antwort auf {{ .Title }}"
   zen_mode_title:
     enable: "Zen-Modus aktivieren"

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -25,7 +25,7 @@ article:
   part: "Teil"
   this_article: "Dieser Artikel"
   related_articles: "Verwandte Artikel"
-  reply_by_email: "Per E-Mail antworten"
+  reply_to: "Antwort auf {{ .Title }}"
   zen_mode_title:
     enable: "Zen-Modus aktivieren"
     disable: "Zen-Modus deaktivieren"

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -26,6 +26,7 @@ article:
   this_article: "This Article"
   related_articles: "Related"
   reply_by_email: "Reply by Email"
+  reply_to: "Reply to {{ .Title }}"
   zen_mode_title:
     enable: "Enable zen mode"
     disable: "Disable zen mode"

--- a/i18n/eo.yaml
+++ b/i18n/eo.yaml
@@ -26,6 +26,7 @@ article:
   this_article: "Tiu ĉi artikolo"
   related_articles: "Rilataj"
   reply_by_email: "Respondu per retpoŝto"
+  reply_to: "Respondo al {{ .Title }}"
   zen_mode_title:
     enable: "Ŝalti zen-reĝimon"
     disable: "Malŝalti zen-reĝimon"

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -26,6 +26,7 @@ article:
   this_article: "Este artículo"
   related_articles: "Relacionados"
   reply_by_email: "Responder por email"
+  reply_to: "Respuesta a {{ .Title }}"
   zen_mode_title:
     enable: "Activar modo zen"
     disable: "Desactivar modo zen"

--- a/i18n/eu.yaml
+++ b/i18n/eu.yaml
@@ -26,6 +26,7 @@ article:
   this_article: "Artikulu hau"
   related_articles: "Lotutakoak"
   reply_by_email: "Erantzun emailez"
+  reply_to: "Erantzuna: {{ .Title }}"
   zen_mode_title:
     enable: "Gaitu zen modua"
     disable: "Desgaitu zen modua"

--- a/i18n/fa.yaml
+++ b/i18n/fa.yaml
@@ -26,6 +26,7 @@ article:
   this_article: "همین مقاله"
   related_articles: "مقاله‌های مرتبط"
   reply_by_email: "پاسخ از طریق ایمیل"
+  reply_to: "پاسخ به {{ .Title }}"
   zen_mode_title:
     enable: "فعال کردن حالت تمام متن"
     disable: "غیر فعال کردن حالت تمام متن"

--- a/i18n/fi.yaml
+++ b/i18n/fi.yaml
@@ -20,6 +20,7 @@ article:
   this_article: "This Article"
   related_articles: "Related"
   reply_by_email: "Vastaa sähköpostitse"
+  reply_to: "Vastaus: {{ .Title }}"
 
 a11y:
   title: "Esteettömyysasetukset"

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -20,6 +20,7 @@ article:
   this_article: "Cet article"
   related_articles: "Articles connexes"
   reply_by_email: "Répondre par email"
+  reply_to: "Réponse à {{ .Title }}"
   zen_mode_title:
     enable: "Activer le mode zen"
     disable: "Désactiver le mode zen"

--- a/i18n/gl.yaml
+++ b/i18n/gl.yaml
@@ -26,6 +26,7 @@ article:
   this_article: "Este artigo"
   related_articles: "Relacionados"
   reply_by_email: "Responder por email"
+  reply_to: "Resposta a {{ .Title }}"
   zen_mode_title:
     enable: "Activar modo zen"
     disable: "Desactivar modo zen"

--- a/i18n/he.yaml
+++ b/i18n/he.yaml
@@ -20,6 +20,7 @@ article:
   this_article: "This Article"
   related_articles: "Related"
   reply_by_email: "השב בדוא\"ל"
+  reply_to: "תגובה ל-{{ .Title }}"
 
 a11y:
   title: "הגדרות נגישות"

--- a/i18n/hr.yaml
+++ b/i18n/hr.yaml
@@ -26,6 +26,7 @@ article:
   this_article: "This Article"
   related_articles: "Related"
   reply_by_email: "Odgovori e-poštom"
+  reply_to: "Odgovor na {{ .Title }}"
 
 a11y:
   title: "Postavke pristupačnosti"

--- a/i18n/hu.yaml
+++ b/i18n/hu.yaml
@@ -20,6 +20,7 @@ article:
   this_article: "This Article"
   related_articles: "Related"
   reply_by_email: "Válasz emailben"
+  reply_to: "Válasz erre: {{ .Title }}"
 
 a11y:
   title: "Akadálymentességi beállítások"

--- a/i18n/id.yaml
+++ b/i18n/id.yaml
@@ -26,6 +26,7 @@ article:
   this_article: "Artikel ini"
   related_articles: "Terkait"
   reply_by_email: "Balas melalui email"
+  reply_to: "Balasan untuk {{ .Title }}"
 
 a11y:
   title: "Pengaturan aksesibilitas"

--- a/i18n/it.yaml
+++ b/i18n/it.yaml
@@ -20,6 +20,7 @@ article:
   this_article: "Questo articolo"
   related_articles: "Articoli correlati"
   reply_by_email: "Rispondi via email"
+  reply_to: "Risposta a {{ .Title }}"
 
 a11y:
   title: "Impostazioni di accessibilità"

--- a/i18n/ja.yaml
+++ b/i18n/ja.yaml
@@ -26,6 +26,7 @@ article:
   this_article: "この記事"
   related_articles: "関連記事"
   reply_by_email: "メールで返信"
+  reply_to: "{{ .Title }} への返信"
   zen_mode_title:
     enable: "Zenモードを有効にする"
     disable: "Zenモードを無効にする"

--- a/i18n/ko.yaml
+++ b/i18n/ko.yaml
@@ -26,6 +26,7 @@ article:
   this_article: "이 글"
   related_articles: "관련 글"
   reply_by_email: "이메일로 답장"
+  reply_to: "{{ .Title }}에 대한 답장"
 
 a11y:
   title: "접근성 설정"

--- a/i18n/nl.yaml
+++ b/i18n/nl.yaml
@@ -26,6 +26,7 @@ article:
   this_article: "Dit artikel"
   related_articles: "Gerelateerde artikelen"
   reply_by_email: "Reageren via email"
+  reply_to: "Reactie op {{ .Title }}"
   zen_mode_title:
     enable: "Zen-modus inschakelen"
     disable: "Zen-modus uitschakelen"

--- a/i18n/pl.yaml
+++ b/i18n/pl.yaml
@@ -26,6 +26,7 @@ article:
   this_article: "This Article"
   related_articles: "Related"
   reply_by_email: "Odpowiedz przez email"
+  reply_to: "Odpowiedź na {{ .Title }}"
 
 a11y:
   title: "Ustawienia dostępności"

--- a/i18n/pt-BR.yaml
+++ b/i18n/pt-BR.yaml
@@ -23,6 +23,7 @@ article:
   this_article: "Esse Artigo"
   related_articles: "Relacionados"
   reply_by_email: "Responder por email"
+  reply_to: "Resposta a {{ .Title }}"
 
 a11y:
   title: "Configurações de acessibilidade"

--- a/i18n/pt-PT.yaml
+++ b/i18n/pt-PT.yaml
@@ -23,6 +23,7 @@ article:
   this_article: "Este artigo"
   related_articles: "Relacionados"
   reply_by_email: "Responder por email"
+  reply_to: "Resposta a {{ .Title }}"
 
 a11y:
   title: "Definições de acessibilidade"

--- a/i18n/ro.yaml
+++ b/i18n/ro.yaml
@@ -20,6 +20,7 @@ article:
   this_article: "This Article"
   related_articles: "Related"
   reply_by_email: "Răspunde prin email"
+  reply_to: "Răspuns la {{ .Title }}"
 
 a11y:
   title: "Setări de accesibilitate"

--- a/i18n/ru.yaml
+++ b/i18n/ru.yaml
@@ -26,6 +26,7 @@ article:
   this_article: "This Article"
   related_articles: "Related"
   reply_by_email: "Ответить по электронной почте"
+  reply_to: "Ответ на {{ .Title }}"
 
 a11y:
   title: "Настройки доступности"

--- a/i18n/sv.yaml
+++ b/i18n/sv.yaml
@@ -20,6 +20,7 @@ article:
   this_article: "Denna artikel"
   related_articles: "Relaterade"
   reply_by_email: "Svara via email"
+  reply_to: "Svar på {{ .Title }}"
 
 a11y:
   title: "Tillgänglighetsinställningar"

--- a/i18n/th.yaml
+++ b/i18n/th.yaml
@@ -26,6 +26,7 @@ article:
   this_article: "บทความนี้"
   related_articles: "บทความที่เกี่ยวข้อง"
   reply_by_email: "ตอบกลับทางอีเมล"
+  reply_to: "ตอบกลับ {{ .Title }}"
   zen_mode_title:
     enable: "เปิดโหมดเซน"
     disable: "ปิดโหมดเซน"

--- a/i18n/tr.yaml
+++ b/i18n/tr.yaml
@@ -19,6 +19,7 @@ article:
   this_article: "This Article"
   related_articles: "Related"
   reply_by_email: "E-posta ile yanıtla"
+  reply_to: "Yanıt: {{ .Title }}"
 
 a11y:
   title: "Erişilebilirlik ayarları"

--- a/i18n/uk.yaml
+++ b/i18n/uk.yaml
@@ -30,6 +30,7 @@ article:
   this_article: "This Article"
   related_articles: "Related"
   reply_by_email: "Відповісти електронною поштою"
+  reply_to: "Відповідь на {{ .Title }}"
   zen_mode_title:
     enable: "Enable zen mode"
     disable: "Disable zen mode"

--- a/i18n/vi.yaml
+++ b/i18n/vi.yaml
@@ -26,6 +26,7 @@ article:
   this_article: "Bài viết này"
   related_articles: "Bài viết liên quan"
   reply_by_email: "Trả lời qua email"
+  reply_to: "Trả lời {{ .Title }}"
   zen_mode_title:
     enable: "Bật zen mode"
     disable: "Tắt zen mode"

--- a/i18n/zh-CN.yaml
+++ b/i18n/zh-CN.yaml
@@ -26,6 +26,7 @@ article:
   this_article: "本文"
   related_articles: "相关文章"
   reply_by_email: "通过邮件回复"
+  reply_to: "回复 {{ .Title }}"
   zen_mode_title:
     enable: "啟用阅读模式"
     disable: "停用阅读模式"

--- a/i18n/zh-TW.yaml
+++ b/i18n/zh-TW.yaml
@@ -26,6 +26,7 @@ article:
   this_article: "本文"
   related_articles: "相關文章"
   reply_by_email: "透過郵件回覆"
+  reply_to: "回覆 {{ .Title }}"
   zen_mode_title:
     enable: "啟用閱讀模式"
     disable: "停用閱讀模式"

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -51,12 +51,13 @@
           {{ $defaultReplyByEmail := site.Params.replyByEmail }}
           {{ $replyByEmail := default $defaultReplyByEmail .Params.replyByEmail }}
           {{ if $replyByEmail }}
+            {{ $replySubject := i18n "article.reply_to" (dict "Title" .Title) | default (printf "Reply to %s" .Title) }}
             <strong class="block mt-8">
               <a
                 class="email-link m-1 rounded bg-neutral-300 p-1.5 text-neutral-700 hover:bg-primary-500 hover:text-neutral dark:bg-neutral-700 dark:text-neutral-300 dark:hover:bg-primary-400 dark:hover:text-neutral-800"
                 href="#"
                 data-email="{{ site.Params.Author.email | base64Encode }}"
-                data-subject="{{ replace (printf "Reply to %s" .Title) "\"" "'" }}">
+                data-subject="{{ replace $replySubject "\"" "'" }}">
                 {{ i18n "article.reply_by_email" | default "Reply by Email" }}
               </a>
               <noscript>


### PR DESCRIPTION
## Summary

Fixes #2936

This PR localizes the reply-by-email subject line.

The visible reply-by-email label already uses the `article.reply_by_email` i18n key, but the generated email subject still used the hardcoded English prefix `Reply to`.

This adds a new `article.reply_to` i18n key and uses it when generating the `data-subject` value.

## Changes

- replace the hardcoded `Reply to <title>` subject with an i18n-based subject
- pass the article title as `{{ .Title }}` so translations can control word order
- add the new `article.reply_to` key to the i18n files
- keep the existing English subject as fallback

## Backward compatibility

The change is backward-compatible. If the new i18n key is missing, the existing English fallback is still used.