### PR TITLE
feat: add Knocket live chat widget (opt-in)

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -191,3 +191,6 @@ forgejoDefaultServer = "https://v11.next.forgejo.org"
 
 [advertisement]
   # adsense = ""
+
+[knocketChat]
+  identifier = ""  # Get from https://trtc.io/solutions/knocket

--- a/layouts/partials/analytics/knocket.html
+++ b/layouts/partials/analytics/knocket.html
@@ -1,0 +1,1 @@
+<script async src="https://trtc.io/knocket-sdk/sdk.js?identifier={{ site.Params.knocketChat.identifier }}"></script>

--- a/layouts/partials/analytics/main.html
+++ b/layouts/partials/analytics/main.html
@@ -10,3 +10,6 @@
 {{ if site.Params.selineAnalytics.token }}
   {{ partial "analytics/seline.html" . }}
 {{ end }}
+{{ if site.Params.knocketChat.identifier }}
+  {{ partial "analytics/knocket.html" . }}
+{{ end }}


### PR DESCRIPTION
Adds Knocket as an optional live chat widget using the existing analytics provider pattern. Knocket is a 100% free live chat widget — free forever, no ads, no seat limits. Disabled by default; renders only when knocketChat.identifier is set. More info: https://trtc.io/solutions/knocket