### PR TITLE
Feat(mobile menu): Add a theme parameter to determine whether mobile nested menu items are expanded by default.

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -47,6 +47,7 @@ forgejoDefaultServer = "https://v11.next.forgejo.org"
 
 [header]
   layout = "basic" # valid options: basic, fixed, fixed-fill, fixed-gradient, fixed-fill-blur
+  # mobileSubmenuChecked = true # set to false to collapse nested mobile menu items by default
 
 [footer]
   showMenu = true

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -166,6 +166,12 @@ forgejoDefaultServer = "https://v11.next.forgejo.org"
   # domain = "llama.yoursite.com"
   # dataDomains = "yoursite.com,yoursite2.com"
   # scriptName = ""
+  # doNotTrack = false # set to true to add data-do-not-track="true" to the Umami script tag
+  # enableReplay = false # set to true to enable Umami session replay with recorder.js
+  # sampleRate = 0.15 # valid values: 0.05 to 1 in 0.05 steps
+  # maskLevel = "moderate" # valid values: "strict" or "moderate"
+  # maxDuration = 300000 # valid values: 300000, 600000, 900000, 1200000
+  # blockSelector = ".my-secret-element" # CSS selector to block elements in session replay
   # enableTrackEvent = true
 
 [selineAnalytics]

--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -151,6 +151,12 @@ fingerprintAlgorithm = "sha512" # Valid values are "sha512" (default), "sha384",
   # domain = "llama.yoursite.com"
   # dataDomains = "yoursite.com,yoursite2.com"
   # scriptName = ""
+  # doNotTrack = false # set to true to add data-do-not-track="true" to the Umami script tag
+  # enableReplay = false # set to true to enable Umami session replay with recorder.js
+  # sampleRate = 0.15 # valid values: 0.05 to 1 in 0.05 steps
+  # maskLevel = "moderate" # valid values: "strict" or "moderate"
+  # maxDuration = 300000 # valid values: 300000, 600000, 900000, 1200000
+  # blockSelector = ".my-secret-element" # CSS selector to block elements in session replay
   # enableTrackEvent = false
 
 [selineAnalytics]

--- a/exampleSite/content/docs/configuration/index.de.md
+++ b/exampleSite/content/docs/configuration/index.de.md
@@ -118,6 +118,19 @@ Blowfish bietet eine große Anzahl von Konfigurationsparametern, die steuern, wi
 
 Viele der Artikel-Standardeinstellungen können auf Artikelebene überschrieben werden, indem sie im Front Matter angegeben werden. Weitere Details finden Sie im Abschnitt [Front Matter]({{< ref "front-matter" >}}).
 
+## Theme-Parameter
+
+Blowfish bietet eine große Anzahl von Konfigurationsparametern, die steuern, wie das Theme funktioniert. Die vollständige Liste aller verfügbaren Parameter finden Sie in der Datei `config/_default/params.toml`.
+
+Viele der Artikel-Standardeinstellungen können auf Artikelebene überschrieben werden, indem sie im Front Matter angegeben werden. Weitere Details finden Sie im Abschnitt [Front Matter]({{< ref "front-matter" >}}).
+
+### Header
+
+| Name | Standard | Beschreibung |
+| --- | --- | --- |
+| `header.layout` | `"basic"` | Definiert den Header für die gesamte Website. Unterstützte Werte sind `basic`, `fixed`, `fixed-fill` und `fixed-fill-blur`. |
+| `header.mobileSubmenuChecked` | `true` | Legt fest, ob verschachtelte Einträge im mobilen Menü standardmäßig aufgeklappt sind. Setze `false`, um sie standardmäßig einzuklappen. |
+
 ## Weitere Konfigurationsdateien
 
 Das Theme enthält auch eine `markup.toml`-Konfigurationsdatei. Diese Datei enthält einige wichtige Parameter, die sicherstellen, dass Hugo korrekt konfiguriert ist, um mit Blowfish erstellte Websites zu generieren.

--- a/exampleSite/content/docs/configuration/index.de.md
+++ b/exampleSite/content/docs/configuration/index.de.md
@@ -131,6 +131,22 @@ Viele der Artikel-Standardeinstellungen können auf Artikelebene überschrieben 
 | `header.layout` | `"basic"` | Definiert den Header für die gesamte Website. Unterstützte Werte sind `basic`, `fixed`, `fixed-fill` und `fixed-fill-blur`. |
 | `header.mobileSubmenuChecked` | `true` | Legt fest, ob verschachtelte Einträge im mobilen Menü standardmäßig aufgeklappt sind. Setze `false`, um sie standardmäßig einzuklappen. |
 
+### Umami Analytics
+
+| Name | Standard | Beschreibung |
+| --- | --- | --- |
+| `umamiAnalytics.websiteid` | _Nicht gesetzt_ | Der von Umami Analytics für die Website erzeugte Seiten-Code. Weitere Details findest du in den [Analytics-Dokumenten]({{< ref "partials#analytics" >}}). |
+| `umamiAnalytics.domain` | _Nicht gesetzt_ | Wenn du eine benutzerdefinierte Domain mit Umami Analytics verwendest, gib sie hier an, um `script.js` von der benutzerdefinierten Domain zu laden. |
+| `umamiAnalytics.dataDomains` | _Nicht gesetzt_ | Wenn der Tracker nur auf bestimmten Domains laufen soll, gib diese für dein Tracker-Skript an. Es handelt sich um eine kommagetrennte Liste von Domainnamen, zum Beispiel `"yoursite.com,yoursite2.com"`. |
+| `umamiAnalytics.scriptName` | `script.js` | Der Name von `script.js`, der zur Anti-Ad-Blocking-Verwendung dient, wird über die Umgebungsvariable `TRACKER_SCRIPT_NAME` konfiguriert. |
+| `umamiAnalytics.doNotTrack` | `false` | Wenn auf `true` gesetzt, wird `data-do-not-track="true"` zum Umami-Skript-Tag hinzugefügt. |
+| `umamiAnalytics.enableReplay` | `false` | Aktiviert das Umami Session Replay-Skript zusätzlich zum normalen Tracking-Skript. |
+| `umamiAnalytics.sampleRate` | `0.15` | Die Stichprobenerfassungsrate für Session Replay. Unterstützte Werte sind `0.05` bis `1` in Schritten von `0.05`. |
+| `umamiAnalytics.maskLevel` | `"moderate"` | Der Maskierungsgrad für Session Replay. Unterstützte Werte sind `strict` und `moderate`. |
+| `umamiAnalytics.maxDuration` | `300000` | Maximale Dauer einer aufgezeichneten Session in Millisekunden. Unterstützte Werte sind `300000` (5 Minuten), `600000` (10 Minuten), `900000` (15 Minuten) und `1200000` (20 Minuten). |
+| `umamiAnalytics.blockSelector` | _Nicht gesetzt_ | CSS-Selektor zum Blockieren bestimmter Elemente im Session Replay. |
+| `umamiAnalytics.enableTrackEvent` | `true` | Wenn auf `true` gesetzt, werden Track-Events automatisch hinzugefügt. Wenn du keine Track-Events hinzufügen möchtest, setze es auf `false`. |
+
 ## Weitere Konfigurationsdateien
 
 Das Theme enthält auch eine `markup.toml`-Konfigurationsdatei. Diese Datei enthält einige wichtige Parameter, die sicherstellen, dass Hugo korrekt konfiguriert ist, um mit Blowfish erstellte Websites zu generieren.

--- a/exampleSite/content/docs/configuration/index.es.md
+++ b/exampleSite/content/docs/configuration/index.es.md
@@ -118,6 +118,19 @@ Blowfish proporciona un gran número de parámetros de configuración que contro
 
 Muchos de los valores predeterminados de artículos pueden sobrescribirse por artículo especificándolos en el front matter. Consulta la sección [Front Matter]({{< ref "front-matter" >}}) para más detalles.
 
