### PR TITLE
♿️ Fix appearance switcher accessibility tooltips

### DIFF
--- a/assets/js/appearance.js
+++ b/assets/js/appearance.js
@@ -54,11 +54,32 @@ window.addEventListener("DOMContentLoaded", (event) => {
   const switcher = document.getElementById("appearance-switcher");
   const switcherMobile = document.getElementById("appearance-switcher-mobile");
 
+  // Load the i18n translations for the tooltips
+  const darkLabel = '{{ i18n "footer.dark_appearance" }}';
+  const lightLabel = '{{ i18n "footer.light_appearance" }}';
+
   updateMeta();
   this.updateLogo?.(getTargetAppearance());
 
   // Initialize mermaid theme on page load
   updateMermaidTheme();
+
+  // Helper to update the tooltip depending on the current mode
+  const updateTooltip = (targetAppearance) => {
+    // If target is dark, the next action will be switching to light
+    const label = targetAppearance === "dark" ? lightLabel : darkLabel;
+    if (switcher) {
+      switcher.setAttribute("aria-label", label);
+      switcher.setAttribute("title", label);
+    }
+    if (switcherMobile) {
+      switcherMobile.setAttribute("aria-label", label);
+      switcherMobile.setAttribute("title", label);
+    }
+  };
+
+  // Set initial tooltip on load
+  updateTooltip(getTargetAppearance());
 
   if (switcher) {
     switcher.addEventListener("click", () => {
@@ -70,6 +91,7 @@ window.addEventListener("DOMContentLoaded", (event) => {
       );
       updateMeta();
       updateMermaidTheme();
+      updateTooltip(targetAppearance);
       this.updateLogo?.(targetAppearance);
     });
     switcher.addEventListener("contextmenu", (event) => {
@@ -87,6 +109,7 @@ window.addEventListener("DOMContentLoaded", (event) => {
       );
       updateMeta();
       updateMermaidTheme();
+      updateTooltip(targetAppearance);
       this.updateLogo?.(targetAppearance);
     });
     switcherMobile.addEventListener("contextmenu", (event) => {

--- a/layouts/partials/header/components/desktop-menu.html
+++ b/layouts/partials/header/components/desktop-menu.html
@@ -24,9 +24,10 @@
     <div class="flex items-center">
       <button
         id="appearance-switcher"
-        aria-label="Dark mode switcher"
+        aria-label="{{ i18n "footer.dark_appearance" }}"
         type="button"
-        class="text-base bf-icon-color-hover">
+        class="text-base bf-icon-color-hover"
+        title="{{ i18n "footer.dark_appearance" }}">
         <div class="flex items-center justify-center dark:hidden">
           {{ partial "icon.html" "moon" }}
         </div>

--- a/layouts/partials/header/components/mobile-menu.html
+++ b/layouts/partials/header/components/mobile-menu.html
@@ -13,7 +13,8 @@
     <button
       id="appearance-switcher-mobile"
       type="button"
-      aria-label="Dark mode switcher"
+      aria-label="{{ i18n "footer.dark_appearance" }}"
+      title="{{ i18n "footer.dark_appearance" }}"
       class="flex items-center justify-center text-neutral-900 hover:text-primary-600 dark:text-neutral-200 dark:hover:text-primary-400">
       <div class="dark:hidden">
         {{ partial "icon.html" "moon" }}


### PR DESCRIPTION
### Summary
This PR fixes an accessibility and localization issue with the light/dark appearance switchers in both the desktop and mobile navigation menus.

### Details
Previously, the `aria-label` and `title` attributes for the appearance switcher were hardcoded to the English string `"Dark mode switcher"`. Furthermore, because the string was static in the HTML, the tooltip never updated when the user toggled the theme.

This PR addresses this by:
1. Replacing the hardcoded strings in `desktop-menu.html` and `mobile-menu.html` with the native `footer.dark_appearance` and `footer.light_appearance` i18n variables.
2. Updating `appearance.js` to dynamically swap the `aria-label` and `title` attributes whenever the user clicks the toggle. The tooltip now accurately reflects the "next" state in the user's localized language (e.g., showing "Switch to light appearance" when the user is currently in dark mode).

*(Note: PR was AI-assisted)*