### PR TITLE
fix: use relative URL for search index to support alternate domains

### DIFF
--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -1,7 +1,7 @@
 <div
   id="search-wrapper"
   class="invisible fixed inset-0 flex h-screen w-screen cursor-default flex-col bg-neutral-500/50 p-4 backdrop-blur-sm dark:bg-neutral-900/50 sm:p-6 md:p-[10vh] lg:p-[12vh] z-500"
-  data-url="{{ "" | absLangURL }}">
+  data-url="{{ "" | relLangURL }}">
   <div
     id="search-modal"
     class="flex flex-col w-full max-w-3xl min-h-0 mx-auto border rounded-md shadow-lg top-20 border-neutral-200 bg-neutral dark:border-neutral-700 dark:bg-neutral-800">


### PR DESCRIPTION
## Problem

When a Blowfish site is served on a domain that differs from the configured `baseURL` (e.g., `www.example.com` vs `example.com`, or alternate domains like `blog.example.com`), the search feature fails silently.

**Root cause:** `layouts/partials/search.html` uses `absLangURL` to build the URL for fetching `index.json`:

```html
data-url="{{ "" | absLangURL }}"
```

This always resolves to the full absolute URL based on `baseURL` (e.g., `https://example.com/`). When a user visits `www.example.com`, the search JS fetches `https://example.com/index.json` -- a cross-origin request that gets blocked by the browser's same-origin policy.

## Fix

Change `absLangURL` to `relLangURL` so the search index is fetched from the current origin using a relative path:

```html
data-url="{{ "" | relLangURL }}"
```

This generates a relative URL (e.g., `/`), so the browser requests `/index.json` from whichever domain the user is actually on. Multi-language setups are still handled correctly (`relLangURL` produces `/en/`, `/fr/`, etc. as appropriate).

## Testing

Verified on a site accessible via `tomrochette.com`, `www.tomrochette.com`, and `blog.tomrochette.com` -- search now works on all three domains.