+## Parámetros del tema
+
+Blowfish proporciona un gran número de parámetros de configuración que controlan cómo funciona el tema. La lista completa de todos los parámetros disponibles se encuentra en el archivo `config/_default/params.toml`.
+
+Muchos de los valores predeterminados de artículos pueden sobrescribirse por artículo especificándolos en el front matter. Consulta la sección [Front Matter]({{< ref "front-matter" >}}) para más detalles.
+
+### Cabecera
+
+| Nombre | Predeterminado | Descripción |
+| --- | --- | --- |
+| `header.layout` | `"basic"` | Define la cabecera de todo el sitio. Los valores admitidos son `basic`, `fixed`, `fixed-fill` y `fixed-fill-blur`. |
+| `header.mobileSubmenuChecked` | `true` | Indica si los elementos anidados del menú móvil se expanden de forma predeterminada. Establécelo en `false` para mantenerlos contraídos por defecto. |
+
 ## Otros archivos de configuración
 
 El tema también incluye un archivo de configuración `markup.toml`. Este archivo contiene algunos parámetros importantes que aseguran que Hugo esté correctamente configurado para generar sitios construidos con Blowfish.

--- a/exampleSite/content/docs/configuration/index.es.md
+++ b/exampleSite/content/docs/configuration/index.es.md
@@ -131,6 +131,22 @@ Muchos de los valores predeterminados de artículos pueden sobrescribirse por ar
 | `header.layout` | `"basic"` | Define la cabecera de todo el sitio. Los valores admitidos son `basic`, `fixed`, `fixed-fill` y `fixed-fill-blur`. |
 | `header.mobileSubmenuChecked` | `true` | Indica si los elementos anidados del menú móvil se expanden de forma predeterminada. Establécelo en `false` para mantenerlos contraídos por defecto. |
 
+### Umami Analytics
+
+| Nombre | Predeterminado | Descripción |
+| --- | --- | --- |
+| `umamiAnalytics.websiteid` | _No establecido_ | El código del sitio generado por Umami Analytics para el sitio web. Consulta los [documentos de Analytics]({{< ref "partials#analytics" >}}) para más detalles. |
+| `umamiAnalytics.domain` | _No establecido_ | Si usas un dominio personalizado con Umami Analytics, indícalo aquí para servir `script.js` desde el dominio personalizado. |
+| `umamiAnalytics.dataDomains` | _No establecido_ | Si quieres que el tracker solo se ejecute en dominios específicos, indícalo para tu script de seguimiento. Es una lista de nombres de dominio separada por comas, como `"yoursite.com,yoursite2.com"`. |
+| `umamiAnalytics.scriptName` | `script.js` | El nombre de `script.js` usado para evitar bloqueadores de anuncios se configura mediante la variable de entorno `TRACKER_SCRIPT_NAME`. |
+| `umamiAnalytics.doNotTrack` | `false` | Si se establece en `true`, se añadirá `data-do-not-track="true"` a la etiqueta del script de Umami. |
+| `umamiAnalytics.enableReplay` | `false` | Activa el script de reproducción de sesiones de Umami además del script de seguimiento normal. |
+| `umamiAnalytics.sampleRate` | `0.15` | La tasa de muestreo para la reproducción de sesiones. Los valores admitidos van de `0.05` a `1` en incrementos de `0.05`. |
+| `umamiAnalytics.maskLevel` | `"moderate"` | El nivel de enmascaramiento para la reproducción de sesiones. Los valores admitidos son `strict` y `moderate`. |
+| `umamiAnalytics.maxDuration` | `300000` | Duración máxima de una sesión grabada en milisegundos. Los valores admitidos son `300000` (5 minutos), `600000` (10 minutos), `900000` (15 minutos) y `1200000` (20 minutos). |
+| `umamiAnalytics.blockSelector` | _No establecido_ | Selector CSS para bloquear elementos específicos en la reproducción de sesiones. |
+| `umamiAnalytics.enableTrackEvent` | `true` | Cuando se establece en `true`, track event se añadirá automáticamente. Si no quieres añadir track events, establécelo en `false`. |
+
 ## Otros archivos de configuración
 
 El tema también incluye un archivo de configuración `markup.toml`. Este archivo contiene algunos parámetros importantes que aseguran que Hugo esté correctamente configurado para generar sitios construidos con Blowfish.

--- a/exampleSite/content/docs/configuration/index.fr.md
+++ b/exampleSite/content/docs/configuration/index.fr.md
@@ -118,6 +118,19 @@ Blowfish fournit un grand nombre de paramètres de configuration qui contrôlent
 
 De nombreuses valeurs par défaut des articles peuvent être remplacées article par article en les spécifiant dans le front matter. Consultez la section [Front Matter]({{< ref "front-matter" >}}) pour plus de détails.
 
+## Paramètres du thème
+
+Blowfish fournit un grand nombre de paramètres de configuration qui contrôlent le fonctionnement du thème. La liste complète de tous les paramètres disponibles se trouve dans le fichier `config/_default/params.toml`.
+
+De nombreuses valeurs par défaut des articles peuvent être remplacées article par article en les spécifiant dans le front matter. Consultez la section [Front Matter]({{< ref "front-matter" >}}) pour plus de détails.
+
+### Header
+
+| Nom | Par défaut | Description |
+| --- | --- | --- |
+| `header.layout` | `"basic"` | Définit l'en-tête du site entier. Les valeurs prises en charge sont `basic`, `fixed`, `fixed-fill` et `fixed-fill-blur`. |
+| `header.mobileSubmenuChecked` | `true` | Indique si les sous-éléments du menu mobile sont ouverts par défaut. Définissez `false` pour les replier par défaut. |
+
 ## Autres fichiers de configuration
 
 Le thème inclut également un fichier de configuration `markup.toml`. Ce fichier contient des paramètres importants qui garantissent que Hugo est correctement configuré pour générer des sites construits avec Blowfish.

--- a/exampleSite/content/docs/configuration/index.fr.md
+++ b/exampleSite/content/docs/configuration/index.fr.md
@@ -131,6 +131,22 @@ De nombreuses valeurs par défaut des articles peuvent être remplacées article
 | `header.layout` | `"basic"` | Définit l'en-tête du site entier. Les valeurs prises en charge sont `basic`, `fixed`, `fixed-fill` et `fixed-fill-blur`. |
 | `header.mobileSubmenuChecked` | `true` | Indique si les sous-éléments du menu mobile sont ouverts par défaut. Définissez `false` pour les replier par défaut. |
 
+### Umami Analytics
+
+| Nom | Par défaut | Description |
+| --- | --- | --- |
+| `umamiAnalytics.websiteid` | _Non défini_ | Le code du site généré par Umami Analytics pour le site web. Consultez la [documentation Analytics]({{< ref "partials#analytics" >}}) pour plus de détails. |
+| `umamiAnalytics.domain` | _Non défini_ | Si vous utilisez un domaine personnalisé avec Umami Analytics, indiquez-le ici pour servir `script.js` depuis ce domaine personnalisé. |
+| `umamiAnalytics.dataDomains` | _Non défini_ | Si vous souhaitez que le tracker ne s'exécute que sur des domaines spécifiques, indiquez-le pour votre script de suivi. Il s'agit d'une liste de noms de domaine séparés par des virgules, par exemple `"yoursite.com,yoursite2.com"`. |
+| `umamiAnalytics.scriptName` | `script.js` | Le nom de `script.js` utilisé pour l'anti-blocage est configuré via la variable d'environnement `TRACKER_SCRIPT_NAME`. |
+| `umamiAnalytics.doNotTrack` | `false` | Si défini sur `true`, `data-do-not-track="true"` sera ajouté à la balise du script Umami. |
+| `umamiAnalytics.enableReplay` | `false` | Active le script de replay de session Umami en plus du script de suivi normal. |
+| `umamiAnalytics.sampleRate` | `0.15` | Le taux d'échantillonnage pour le replay de session. Les valeurs prises en charge vont de `0.05` à `1` par incréments de `0.05`. |
+| `umamiAnalytics.maskLevel` | `"moderate"` | Le niveau de masquage pour le replay de session. Les valeurs prises en charge sont `strict` et `moderate`. |
+| `umamiAnalytics.maxDuration` | `300000` | Durée maximale d'une session enregistrée en millisecondes. Les valeurs prises en charge sont `300000` (5 minutes), `600000` (10 minutes), `900000` (15 minutes) et `1200000` (20 minutes). |
+| `umamiAnalytics.blockSelector` | _Non défini_ | Sélecteur CSS permettant de bloquer des éléments spécifiques dans le replay de session. |
+| `umamiAnalytics.enableTrackEvent` | `true` | Lorsqu'il est défini sur `true`, track event sera ajouté automatiquement. Si vous ne souhaitez pas ajouter track event, définissez-le sur `false`. |
+
 ## Autres fichiers de configuration
 
 Le thème inclut également un fichier de configuration `markup.toml`. Ce fichier contient des paramètres importants qui garantissent que Hugo est correctement configuré pour générer des sites construits avec Blowfish.

