### PR TITLE
🐛 fix(schema): resolve article author from data/authors

### DIFF
--- a/layouts/partials/schema.html
+++ b/layouts/partials/schema.html
@@ -17,6 +17,22 @@
   </script>
 {{ else }}
   {{- $iso8601 := "2006-01-02T15:04:05-07:00" -}}
+  {{- /* Resolve the author: first `authors` front matter key looked up in data/authors/, else the site author. */ -}}
+  {{- $author := .Site.Params.Author -}}
+  {{- with .Params.authors -}}
+    {{- with index site.Data.authors (index . 0 | lower) -}}
+      {{- $author = . -}}
+    {{- end -}}
+  {{- end -}}
+  {{- /* sameAs from social profiles: data/authors uses `social`, the site author uses `links` (each a {platform: url} map). */ -}}
+  {{- $sameAs := slice -}}
+  {{- range (or $author.social $author.links) -}}
+    {{- range $platform, $url := . -}}
+      {{- if not (strings.HasPrefix $url "mailto:") -}}
+        {{- $sameAs = $sameAs | append $url -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
   <script type="application/ld+json">
   [{
     "@context": "https://schema.org",
@@ -29,7 +45,9 @@
     "url" : {{ .Permalink }},
     "author" : {
       "@type": "Person",
-      "name": "{{ .Site.Params.Author.name | safeJS }}"
+      "name": "{{ $author.name | safeJS }}"{{ with $author.image }},
+      "image": {{ . | absURL }}{{ end }}{{ if $sameAs }},
+      "sameAs": [{{ range $i, $u := $sameAs }}{{ if $i }}, {{ end }}{{ $u }}{{ end }}]{{ end }}
     },
     {{ with .PublishDate }}"copyrightYear": "{{ .Format "2006" }}",{{ end }}
     {{ with .Date }}"dateCreated": "{{ .Format $iso8601 }}",{{ end }}


### PR DESCRIPTION
## Describe your changes

`layouts/partials/schema.html` always read the author from `.Site.Params.Author`, so the structured-data `author` was the site-level author (or empty) regardless of a post's `authors` front matter — despite the theme supporting multiple authors via `data/authors/`.

This resolves the first `authors` key against `data/authors/` and emits that author's `name`, `image`, and `sameAs` (from their `social`/`links`), falling back to the site-level author when there's no match. Single-author sites are unaffected apart from the additive `image`/`sameAs` fields; backward compatible. A future enhancement could emit an array of all `authors` rather than just the first — kept to the first here to match the issue's suggested fix and keep the change focused.

Validated by building the `exampleSite`: the multi-author sample resolves to the post's author, and missing-key, uppercase-key, `mailto:` filtering, and no-social authors all behave correctly. Prettier-clean against the repo config.

## Issue ticket number and link

Fixes #2943 — https://github.com/nunocoracao/blowfish/issues/2943

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Will this be part of a product update? Structured data `author` now reflects a post's `data/authors/` entry instead of always the site author.