### PR TITLE
Allow pages using list layout to render emojis in titles

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -18,8 +18,10 @@
     {{ if .Params.showBreadcrumbs | default (site.Params.list.showBreadcrumbs | default false) }}
       {{ partial "breadcrumbs.html" . }}
     {{ end }}
-    <h1 class="mt-5 text-4xl font-extrabold text-neutral-900 dark:text-neutral">{{ .Title }}</h1>
-    <div class="mt-1 mb-2 text-base text-neutral-500 dark:text-neutral-400 print:hidden">
+      <h1 class="mt-5 text-4xl font-extrabold text-neutral-900 dark:text-neutral">
+        {{ .Title | emojify }}
+      </h1>
+      <div class="mt-1 mb-2 text-base text-neutral-500 dark:text-neutral-400 print:hidden">
       {{ partial "article-meta/list.html" (dict "context" . "scope" "single") }}
     </div>
   </header>


### PR DESCRIPTION
Allow pages using `list` layout to render emojis in titles.

Pages using the `single` layout can already render emojis in titles: https://github.com/nunocoracao/blowfish/blob/e9699d8c5da9a64a105eb8401fd2cf79c6015c6f/layouts/_default/single.html#L22