--- a/exampleSite/content/docs/configuration/index.it.md
+++ b/exampleSite/content/docs/configuration/index.it.md
@@ -198,6 +198,7 @@ Many of the article defaults here can be overridden on a per article basis by sp
 | Name | Default | Description |
 | --- | --- | --- |
 | `header.layout` | `"basic"` | Defines the header for the entire site, supported values are `basic`, `fixed`, `fixed-fill`, and `fixed-fill-blur`. |
+| `header.mobileSubmenuChecked` | `true` | Indica se le voci annidate del menu mobile sono espanse per impostazione predefinita. Imposta `false` per comprimerle di default. |
 
 ### Footer
 

--- a/exampleSite/content/docs/configuration/index.it.md
+++ b/exampleSite/content/docs/configuration/index.it.md
@@ -342,6 +342,12 @@ Many of the article defaults here can be overridden on a per article basis by sp
 | `umamiAnalytics.domain` | _Not set_ | If using a custom domain with Umami Analytics, provide it here to serve `script.js` from the custom domain. |
 | `umamiAnalytics.dataDomains` | _Not set_ | If you want the tracker to only run on specific domains, provide it for your tracker script. This is a comma delimited list of domain names. Such as "yoursite.com,yoursite2.com". |
 | `umamiAnalytics.scriptName` | script.js | The name of the `script.js` used for anti-ad-blocking is configured by the environment variable `TRACKER_SCRIPT_NAME` |
+| `umamiAnalytics.doNotTrack` | `false` | Se impostato su `true`, aggiunge `data-do-not-track="true"` al tag script di Umami. |
+| `umamiAnalytics.enableReplay` | `false` | Abilita lo script di session replay di Umami oltre al normale script di tracking. |
+| `umamiAnalytics.sampleRate` | `0.15` | Frequenza di campionamento per la session replay. I valori supportati vanno da `0.05` a `1` con incrementi di `0.05`. |
+| `umamiAnalytics.maskLevel` | `"moderate"` | Livello di mascheramento per la session replay. I valori supportati sono `strict` e `moderate`. |
+| `umamiAnalytics.maxDuration` | `300000` | Durata massima di una sessione registrata in millisecondi. I valori supportati sono `300000` (5 minuti), `600000` (10 minuti), `900000` (15 minuti) e `1200000` (20 minuti). |
+| `umamiAnalytics.blockSelector` | _Not set_ | Selettore CSS usato per bloccare elementi specifici nella session replay. |
 | `umamiAnalytics.enableTrackEvent` | true | When set to `true` track event will add automatically. If you do not want to add track event, set it to `false`. |
 
 ### Seline Analytics

--- a/exampleSite/content/docs/configuration/index.ja.md
+++ b/exampleSite/content/docs/configuration/index.ja.md
@@ -198,6 +198,7 @@ Blowfish は、テーマの機能を制御する多数の設定パラメータ�
 | 名前 | デフォルト | 説明 |
 | --- | --- | --- |
 | `header.layout` | `"basic"` | サイト全体のヘッダーを定義します。サポートされている値は、`basic`、`fixed`、`fixed-fill`、`fixed-fill-blur` です。 |
+| `header.mobileSubmenuChecked` | `true` | モバイルメニューのネストされた項目を既定で展開するかどうかを指定します。既定で折りたたむには `false` に設定します。 |
 
 ### フッター(Footer)
 

--- a/exampleSite/content/docs/configuration/index.ja.md
+++ b/exampleSite/content/docs/configuration/index.ja.md
@@ -384,6 +384,22 @@ Blowfish は、テーマの機能を制御する多数の設定パラメータ�
 | ------------------------ | ---------- | ------------------------------------------------------------------ |
 | `advertisement.adsense` | _未設定_ | Google AdSense パブリッシャー ID （例：`ca-pub-1234567890abcdef`）。このパラメータを設定すると、サイト上で AdSense 広告が有効になります。 |
 
+### Umami Analytics
+
+| Name | Default | Description |
+| --- | --- | --- |
+| `umamiAnalytics.websiteid` | _未設定_ | Umami Analytics がサイト用に生成したサイトコードです。詳細は [Analytics docs]({{< ref "partials#analytics" >}}) を参照してください。 |
+| `umamiAnalytics.domain` | _未設定_ | Umami Analytics でカスタムドメインを使用している場合は、ここで指定すると `script.js` をそのカスタムドメインから配信できます。 |
+| `umamiAnalytics.dataDomains` | _未設定_ | トラッカーを特定のドメインでのみ実行したい場合に指定します。カンマ区切りのドメイン名リストです。例: `"yoursite.com,yoursite2.com"` |
+| `umamiAnalytics.scriptName` | `script.js` | アドブロック回避に使う `script.js` の名前は、環境変数 `TRACKER_SCRIPT_NAME` で設定します。 |
+| `umamiAnalytics.doNotTrack` | `false` | `true` に設定すると、Umami の script タグに `data-do-not-track="true"` を追加します。 |
+| `umamiAnalytics.enableReplay` | `false` | 通常のトラッキングスクリプトに加えて Umami Session Replay を有効にします。 |
+| `umamiAnalytics.sampleRate` | `0.15` | Session Replay のサンプリングレートです。対応値は `0.05` から `1` まで、`0.05` 刻みです。 |
+| `umamiAnalytics.maskLevel` | `"moderate"` | Session Replay のマスクレベルです。対応値は `strict` と `moderate` です。 |
+| `umamiAnalytics.maxDuration` | `300000` | 記録するセッションの最大時間（ミリ秒）です。対応値は `300000`（5分）、`600000`（10分）、`900000`（15分）、`1200000`（20分）です。 |
+| `umamiAnalytics.blockSelector` | _未設定_ | Session Replay で要素をブロックするための CSS セレクタです。 |
+| `umamiAnalytics.enableTrackEvent` | `true` | `true` に設定すると、track event が自動的に追加されます。追加したくない場合は `false` に設定してください。 |
+
 ## その他の設定ファイル
 
 このテーマには `markup.toml` 設定ファイルも含まれています。このファイルには、Hugo が Blowfish で構築されたサイトを正しく生成するために重要なパラメータがいくつか含まれています。

--- a/exampleSite/content/docs/configuration/index.md
+++ b/exampleSite/content/docs/configuration/index.md
@@ -207,6 +207,7 @@ Many of the article defaults here can be overridden on a per article basis by sp
 | Name | Default | Description |
 | --- | --- | --- |
 | `header.layout` | `"basic"` | Defines the header for the entire site, supported values are `basic`, `fixed`, `fixed-fill`, and `fixed-fill-blur`. |
+| `header.mobileSubmenuChecked` | `true` | Whether nested items in the mobile menu are expanded by default. Set to `false` to collapse them by default. |
 
 ### Footer
 

--- a/exampleSite/content/docs/configuration/index.md
+++ b/exampleSite/content/docs/configuration/index.md
@@ -358,6 +358,12 @@ Many of the article defaults here can be overridden on a per article basis by sp
 | `umamiAnalytics.domain` | _Not set_ | If using a custom domain with Umami Analytics, provide it here to serve `script.js` from the custom domain. |
 | `umamiAnalytics.dataDomains` | _Not set_ | If you want the tracker to only run on specific domains, provide it for your tracker script. This is a comma delimited list of domain names. Such as "yoursite.com,yoursite2.com". |
 | `umamiAnalytics.scriptName` | script.js | The name of the `script.js` used for anti-ad-blocking is configured by the environment variable `TRACKER_SCRIPT_NAME` |
+| `umamiAnalytics.doNotTrack` | false | Script tag attribute. When set to `true`, Blowfish adds `data-do-not-track="true"` to the Umami script tag. If you do not set it, Umami tracks normally. |
+| `umamiAnalytics.enableReplay` | false | When set to `true`, Blowfish loads `recorder.js` and enables Umami session replay. |
+| `umamiAnalytics.sampleRate` | _Not set_ | Session replay sample rate. Valid values are `0.05` through `1`, in `0.05` steps. |
+| `umamiAnalytics.maskLevel` | _Not set_ | Session replay masking level. Valid values are `strict` and `moderate`. |
+| `umamiAnalytics.maxDuration` | _Not set_ | Maximum session replay duration in milliseconds. Valid values are `300000`, `600000`, `900000`, and `1200000`. |
+| `umamiAnalytics.blockSelector` | _Not set_ | CSS selector used to block elements during session replay. |
 | `umamiAnalytics.enableTrackEvent` | true | When set to `true` track event will add automatically. If you do not want to add track event, set it to `false`. |
 
 ### Seline Analytics

