### PR TITLE
🐛 fix(schema): use page URL for mainEntityOfPage

### DIFF
--- a/layouts/partials/schema.html
+++ b/layouts/partials/schema.html
@@ -41,7 +41,7 @@
     {{ else }}
     {{ with .Params.tags }}"keywords": {{ . }},{{ end }}
     {{ end }}
-    "mainEntityOfPage": "true",
+    "mainEntityOfPage": {{ .Permalink }},
     "wordCount": "{{ .WordCount }}"
   }{{ if site.Params.enableStructuredBreadcrumbs | default false }},
   {


### PR DESCRIPTION
## Describe your changes

The `Article` JSON-LD in `layouts/partials/schema.html` set `"mainEntityOfPage": "true"` (a literal boolean string) on every non-home page. Per [schema.org/mainEntityOfPage](https://schema.org/mainEntityOfPage), the property expects a `CreativeWork` or a `URL` — a boolean is not valid.

This emits the page's canonical URL instead, mirroring the adjacent `"url" : {{ .Permalink }}` in the same block. Verified against the exampleSite build: `mainEntityOfPage` now equals the page URL and all JSON-LD remains valid. Prettier-clean.

## Issue ticket number and link

Fixes #2971 — https://github.com/nunocoracao/blowfish/issues/2971

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Will this be part of a product update? `mainEntityOfPage` in article structured data is now a valid URL instead of the string "true".