### PR TITLE
✨ Add basic microformats2 support

### DIFF
--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -13,6 +13,7 @@ enableA11y = false
 enableSearch = true
 enableCodeCopy = true
 enableStructuredBreadcrumbs = true
+enableMicroformats2 = false
 
 replyByEmail = false
 

--- a/exampleSite/content/docs/configuration/index.md
+++ b/exampleSite/content/docs/configuration/index.md
@@ -179,6 +179,7 @@ Many of the article defaults here can be overridden on a per article basis by sp
 | `enableCodeCopy` | `false` | Whether copy-to-clipboard buttons are enabled for `<code>` blocks. The `highlight.noClasses` parameter must be set to `false` for code copy to function correctly. Read more about [other configuration files](#other-configuration-files) below. |
 | `enableStructuredBreadcrumbs` | `false` | Whether to add [BreadcrumbList](https://developers.google.com/search/docs/appearance/structured-data/breadcrumb) for SEO. Do NOT enable this if your content path does not match the URL, i.e., complex [URL setting](https://gohugo.io/content-management/urls/). |
 | `enableStyledScrollbar` | `true` | Whether to enable styled scrollbar via tailwind-scrollbar. Set to `false` to use the browser's default scrollbar styling. |
+| `enableMicroformats2` | `false` | Whether to add [microformats2](https://microformats.org/wiki/microformats2) markup: `h-entry` on posts, `h-feed` on list pages, and a representative `h-card` in the footer. Lets IndieWeb tooling (webmentions, feed readers, IndieAuth) parse author and post metadata from the rendered HTML. See also `verification.fediverse` to attribute links shared on the Fediverse (e.g. Mastodon) to your account. |
 | `replyByEmail` | `false` | Whether the reply-by-email link is enabled after post. The `params.author.email` parameter in `config/_default/languages.en.toml` must be set. |
 | `forgejoDefaultServer` | _Not set_ | The default `server` parameter for the `forgejo` shortcode. |
 | `giteaDefaultServer` | _Not set_ | The default `server` parameter for the `gitea` shortcode. |
@@ -384,7 +385,7 @@ Many of the article defaults here can be overridden on a per article basis by sp
 | `verification.bing` | _Not set_ | The site verification string provided by Bing to be included in the site metadata. |
 | `verification.pinterest` | _Not set_ | The site verification string provided by Pinterest to be included in the site metadata. |
 | `verification.yandex` | _Not set_ | The site verification string provided by Yandex to be included in the site metadata. |
-| `verification.fediverse` | _Not set_ | The fediverse handle to include in the site metadata. Include the server domain in the username, e.g. `@you@instanceaddress.tld`. |
+| `verification.fediverse` | _Not set_ | The fediverse handle to include in the site metadata. Include the server domain in the username, e.g. `@you@instanceaddress.tld`. See also `enableMicroformats2` for IndieWeb author and post discovery. |
 <!-- prettier-ignore-end -->
 
 ### RSSNext

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,5 +1,6 @@
 {{ define "main" }}
   {{ .Scratch.Set "scope" "list" }}
+  {{ $mf2 := site.Params.enableMicroformats2 | default false }}
   {{ $enableToc := .Params.showTableOfContents | default (site.Params.list.showTableOfContents | default false) }}
   {{ $showToc := and $enableToc (in .TableOfContents "<ul") }}
 
@@ -49,7 +50,7 @@
     {{ $groupByYear := and (not $orderByWeight) $groupByYear }}
 
     {{ if not $cardView }}
-      <section class="space-y-10 w-full">
+      <section class="{{ if $mf2 }}h-feed {{ end }}space-y-10 w-full">
         {{ if not $orderByWeight }}
           {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
             {{ if $groupByYear }}
@@ -76,7 +77,7 @@
               <h2 class="mt-12 mb-3 text-2xl font-bold text-neutral-700 first:mt-8 dark:text-neutral-300">
                 {{ .Key }}
               </h2>
-              <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
+              <section class="{{ if $mf2 }}h-feed {{ end }}w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
                 {{ range .Pages }}
                   {{ partial "article-link/card.html" . }}
                 {{ end }}
@@ -86,7 +87,7 @@
             <h2 class="mt-12 mb-3 text-2xl font-bold text-neutral-700 first:mt-8 dark:text-neutral-300">
               {{ .Key }}
             </h2>
-            <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+            <section class="{{ if $mf2 }}h-feed {{ end }}w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3">
               {{ range .Pages }}
                 {{ partial "article-link/card.html" . }}
               {{ end }}
@@ -98,7 +99,7 @@
       {{ else }}
         {{ if $cardViewScreenWidth }}
           <div class="relative w-screen max-w-[1600px] px-[30px] start-[calc(max(-50vw,-800px)+50%)]">
-            <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
+            <section class="{{ if $mf2 }}h-feed {{ end }}w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
               {{ if not $orderByWeight }}
                 {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
                   {{ range .Pages }}
@@ -113,7 +114,7 @@
             </section>
           </div>
         {{ else }}
-          <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+          <section class="{{ if $mf2 }}h-feed {{ end }}w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3">
             {{ if not $orderByWeight }}
               {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
                 {{ range .Pages }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,6 +1,18 @@
 {{ define "main" }}
   {{ .Scratch.Set "scope" "single" }}
-  <article>
+  {{ $mf2 := site.Params.enableMicroformats2 | default false }}
+  <article{{ if $mf2 }} class="h-entry"{{ end }}>
+    {{ if $mf2 }}
+      {{/* microformats2: hidden h-entry metadata for IndieWeb / webmention discovery. */}}
+      <a class="u-url u-uid" href="{{ .Permalink }}" hidden>{{ .Title }}</a>
+      <time class="dt-published" datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}" hidden></time>
+      {{ if .Lastmod.After .Date }}
+        <time class="dt-updated" datetime="{{ .Lastmod.Format "2006-01-02T15:04:05Z07:00" }}" hidden></time>
+      {{ end }}
+      <div class="p-author h-card" hidden>
+        <a class="u-url p-name" href="{{ site.Home.Permalink }}">{{ site.Params.Author.name }}</a>
+      </div>
+    {{ end }}
     {{/* Hero */}}
     {{ if .Params.showHero | default (site.Params.article.showHero | default false) }}
       {{ $heroStyle := .Params.heroStyle }}
@@ -18,7 +30,7 @@
       {{ if .Params.showBreadcrumbs | default (site.Params.article.showBreadcrumbs | default false) }}
         {{ partial "breadcrumbs.html" . }}
       {{ end }}
-      <h1 class="mt-0 text-4xl font-extrabold text-neutral-900 dark:text-neutral">
+      <h1 class="{{ if $mf2 }}p-name {{ end }}mt-0 text-4xl font-extrabold text-neutral-900 dark:text-neutral">
         {{ .Title | emojify }}
       </h1>
       <div class="mt-1 mb-6 text-base text-neutral-500 dark:text-neutral-400 print:hidden">
@@ -47,7 +59,9 @@
       <div class="min-w-0 min-h-0 max-w-fit">
         {{ partial "series/series.html" . }}
         <div class="article-content max-w-prose mb-20">
+          {{ if $mf2 }}<div class="e-content">{{ end }}
           {{ .Content }}
+          {{ if $mf2 }}</div>{{ end }}
           {{ $defaultReplyByEmail := site.Params.replyByEmail }}
           {{ $replyByEmail := default $defaultReplyByEmail .Params.replyByEmail }}
           {{ if $replyByEmail }}

--- a/layouts/partials/article-link/card.html
+++ b/layouts/partials/article-link/card.html
@@ -4,6 +4,7 @@
   3. Shortcode list.html
 */}}
 {{ $disableImageOptimization := site.Store.Get "disableImageOptimization" }}
+{{ $mf2 := site.Params.enableMicroformats2 | default false }}
 
 {{ $page := .Page }}
 {{ $featured := "" }}
@@ -58,7 +59,11 @@
 
 
 <article
-  class="article-link--card relative min-h-full min-w-full overflow-hidden rounded-lg border border-neutral-300 dark:border-neutral-600">
+  class="{{ if $mf2 }}h-entry {{ end }}article-link--card relative min-h-full min-w-full overflow-hidden rounded-lg border border-neutral-300 dark:border-neutral-600">
+  {{ if $mf2 }}
+    <a class="u-url" href="{{ $page.Permalink }}" hidden>{{ $page.Title }}</a>
+    <time class="dt-published" datetime="{{ $page.Date.Format "2006-01-02T15:04:05Z07:00" }}" hidden></time>
+  {{ end }}
   {{ with $featuredURL }}
     <div class="flex-none relative overflow-hidden thumbnail_card" style="--thumbnail-aspect-ratio: {{ $thumbnailAspectRatio }}">
       <img
@@ -83,7 +88,7 @@
           href="{{ $page.RelPermalink }}"
         {{ end }}
         class="not-prose before:absolute before:inset-0 decoration-primary-500 dark:text-neutral text-xl font-bold text-neutral-800 hover:underline hover:underline-offset-2">
-        <h2>
+        <h2{{ if $mf2 }} class="p-name"{{ end }}>
           {{ .Title | emojify }}
           {{ if .Params.externalUrl }}
             <span class="cursor-default align-top text-xs text-neutral-400 dark:text-neutral-500">
@@ -98,7 +103,7 @@
       {{ partial "article-meta/basic.html" . }}
     </div>
     {{ if .Params.showSummary | default (.Site.Params.list.showSummary | default false) }}
-      <div class="article-link__summary prose dark:prose-invert mt-1 line-clamp-5">
+      <div class="{{ if $mf2 }}p-summary {{ end }}article-link__summary prose dark:prose-invert mt-1 line-clamp-5">
         {{ .Summary | plainify }}
       </div>
     {{ end }}

--- a/layouts/partials/article-link/simple.html
+++ b/layouts/partials/article-link/simple.html
@@ -5,6 +5,7 @@
 */}}
 {{ $constrainItemsWidth := site.Params.list.constrainItemsWidth | default false }}
 {{ $disableImageOptimization := site.Store.Get "disableImageOptimization" }}
+{{ $mf2 := site.Params.enableMicroformats2 | default false }}
 
 {{ $cardClasses := "flex flex-col md:flex-row relative" }}
 {{ $imgWrapperClasses := "" }}
@@ -73,7 +74,11 @@
 {{ end }}
 
 
-<article class="article-link--simple {{ $cardClasses }}">
+<article class="{{ if $mf2 }}h-entry {{ end }}article-link--simple {{ $cardClasses }}">
+  {{ if $mf2 }}
+    <a class="u-url" href="{{ $page.Permalink }}" hidden>{{ $page.Title }}</a>
+    <time class="dt-published" datetime="{{ $page.Date.Format "2006-01-02T15:04:05Z07:00" }}" hidden></time>
+  {{ end }}
   {{ with $featuredURL }}
     <div class="flex-none relative overflow-hidden {{ $imgWrapperClasses }} thumbnail">
       <img
@@ -93,7 +98,7 @@
           href="{{ $page.RelPermalink }}"
         {{ end }}
         class="not-prose before:absolute before:inset-0 decoration-primary-500 dark:text-neutral text-xl font-bold text-neutral-800 hover:underline hover:underline-offset-2">
-        <h2>
+        <h2{{ if $mf2 }} class="p-name"{{ end }}>
           {{ .Title | emojify }}
           {{ if .Params.externalUrl }}
             <span class="cursor-default align-top text-xs text-neutral-400 dark:text-neutral-500">
@@ -114,7 +119,7 @@
       {{ partial "article-meta/basic.html" . }}
     </div>
     {{ if .Params.showSummary | default (site.Params.list.showSummary | default false) }}
-      <div class="article-link__summary prose dark:prose-invert max-w-fit mt-1 line-clamp-3">
+      <div class="{{ if $mf2 }}p-summary {{ end }}article-link__summary prose dark:prose-invert max-w-fit mt-1 line-clamp-3">
         {{ .Summary | plainify }}
       </div>
     {{ end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -69,6 +69,37 @@
       });
     </script>
   {{ end }}
+  {{/* microformats2: representative h-card for IndieWeb identity / webmention author
+       discovery. Hidden from view; parsers read it from the DOM. Email is intentionally
+       omitted to keep the theme's anti-scraping stance (see rel=me handling in head.html). */}}
+  {{ if site.Params.enableMicroformats2 | default false }}
+    {{ with site.Params.Author }}
+      {{ $authorName := .name | default site.Title }}
+      <div class="h-card" hidden>
+        <a class="u-url u-uid p-name" href="{{ site.Home.Permalink }}">{{ $authorName }}</a>
+        {{ $photo := "" }}
+        {{ with .image }}
+          {{ if or (strings.HasPrefix . "http:") (strings.HasPrefix . "https:") }}
+            {{ $photo = resources.GetRemote . }}
+          {{ else }}
+            {{ $photo = resources.Get . }}
+          {{ end }}
+        {{ end }}
+        {{ with $photo }}
+          <img class="u-photo" src="{{ .RelPermalink }}" alt="{{ $authorName }}">
+        {{ end }}
+        {{ with .headline }}<p class="p-note">{{ . }}</p>{{ end }}
+        {{ range .links }}
+          {{ range $name, $url := . }}
+            {{ if not (strings.HasPrefix $url "mailto:") }}
+              <a class="u-url" rel="me" href="{{ $url }}">{{ $name }}</a>
+            {{ end }}
+          {{ end }}
+        {{ end }}
+      </div>
+    {{ end }}
+  {{ end }}
+
   {{/* Extend footer - eg. for extra scripts, etc. */}}
   {{ if templates.Exists "partials/extend-footer.html" }}
     {{ partialCached "extend-footer.html" . }}


### PR DESCRIPTION
Adds opt-in [[microformats2](https://microformats.org/wiki/microformats2)](https://microformats.org/wiki/microformats2) markup behind a new `enableMicroformats2` param (default `false`).

Everything is gated, so default output is unchanged and therefore non-breaking.

**Changes:**

- `single.html`: post as `h-entry` (`p-name`, `e-content`, `dt-published`/`dt-updated`, `u-url`/`u-uid`, `p-author h-card`)
- `list.html`: article-grid sections get `h-feed`
- `article-link/card.html` + `simple.html`: items as `h-entry` (`u-url`, `p-name`, `dt-published`, `p-summary`)
- `footer.html`: hidden representative `h-card` from `params.author` (email omitted, matching the `rel="me"` handling in `head.html`)
- docs + exampleSite `params.toml`, cross-linked with `verification.fediverse`

**Decisions:**
I put this behind a dedicated `enableMicroformats2` switch instead of reusing `verification.fediverse`. Different scope (one `<head>` meta tag vs site-wide markup) and independent of each other (the `h-card` reads `params.author`, not the handle).

This is a first step. I'd like to contribute further syndication / IndieWeb features over time.