--- a/exampleSite/content/docs/configuration/index.pt-br.md
+++ b/exampleSite/content/docs/configuration/index.pt-br.md
@@ -118,6 +118,19 @@ O Blowfish fornece um grande número de parâmetros de configuração que contro
 
 Muitos dos padrões de artigos podem ser substituídos por artigo, especificando-os no front matter. Consulte a seção [Front Matter]({{< ref "front-matter" >}}) para mais detalhes.
 
+## Parâmetros do tema
+
+O Blowfish fornece um grande número de parâmetros de configuração que controlam como o tema funciona. A lista completa de todos os parâmetros disponíveis está no arquivo `config/_default/params.toml`.
+
+Muitos dos padrões de artigos podem ser substituídos por artigo, especificando-os no front matter. Consulte a seção [Front Matter]({{< ref "front-matter" >}}) para mais detalhes.
+
+### Cabeçalho
+
+| Nome | Padrão | Descrição |
+| --- | --- | --- |
+| `header.layout` | `"basic"` | Define o cabeçalho de todo o site. Os valores suportados são `basic`, `fixed`, `fixed-fill` e `fixed-fill-blur`. |
+| `header.mobileSubmenuChecked` | `true` | Define se os itens aninhados do menu mobile ficam expandidos por padrão. Defina `false` para recolhê-los por padrão. |
+
 ## Outros arquivos de configuração
 
 O tema também inclui um arquivo de configuração `markup.toml`. Este arquivo contém alguns parâmetros importantes que garantem que o Hugo esteja corretamente configurado para gerar sites construídos com o Blowfish.

--- a/exampleSite/content/docs/configuration/index.pt-br.md
+++ b/exampleSite/content/docs/configuration/index.pt-br.md
@@ -131,6 +131,22 @@ Muitos dos padrões de artigos podem ser substituídos por artigo, especificando
 | `header.layout` | `"basic"` | Define o cabeçalho de todo o site. Os valores suportados são `basic`, `fixed`, `fixed-fill` e `fixed-fill-blur`. |
 | `header.mobileSubmenuChecked` | `true` | Define se os itens aninhados do menu mobile ficam expandidos por padrão. Defina `false` para recolhê-los por padrão. |
 
+### Umami Analytics
+
+| Nome | Padrão | Descrição |
+| --- | --- | --- |
+| `umamiAnalytics.websiteid` | _Não definido_ | O código do site gerado pelo Umami Analytics para o site. Consulte a [documentação de Analytics]({{< ref "partials#analytics" >}}) para mais detalhes. |
+| `umamiAnalytics.domain` | _Não definido_ | Se você usar um domínio personalizado com o Umami Analytics, informe-o aqui para servir `script.js` a partir do domínio personalizado. |
+| `umamiAnalytics.dataDomains` | _Não definido_ | Se quiser que o rastreador execute apenas em domínios específicos, informe isso para o seu script de rastreamento. É uma lista de nomes de domínio separada por vírgulas, como `"yoursite.com,yoursite2.com"`. |
+| `umamiAnalytics.scriptName` | `script.js` | O nome de `script.js` usado para anti-ad-blocking é configurado pela variável de ambiente `TRACKER_SCRIPT_NAME`. |
+| `umamiAnalytics.doNotTrack` | `false` | Se definido como `true`, `data-do-not-track="true"` será adicionado à tag do script do Umami. |
+| `umamiAnalytics.enableReplay` | `false` | Ativa o script de session replay do Umami além do script de rastreamento normal. |
+| `umamiAnalytics.sampleRate` | `0.15` | A taxa de amostragem para session replay. Os valores suportados vão de `0.05` a `1` em incrementos de `0.05`. |
+| `umamiAnalytics.maskLevel` | `"moderate"` | O nível de mascaramento para session replay. Os valores suportados são `strict` e `moderate`. |
+| `umamiAnalytics.maxDuration` | `300000` | Duração máxima de uma sessão gravada em milissegundos. Os valores suportados são `300000` (5 minutos), `600000` (10 minutos), `900000` (15 minutos) e `1200000` (20 minutos). |
+| `umamiAnalytics.blockSelector` | _Não definido_ | Seletor CSS usado para bloquear elementos específicos na session replay. |
+| `umamiAnalytics.enableTrackEvent` | `true` | Quando definido como `true`, track event será adicionado automaticamente. Se você não quiser adicionar track event, defina como `false`. |
+
 ## Outros arquivos de configuração
 
 O tema também inclui um arquivo de configuração `markup.toml`. Este arquivo contém alguns parâmetros importantes que garantem que o Hugo esteja corretamente configurado para gerar sites construídos com o Blowfish.

--- a/exampleSite/content/docs/configuration/index.pt-pt.md
+++ b/exampleSite/content/docs/configuration/index.pt-pt.md
@@ -118,6 +118,19 @@ O Blowfish fornece um grande número de parâmetros de configuração que contro
 
 Muitas das predefinições de artigos podem ser substituídas por artigo, especificando-as no front matter. Consulte a secção [Front Matter]({{< ref "front-matter" >}}) para mais detalhes.
 
+## Parâmetros do tema
+
+O Blowfish fornece um grande número de parâmetros de configuração que controlam como o tema funciona. A lista completa de todos os parâmetros disponíveis está no ficheiro `config/_default/params.toml`.
+
+Muitas das predefinições de artigos podem ser substituídas por artigo, especificando-as no front matter. Consulte a secção [Front Matter]({{< ref "front-matter" >}}) para mais detalhes.
+
+### Cabeçalho
+
+| Nome | Predefinição | Descrição |
+| --- | --- | --- |
+| `header.layout` | `"basic"` | Define o cabeçalho de todo o site. Os valores suportados são `basic`, `fixed`, `fixed-fill` e `fixed-fill-blur`. |
+| `header.mobileSubmenuChecked` | `true` | Define se os itens aninhados do menu móvel ficam expandidos por predefinição. Defina `false` para os recolher por predefinição. |
+
 ## Outros ficheiros de configuração
 
 O tema também inclui um ficheiro de configuração `markup.toml`. Este ficheiro contém alguns parâmetros importantes que garantem que o Hugo está corretamente configurado para gerar sites construídos com o Blowfish.

--- a/exampleSite/content/docs/configuration/index.pt-pt.md
+++ b/exampleSite/content/docs/configuration/index.pt-pt.md
@@ -131,6 +131,22 @@ Muitas das predefinições de artigos podem ser substituídas por artigo, especi
 | `header.layout` | `"basic"` | Define o cabeçalho de todo o site. Os valores suportados são `basic`, `fixed`, `fixed-fill` e `fixed-fill-blur`. |
 | `header.mobileSubmenuChecked` | `true` | Define se os itens aninhados do menu móvel ficam expandidos por predefinição. Defina `false` para os recolher por predefinição. |
 
+### Umami Analytics
+
+| Nome | Predefinição | Descrição |
+| --- | --- | --- |
+| `umamiAnalytics.websiteid` | _Não definido_ | O código do site gerado pelo Umami Analytics para o website. Consulte a [documentação de Analytics]({{< ref "partials#analytics" >}}) para mais detalhes. |
+| `umamiAnalytics.domain` | _Não definido_ | Se usar um domínio personalizado com o Umami Analytics, indique-o aqui para servir `script.js` a partir do domínio personalizado. |
+| `umamiAnalytics.dataDomains` | _Não definido_ | Se quiser que o rastreador seja executado apenas em domínios específicos, indique-o para o seu script de rastreamento. Trata-se de uma lista de nomes de domínio separada por vírgulas, como `"yoursite.com,yoursite2.com"`. |
+| `umamiAnalytics.scriptName` | `script.js` | O nome de `script.js` usado para anti-ad-blocking é configurado pela variável de ambiente `TRACKER_SCRIPT_NAME`. |
+| `umamiAnalytics.doNotTrack` | `false` | Se definido como `true`, `data-do-not-track="true"` será adicionado à tag de script do Umami. |
+| `umamiAnalytics.enableReplay` | `false` | Ativa o script de session replay do Umami para além do script de rastreamento normal. |
+| `umamiAnalytics.sampleRate` | `0.15` | A taxa de amostragem para session replay. Os valores suportados vão de `0.05` a `1` em incrementos de `0.05`. |
+| `umamiAnalytics.maskLevel` | `"moderate"` | O nível de mascaramento para session replay. Os valores suportados são `strict` e `moderate`. |
+| `umamiAnalytics.maxDuration` | `300000` | Duração máxima de uma sessão gravada em milissegundos. Os valores suportados são `300000` (5 minutos), `600000` (10 minutos), `900000` (15 minutos) e `1200000` (20 minutos). |
+| `umamiAnalytics.blockSelector` | _Não definido_ | Seletor CSS usado para bloquear elementos específicos na session replay. |
+| `umamiAnalytics.enableTrackEvent` | `true` | Quando definido como `true`, track event será adicionado automaticamente. Se não quiser adicionar track event, defina como `false`. |
+
 ## Outros ficheiros de configuração
 
 O tema também inclui um ficheiro de configuração `markup.toml`. Este ficheiro contém alguns parâmetros importantes que garantem que o Hugo está corretamente configurado para gerar sites construídos com o Blowfish.

--- a/exampleSite/content/docs/configuration/index.zh-cn.md
+++ b/exampleSite/content/docs/configuration/index.zh-cn.md
@@ -202,6 +202,7 @@ Blowfish 提供了大量控制主题功能的配置参数，下面的表格中�
 | 名称 | 默认值 | 描述 |
 | --- | --- | --- |
 | `header.layout` | `"basic"` | 定义整个站点的页头的布局，支持的参数有 `basic`、`fixed`、`fixed-fill`、and `fixed-fill-blur`. |
+| `header.mobileSubmenuChecked` | `true` | 定义移动端菜单中的嵌套项目是否默认展开。设置为 `false` 可让它们默认折叠。 |
 
 ### 页脚
 

--- a/exampleSite/content/docs/configuration/index.zh-cn.md
+++ b/exampleSite/content/docs/configuration/index.zh-cn.md
@@ -389,6 +389,22 @@ Blowfish 提供了大量控制主题功能的配置参数，下面的表格中�
 | ------------------------ | --------- |-------------|
 | `advertisement.adsense` | _无_ | 您的 Google AdSense 发布商 ID (例如 `ca-pub-1234567890abcdef`)。设置此参数可在您的网站上启用 AdSense 广告。 |
 
+### Umami
+
+| 名称 | 默认值 | 描述 |
+| --- | --- | --- |
+| `umamiAnalytics.websiteid` | _未设置_ | Umami Analytics 为网站生成的网站代码。更多信息请参考 [Analytics docs]({{< ref "partials#analytics" >}})。 |
+| `umamiAnalytics.domain` | _未设置_ | 如果你使用 Umami Analytics 的自定义域名，可以在这里填写，以便从自定义域名提供 `script.js`。 |
+| `umamiAnalytics.dataDomains` | _未设置_ | 如果你只想让 tracker 在特定域名上运行，可以为 tracker 脚本提供该配置。这是一个逗号分隔的域名列表，例如 `"yoursite.com,yoursite2.com"`。 |
+| `umamiAnalytics.scriptName` | `script.js` | 反广告拦截所用的 `script.js` 名称通过环境变量 `TRACKER_SCRIPT_NAME` 配置。 |
+| `umamiAnalytics.doNotTrack` | `false` | 设置为 `true` 时，会在 Umami script 标签上添加 `data-do-not-track="true"`。 |
+| `umamiAnalytics.enableReplay` | `false` | 在普通跟踪脚本之外启用 Umami Session Replay。 |
+| `umamiAnalytics.sampleRate` | `0.15` | Session Replay 的采样率。支持的值为 `0.05` 到 `1`，步进为 `0.05`。 |
+| `umamiAnalytics.maskLevel` | `"moderate"` | Session Replay 的遮罩级别。支持的值为 `strict` 和 `moderate`。 |
+| `umamiAnalytics.maxDuration` | `300000` | 录制会话的最大时长，单位毫秒。支持的值为 `300000`（5 分钟）、`600000`（10 分钟）、`900000`（15 分钟）和 `1200000`（20 分钟）。 |
+| `umamiAnalytics.blockSelector` | _未设置_ | 用于在 Session Replay 中阻止元素的 CSS 选择器。 |
+| `umamiAnalytics.enableTrackEvent` | `true` | 当设置为 `true` 时，会自动添加 track event。如果你不想添加 track event，请设为 `false`。 |
+
 ## 其他配置文件
 
 Blowfish 主题还包括 `markup.toml` 配置文件。这个文件包含了一些重要参数，来确保 Hugo 正确配置以生成使用 Blowfish 创建的网站。

--- a/exampleSite/content/docs/partials/index.de.md
+++ b/exampleSite/content/docs/partials/index.de.md
@@ -48,6 +48,8 @@ Wenn Sie möchten, dass der Tracker nur auf bestimmten Domains ausgeführt wird,
 
 Wenn Sie die Do Not Track Einstellung im Browser berücksichtigen möchten, dann setzen Sie `doNotTrack` auf `true`, Blowfish berücksichtigt die Do Not Track Einstellung standardmäßig nicht.
 
+Wenn Sie Umami Session Replay zusätzlich zum normalen Tracking-Skript aktivieren möchten, setzen Sie `enableReplay` auf `true`. Wenn es aktiviert ist, lädt Blowfish das Replay-Skript zusätzlich zum regulären Umami-Skript, zusammen mit den replay-spezifischen Einstellungen wie `sampleRate`, `maskLevel`, `maxDuration` und `blockSelector`.
+
 {{< alert >}}
 **Hinweis:** Wenn Sie Umami Analytics aktivieren, unterstützt Blowfish [Umami Track Event](https://umami.is/docs/track-events) automatisch. Wenn Sie Track Event nicht unterstützen möchten, muss der Parameter `enableTrackEvent` auf `false` gesetzt werden.
 {{< /alert >}}
@@ -62,6 +64,11 @@ Wenn Sie die Do Not Track Einstellung im Browser berücksichtigen möchten, dann
   scriptName = "TRACKER_SCRIPT_NAME"
   doNotTrack = false
   enableTrackEvent = true
+  enableReplay = true
+  sampleRate = 0.15
+  maskLevel = "moderate"
+  maxDuration = 300000
+  blockSelector = ".my-secret-element"
 ```
 
 ### Seline Analytics

--- a/exampleSite/content/docs/partials/index.es.md
+++ b/exampleSite/content/docs/partials/index.es.md
@@ -46,6 +46,8 @@ Para habilitar el soporte de Umami Analytics, simplemente proporciona tu [códig
 Si también utilizas la función de dominio personalizado de Umami y deseas servir su script desde tu dominio, también puedes proporcionar adicionalmente el valor de configuración `domain`. Si no proporcionas un valor `domain`, el script se cargará directamente desde el DNS de Umami (analytics.umami.is).
 Si quieres que el rastreador solo se ejecute en dominios específicos, puedes proporcionar el valor de configuración `dataDomains`. Si no proporcionas un valor `dataDomains`, el script se ejecutará en cualquier sitio web donde coincidan `domain` y `websiteid`. Si la variable de entorno `TRACKER_SCRIPT_NAME` está configurada, puedes especificar un nombre de script personalizado `scriptName`. Si no está configurada, coméntala o usa el valor predeterminado `script.js`.
 
+Si quieres habilitar Umami Session Replay además del script de seguimiento normal, establece `enableReplay` en `true`. Cuando está habilitado, Blowfish cargará el script de replay además del script normal de Umami, junto con los ajustes específicos de replay como `sampleRate`, `maskLevel`, `maxDuration` y `blockSelector`.
+
 {{< alert >}}
 **Nota:** Si habilitas Umami Analytics, Blowfish soportará [Umami Track Event](https://umami.is/docs/track-events) automáticamente. Si no deseas soportar Track Event, el parámetro `enableTrackEvent` debe establecerse en `false`.
 {{< /alert >}}
@@ -58,6 +60,11 @@ Si quieres que el rastreador solo se ejecute en dominios específicos, puedes pr
   domain = "llama.yoursite.com"
   dataDomains = "yoursite.com,yoursite2.com"
   scriptName = "TRACKER_SCRIPT_NAME"
+  enableReplay = true
+  sampleRate = 0.15
+  maskLevel = "moderate"
+  maxDuration = 300000
+  blockSelector = ".my-secret-element"
   enableTrackEvent = true
 ```
 

--- a/exampleSite/content/docs/partials/index.fr.md
+++ b/exampleSite/content/docs/partials/index.fr.md
@@ -46,6 +46,8 @@ Pour activer la prise en charge d'Umami Analytics, fournissez simplement votre [
 Si vous utilisez également la fonctionnalité de domaine personnalisé d'Umami et souhaitez servir leur script depuis votre domaine, vous pouvez également fournir la valeur de configuration `domain`. Si vous ne fournissez pas de valeur `domain`, le script se chargera directement depuis le DNS d'Umami (analytics.umami.is).
 Si vous souhaitez que le tracker ne s'exécute que sur des domaines spécifiques, vous pouvez fournir la valeur de configuration `dataDomains`. Si vous ne fournissez pas de valeur `dataDomains`, le script s'exécutera sur tout site web où `domain` et `websiteid` correspondent. Si la variable d'environnement `TRACKER_SCRIPT_NAME` est configurée, vous pouvez spécifier un nom de script personnalisé `scriptName`. Si elle n'est pas configurée, commentez-la ou utilisez la valeur par défaut `script.js`.
 
+Si vous souhaitez activer Umami Session Replay en plus du script de suivi normal, définissez `enableReplay` sur `true`. Lorsqu'il est activé, Blowfish chargera le script de replay en plus du script Umami habituel, ainsi que les paramètres spécifiques au replay comme `sampleRate`, `maskLevel`, `maxDuration` et `blockSelector`.
+
 {{< alert >}}
 **Note :** Si vous activez Umami Analytics, Blowfish prendra en charge [Umami Track Event](https://umami.is/docs/track-events) automatiquement. Si vous ne souhaitez pas prendre en charge Track Event, le paramètre `enableTrackEvent` doit être défini sur `false`.
 {{< /alert >}}
@@ -58,6 +60,11 @@ Si vous souhaitez que le tracker ne s'exécute que sur des domaines spécifiques
   domain = "llama.yoursite.com"
   dataDomains = "yoursite.com,yoursite2.com"
   scriptName = "TRACKER_SCRIPT_NAME"
+  enableReplay = true
+  sampleRate = 0.15
+  maskLevel = "moderate"
+  maxDuration = 300000
+  blockSelector = ".my-secret-element"
   enableTrackEvent = true
 ```
 

--- a/exampleSite/content/docs/partials/index.it.md
+++ b/exampleSite/content/docs/partials/index.it.md
@@ -46,6 +46,8 @@ To enable Umami Analytics support, simply provide your [Umami tracking code](htt
 If you also use the custom domain feature of Umami and would like to serve their script from your domain, you can also additionally provide the `domain` configuration value. If you don't provide a `domain` value, the script will load directly from Umami DNS (analytics.umami.is).
 If you want the tracker to only run on specific domains, you can provide the `dataDomains` configuration value. If you don't provide a `dataDomains` value, the script will run on any website where the `domain` and`websiteid` match. If the environment variable `TRACKER_SCRIPT_NAME` is configured, you can specify a custom script name `scriptName`. If it is not configured, either comment it out or use the default `script.js`.
 
+If you want to enable Umami Session Replay as well as the normal tracking script, set `enableReplay` to `true`. When enabled, Blowfish will load the replay script in addition to the regular Umami script, along with the replay-specific settings such as `sampleRate`, `maskLevel`, `maxDuration`, and `blockSelector`.
+
 {{< alert >}}
 **Note:** If you enable Umami Analytics, Blowfish will support [Umami Track Event](https://umami.is/docs/track-events) automatically. If you do not want to support Track Event, the param `enableTrackEvent` must set to `false`.
 {{< /alert >}}
@@ -58,6 +60,11 @@ If you want the tracker to only run on specific domains, you can provide the `da
   domain = "llama.yoursite.com"
   dataDomains = "yoursite.com,yoursite2.com"
   scriptName = "TRACKER_SCRIPT_NAME"
+  enableReplay = true
+  sampleRate = 0.15
+  maskLevel = "moderate"
+  maxDuration = 300000
+  blockSelector = ".my-secret-element"
   enableTrackEvent = true
 ```
 

--- a/exampleSite/content/docs/partials/index.md
+++ b/exampleSite/content/docs/partials/index.md
@@ -48,6 +48,8 @@ If you want the tracker to only run on specific domains, you can provide the `da
 
 If you want to honor the Do Not Track setting of the users browser, you have to set `doNotTrack` to `true`. Blowfish does not honor the Do Not Track setting per default.
 
+If you want to enable Umami session replay as well as the normal tracking script, set `enableReplay` to `true`. When enabled, Blowfish will load the replay script in addition to the regular Umami script, along with the replay-specific settings such as `sampleRate`, `maskLevel`, `maxDuration`, and `blockSelector`.
+
 {{< alert >}}
 **Note:** If you enable Umami Analytics, Blowfish will support [Umami Track Event](https://umami.is/docs/track-events) automatically. If you do not want to support Track Event, the param `enableTrackEvent` must set to `false`.
 {{< /alert >}}
@@ -62,6 +64,11 @@ If you want to honor the Do Not Track setting of the users browser, you have to 
   scriptName = "TRACKER_SCRIPT_NAME"
   enableTrackEvent = true
   doNotTrack = false
+  enableReplay = true
+  sampleRate = 0.15
+  maskLevel = "moderate"
+  maxDuration = 300000
+  blockSelector = ".my-secret-element"
 ```
 
 ### Seline Analytics

--- a/exampleSite/content/docs/partials/index.pt-br.md
+++ b/exampleSite/content/docs/partials/index.pt-br.md
@@ -46,6 +46,8 @@ Para habilitar o suporte ao Umami Analytics, simplesmente forneça seu [código 
 Se você também usa o recurso de domínio personalizado do Umami e gostaria de servir o script deles do seu domínio, você também pode fornecer adicionalmente o valor de configuração `domain`. Se você não fornecer um valor `domain`, o script será carregado diretamente do DNS do Umami (analytics.umami.is).
 Se você quiser que o rastreador execute apenas em domínios específicos, você pode fornecer o valor de configuração `dataDomains`. Se você não fornecer um valor `dataDomains`, o script será executado em qualquer site onde `domain` e `websiteid` correspondam. Se a variável de ambiente `TRACKER_SCRIPT_NAME` estiver configurada, você pode especificar um nome de script personalizado `scriptName`. Se não estiver configurada, comente-a ou use o padrão `script.js`.
 
+Se você quiser habilitar o Umami Session Replay junto com o script de rastreamento normal, defina `enableReplay` como `true`. Quando ativado, o Blowfish carregará o script de replay além do script normal do Umami, junto com as configurações específicas de replay como `sampleRate`, `maskLevel`, `maxDuration` e `blockSelector`.
+
 {{< alert >}}
 **Nota:** Se você habilitar o Umami Analytics, o Blowfish suportará [Umami Track Event](https://umami.is/docs/track-events) automaticamente. Se você não quiser suportar Track Event, o parâmetro `enableTrackEvent` deve ser definido como `false`.
 {{< /alert >}}
@@ -58,6 +60,11 @@ Se você quiser que o rastreador execute apenas em domínios específicos, você
   domain = "llama.yoursite.com"
   dataDomains = "yoursite.com,yoursite2.com"
   scriptName = "TRACKER_SCRIPT_NAME"
+  enableReplay = true
+  sampleRate = 0.15
+  maskLevel = "moderate"
+  maxDuration = 300000
+  blockSelector = ".my-secret-element"
   enableTrackEvent = true
 ```
 

--- a/exampleSite/content/docs/partials/index.pt-pt.md
+++ b/exampleSite/content/docs/partials/index.pt-pt.md
@@ -46,6 +46,8 @@ Para ativar o suporte ao Umami Analytics, basta fornecer o seu [código de rastr
 Se também utiliza a funcionalidade de domínio personalizado do Umami e gostaria de servir o script deles do seu domínio, pode também fornecer adicionalmente o valor de configuração `domain`. Se não fornecer um valor `domain`, o script será carregado diretamente do DNS do Umami (analytics.umami.is).
 Se quiser que o rastreador execute apenas em domínios específicos, pode fornecer o valor de configuração `dataDomains`. Se não fornecer um valor `dataDomains`, o script será executado em qualquer site onde `domain` e `websiteid` correspondam. Se a variável de ambiente `TRACKER_SCRIPT_NAME` estiver configurada, pode especificar um nome de script personalizado `scriptName`. Se não estiver configurada, comente-a ou utilize a predefinição `script.js`.
 
+Se quiser ativar o Umami Session Replay juntamente com o script de rastreamento normal, defina `enableReplay` como `true`. Quando ativado, o Blowfish carregará o script de replay além do script normal do Umami, juntamente com as definições específicas de replay como `sampleRate`, `maskLevel`, `maxDuration` e `blockSelector`.
+
 {{< alert >}}
 **Nota:** Se ativar o Umami Analytics, o Blowfish suportará [Umami Track Event](https://umami.is/docs/track-events) automaticamente. Se não quiser suportar Track Event, o parâmetro `enableTrackEvent` deve ser definido como `false`.
 {{< /alert >}}
@@ -58,6 +60,11 @@ Se quiser que o rastreador execute apenas em domínios específicos, pode fornec
   domain = "llama.yoursite.com"
   dataDomains = "yoursite.com,yoursite2.com"
   scriptName = "TRACKER_SCRIPT_NAME"
+  enableReplay = true
+  sampleRate = 0.15
+  maskLevel = "moderate"
+  maxDuration = 300000
+  blockSelector = ".my-secret-element"
   enableTrackEvent = true
 ```
 

--- a/i18n/ar.yaml
+++ b/i18n/ar.yaml
@@ -73,6 +73,7 @@ sharing:
   pinterest: "النشر على بينترست"
   reddit: "النشر على ريديت"
   twitter: "النشر على تويتر"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "تم النشر مؤخرا"

--- a/i18n/bg.yaml
+++ b/i18n/bg.yaml
@@ -73,6 +73,7 @@ sharing:
   pinterest: "Закачи в Pinterest"
   reddit: "Добави на Reddit"
   twitter: "Сподели на Twitter"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Последни"

--- a/i18n/bn.yaml
+++ b/i18n/bn.yaml
@@ -69,6 +69,7 @@ sharing:
   pinterest: "পিন্টারেস্টে পিন করুন"
   reddit: "রেড্ডিটে জমা দিন"
   twitter: "ট্যুইট করুন"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "সাম্প্রতিক"

--- a/i18n/cs.yaml
+++ b/i18n/cs.yaml
@@ -73,6 +73,7 @@ sharing:
   pinterest: "Připnout na Pinterest"
   reddit: "Přidat na Reddit"
   twitter: "Tweet na Twitter"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Nedávné"

--- a/i18n/eo.yaml
+++ b/i18n/eo.yaml
@@ -77,6 +77,7 @@ sharing:
   reddit: "Sendi al Reddit"
   twitter: "Pepi per Twitter"
   bluesky: "Afiŝi en Bluesky"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Freŝaj"

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -72,6 +72,7 @@ sharing:
   pinterest: "Pinear en Pinterest"
   reddit: "Publicar en Reddit"
   twitter: "Tuitear en Twitter"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Reciente"

--- a/i18n/eu.yaml
+++ b/i18n/eu.yaml
@@ -72,6 +72,7 @@ sharing:
   pinterest: "Pin egin Pinteresten"
   reddit: "Argitaratu Redditen"
   twitter: "Tuitu Twitterren"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Azkenak"

--- a/i18n/fa.yaml
+++ b/i18n/fa.yaml
@@ -79,6 +79,7 @@ sharing:
   bluesky: "هم‌رسانی در بلواسکای"
   whatsapp: "هم‌رسانی در واتس‌اپ"
   telegram: "هم‌رسانی در تلگرام"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "مقاله‌های اخیر"

--- a/i18n/fi.yaml
+++ b/i18n/fi.yaml
@@ -67,6 +67,7 @@ sharing:
   pinterest: "Kiinnitä Pinterestiin"
   reddit: "Lähetä Reddittiin"
   twitter: "Twiittaa Twitterissä"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Viimeaikaiset"

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -70,6 +70,7 @@ sharing:
   pinterest: "Poster sur Pinterest"
   reddit: "Poster sur Reddit"
   twitter: "Tweeter"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Articles récents"

--- a/i18n/gl.yaml
+++ b/i18n/gl.yaml
@@ -79,6 +79,7 @@ sharing:
   bluesky: "Publicar en Bluesky"
   whatsapp: "Compartir vía WhatsApp"
   telegram: "Compartir vía Telegram"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Recente"

--- a/i18n/he.yaml
+++ b/i18n/he.yaml
@@ -67,6 +67,7 @@ sharing:
   pinterest: "שיתוף בפינטרסט"
   reddit: "שליחה לרדיט"
   twitter: "ציוץ בטוויטר"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "חדשים"

--- a/i18n/hr.yaml
+++ b/i18n/hr.yaml
@@ -69,6 +69,7 @@ sharing:
   pinterest: "Podijeli na Pinterest"
   reddit: "Objavi na Reddit"
   twitter: "Tweet na Twitter"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Nedavno"

--- a/i18n/hu.yaml
+++ b/i18n/hu.yaml
@@ -67,6 +67,7 @@ sharing:
   pinterest: "Megosztás a Pinteresten"
   reddit: "Megosztás a Redditen"
   twitter: "Megosztás a Twitteren"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Friss"

--- a/i18n/id.yaml
+++ b/i18n/id.yaml
@@ -73,6 +73,7 @@ sharing:
   pinterest: "Pin di Pinterest"
   reddit: "Kirim ke Reddit"
   twitter: "Tweet di Twitter"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Terbaru"

--- a/i18n/it.yaml
+++ b/i18n/it.yaml
@@ -67,6 +67,7 @@ sharing:
   pinterest: "Pinna su Pinterest"
   reddit: "Invia a Reddit"
   twitter: "Tweetta su Twitter"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Recenti"

--- a/i18n/ja.yaml
+++ b/i18n/ja.yaml
@@ -79,6 +79,7 @@ sharing:
   bluesky: "Blueskyに投稿する"
   whatsapp: "WhatsAppでシェアする"
   telegram: "Telegramでシェアする"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "最近の記事"

--- a/i18n/ko.yaml
+++ b/i18n/ko.yaml
@@ -73,6 +73,7 @@ sharing:
   pinterest: "Pinterest에 고정"
   reddit: "Reddit에 게시"
   twitter: "Twitter에 트윗"
+  mastodon: "Mastodon에 공유"
 
 shortcode:
   recent_articles: "최근 글"

--- a/i18n/nl.yaml
+++ b/i18n/nl.yaml
@@ -75,6 +75,7 @@ sharing:
   bluesky: "Delen op Bluesky"
   whatsapp: "Delen op WhatsApp"
   telegram: "Delen op Telegram"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Recente"

--- a/i18n/pl.yaml
+++ b/i18n/pl.yaml
@@ -74,6 +74,7 @@ sharing:
   pinterest: "Przypnij na Pinterest"
   reddit: "Prześlij na Reddita"
   twitter: "Tweetuj na Twitterze"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Ostatnie artykuły"

--- a/i18n/pt-BR.yaml
+++ b/i18n/pt-BR.yaml
@@ -70,6 +70,7 @@ sharing:
   pinterest: "Pin no Pinterest"
   reddit: "Postar no Reddit"
   twitter: "Tweet no Twitter"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Recente"

--- a/i18n/pt-PT.yaml
+++ b/i18n/pt-PT.yaml
@@ -70,6 +70,7 @@ sharing:
   pinterest: "Partilhar no Pinterest"
   reddit: "Partilhar no Reddit"
   twitter: "Partilhar no Twitter"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Recentes"

--- a/i18n/ro.yaml
+++ b/i18n/ro.yaml
@@ -67,6 +67,7 @@ sharing:
   pinterest: "Pune pe Pinterest"
   reddit: "Postează pe Reddit"
   twitter: "Scrie pe Twitter"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Cele mai noi"

--- a/i18n/ru.yaml
+++ b/i18n/ru.yaml
@@ -73,6 +73,7 @@ sharing:
   pinterest: "Добавить в Pinterest"
   reddit: "Отправить в Reddit"
   twitter: "Твитнуть в Twitter"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Недавние"

--- a/i18n/sv.yaml
+++ b/i18n/sv.yaml
@@ -67,6 +67,7 @@ sharing:
   pinterest: "Fäst på Pinterest"
   reddit: "Skicka till Reddit"
   twitter: "Twittra på Twitter"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Senaste"

--- a/i18n/th.yaml
+++ b/i18n/th.yaml
@@ -78,6 +78,7 @@ sharing:
   bluesky: "โพสต์บน Bluesky"
   whatsapp: "แชร์ทาง WhatsApp"
   telegram: "แชร์ทาง Telegram"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "บทความล่าสุด"

--- a/i18n/tr.yaml
+++ b/i18n/tr.yaml
@@ -62,6 +62,7 @@ sharing:
   pinterest: "Pinterest'te pinle"
   reddit: "Reddit'te gönder"
   twitter: "Twitter'da Tweetle"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Güncel"

--- a/i18n/uk.yaml
+++ b/i18n/uk.yaml
@@ -80,6 +80,7 @@ sharing:
   pinterest: "Зберегти на Pinterest"
   reddit: "Опублікувати на Reddit"
   twitter: "Поширити на Twitter"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Недавні дописи"

--- a/i18n/vi.yaml
+++ b/i18n/vi.yaml
@@ -76,6 +76,7 @@ sharing:
   pinterest: "Ghim lên Pinterest"
   reddit: "Gửi lên Reddit"
   twitter: "Tweet lên Twitter"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Gần đây"

--- a/i18n/zh-CN.yaml
+++ b/i18n/zh-CN.yaml
@@ -79,6 +79,7 @@ sharing:
   bluesky: "发布到 Bluesky"
   whatsapp: "通过 WhatsApp 分享"
   telegram: "通过 Telegram 分享"
+  mastodon: "分享到 Mastodon"
 
 shortcode:
   recent_articles: "最近的文章"

--- a/i18n/zh-TW.yaml
+++ b/i18n/zh-TW.yaml
@@ -79,6 +79,7 @@ sharing:
   bluesky: "發布到 Bluesky"
   whatsapp: "以 WhatsApp 分享"
   telegram: "以 Telegram 分享"
+  mastodon: "分享到 Mastodon"
 
 shortcode:
   recent_articles: "最近的文章"

--- a/layouts/partials/analytics/umami.html
+++ b/layouts/partials/analytics/umami.html
@@ -1,19 +1,44 @@
 {{/* prettier-ignore-start */}}
+{{ $enableReplay := site.Params.umamiAnalytics.enableReplay | default false }}
+{{ $scriptName := site.Params.umamiAnalytics.scriptName | default "script.js" }}
 {{ if isset site.Params.umamiAnalytics "domain" }}
   <script
     data-id="umami-script"
-    async
-    src="https://{{ site.Params.umamiAnalytics.domain }}/{{ with site.Params.umamiAnalytics.scriptName }}{{ . }}{{ else }}script.js{{ end }}"
+    defer
+    src="https://{{ site.Params.umamiAnalytics.domain }}/{{ $scriptName }}"
     data-website-id="{{ site.Params.umamiAnalytics.websiteid }}"
     {{ with site.Params.umamiAnalytics.dataDomains }}data-domains="{{ . }}"{{ end }}
     data-do-not-track="{{ site.Params.umamiAnalytics.doNotTrack | default false }}"></script>
+  {{ if $enableReplay }}
+    <script
+      data-id="umami-replay-script"
+      defer
+      src="https://{{ site.Params.umamiAnalytics.domain }}/recorder.js"
+      data-website-id="{{ site.Params.umamiAnalytics.websiteid }}"
+      {{ with site.Params.umamiAnalytics.dataDomains }}data-domains="{{ . }}"{{ end }}
+      {{ with site.Params.umamiAnalytics.sampleRate }}data-sample-rate="{{ . }}"{{ end }}
+      {{ with site.Params.umamiAnalytics.maskLevel }}data-mask-level="{{ . }}"{{ end }}
+      {{ with site.Params.umamiAnalytics.maxDuration }}data-max-duration="{{ . }}"{{ end }}
+      {{ with site.Params.umamiAnalytics.blockSelector }}data-block-selector="{{ . }}"{{ end }}></script>
+  {{ end }}
 {{ else }}
   <script
     data-id="umami-script"
-    async
+    defer
     src="https://analytics.umami.is/script.js"
     data-website-id="{{ site.Params.umamiAnalytics.websiteid }}"
     data-do-not-track="{{ site.Params.umamiAnalytics.doNotTrack | default false }}"></script>
+  {{ if $enableReplay }}
+    <script
+      data-id="umami-replay-script"
+      defer
+      src="https://analytics.umami.is/recorder.js"
+      data-website-id="{{ site.Params.umamiAnalytics.websiteid }}"
+      {{ with site.Params.umamiAnalytics.sampleRate }}data-sample-rate="{{ . }}"{{ end }}
+      {{ with site.Params.umamiAnalytics.maskLevel }}data-mask-level="{{ . }}"{{ end }}
+      {{ with site.Params.umamiAnalytics.maxDuration }}data-max-duration="{{ . }}"{{ end }}
+      {{ with site.Params.umamiAnalytics.blockSelector }}data-block-selector="{{ . }}"{{ end }}></script>
+  {{ end }}
 {{ end }}
 {{/* prettier-ignore-end */}}
 

--- a/layouts/partials/header/components/mobile-menu.html
+++ b/layouts/partials/header/components/mobile-menu.html
@@ -57,6 +57,7 @@
 {{ define "mobile-main-menu" }}
   {{ range .Site.Menus.main }}
     {{ $submenuId := printf "fullscreen-submenu-%s" (.Identifier | default .Name | anchorize) }}
+    {{ $submenuChecked := site.Params.header.mobileSubmenuChecked | default true }}
     <div class="px-2">
       <a
         href="{{ .URL }}"
@@ -83,7 +84,7 @@
       </a>
 
       {{ if .HasChildren }}
-        <input checked type="checkbox" id="{{ $submenuId }}" autocomplete="off" class="hidden peer/full">
+        <input {{ if $submenuChecked }}checked{{ end }} type="checkbox" id="{{ $submenuId }}" autocomplete="off" class="hidden peer/full">
 
         <div
           class="grid grid-rows-[0fr] transition-[grid-template-rows] duration-300 peer-checked/full:grid-rows-[1fr]">

--- a/layouts/partials/sharing-links.html
+++ b/layouts/partials/sharing-links.html
@@ -3,12 +3,17 @@
   <section class="flex flex-row flex-wrap justify-center pt-4 text-xl">
     {{ range . }}
       {{ with index $links . }}
+        {{ $label := i18n .title }}
+        {{ if not $label }}
+          {{ $serviceName := replaceRE "^sharing\\." "" .title | title }}
+          {{ $label = printf "Share via %s" $serviceName }}
+        {{ end }}
         <a
           class="m-1 rounded bg-neutral-300 p-1.5 text-neutral-700 hover:bg-primary-500 hover:text-neutral dark:bg-neutral-700 dark:text-neutral-300 dark:hover:bg-primary-400 dark:hover:text-neutral-800"
           target="_blank"
           href="{{ printf .url $.Permalink $.Title | safeURL }}"
-          title="{{ i18n .title }}"
-          aria-label="{{ i18n .title }}">
+          title="{{ $label }}"
+          aria-label="{{ $label }}">
           {{ partial "icon.html" .icon }}
         </a>
       {{ end }}


### PR DESCRIPTION
## Summary

Set the default appearance of the mobile menu as shown in the image below.

<img width="500" height="661" alt="mobile-menu" src="https://github.com/user-attachments/assets/447b18fc-dc38-474e-bbd9-198c1106d405" />

## Changes

- Add a new parameter to `params.toml` to control whether nested menu items on mobile devices are expanded by default.
- Update the mobile menu behavior to respect the new configuration.
- Document the new parameter in the configuration docs.

## Notes

I'm not sure whether i should update the configuration docs or not, but I did anyway. 

Only the English and Simplified Chinese versions of the configuration docs have been reviewed. The other translations were generated using AI, and I cannot guarantee their grammatical or semantic accuracy.
