### PR TITLE
fix: global resources fallback incorrectly removed in #2978

### DIFF
--- a/layouts/partials/article-link/_shortcode.html
+++ b/layouts/partials/article-link/_shortcode.html
@@ -47,6 +47,9 @@
         {{ end }}
       {{ else }}
         {{ $featured = $p.Resources.Get . }}
+        {{ if not $featured }}
+          {{ $featured = resources.Get . }}
+        {{ end }}
       {{ end }}
     {{ end }}
 
@@ -89,7 +92,7 @@
         role="presentation"
         loading="lazy"
         decoding="async"
-        class="not-prose absolute inset-0 w-full h-full object-cover">
+        class="not-prose absolute inset-0 w-full h-full object-cover" />
     </div>
   {{ end }}
   <div class="{{ $cardContentClasses }}">

--- a/layouts/partials/article-link/card-related.html
+++ b/layouts/partials/article-link/card-related.html
@@ -21,6 +21,9 @@
       {{ end }}
     {{ else }}
       {{ $featured = $p.Resources.Get . }}
+      {{ if not $featured }}
+        {{ $featured = resources.Get . }}
+      {{ end }}
     {{ end }}
   {{ end }}
 
@@ -57,14 +60,16 @@
 <article
   class="article-link--related relative min-h-full min-w-full overflow-hidden rounded-lg border border-neutral-300 dark:border-neutral-600">
   {{ with $featuredURL }}
-    <div class="flex-none relative overflow-hidden thumbnail_card_related" style="--thumbnail-aspect-ratio: {{ $thumbnailAspectRatio }}">
+    <div
+      class="flex-none relative overflow-hidden thumbnail_card_related"
+      style="--thumbnail-aspect-ratio: {{ $thumbnailAspectRatio }}">
       <img
         src="{{ . }}"
         role="presentation"
         loading="lazy"
         decoding="async"
         fetchpriority="low"
-        class="not-prose absolute inset-0 w-full h-full object-cover">
+        class="not-prose absolute inset-0 w-full h-full object-cover" />
     </div>
   {{ end }}
   {{ if and .Draft .Site.Params.article.showDraftLabel }}

--- a/layouts/partials/article-link/card.html
+++ b/layouts/partials/article-link/card.html
@@ -24,6 +24,9 @@
         {{ end }}
       {{ else }}
         {{ $featured = $p.Resources.Get . }}
+        {{ if not $featured }}
+          {{ $featured = resources.Get . }}
+        {{ end }}
       {{ end }}
     {{ end }}
 
@@ -61,13 +64,15 @@
 <article
   class="article-link--card relative min-h-full min-w-full overflow-hidden rounded-lg border border-neutral-300 dark:border-neutral-600">
   {{ with $featuredURL }}
-    <div class="flex-none relative overflow-hidden thumbnail_card" style="--thumbnail-aspect-ratio: {{ $thumbnailAspectRatio }}">
+    <div
+      class="flex-none relative overflow-hidden thumbnail_card"
+      style="--thumbnail-aspect-ratio: {{ $thumbnailAspectRatio }}">
       <img
         src="{{ . }}"
         role="presentation"
         loading="lazy"
         decoding="async"
-        class="not-prose absolute inset-0 w-full h-full object-cover">
+        class="not-prose absolute inset-0 w-full h-full object-cover" />
     </div>
   {{ end }}
   {{ if and .Draft .Site.Params.article.showDraftLabel }}

--- a/layouts/partials/article-link/simple.html
+++ b/layouts/partials/article-link/simple.html
@@ -40,6 +40,9 @@
         {{ end }}
       {{ else }}
         {{ $featured = $p.Resources.Get . }}
+        {{ if not $featured }}
+          {{ $featured = resources.Get . }}
+        {{ end }}
       {{ end }}
     {{ end }}
 
@@ -82,7 +85,7 @@
         role="presentation"
         loading="lazy"
         decoding="async"
-        class="not-prose absolute inset-0 w-full h-full object-cover">
+        class="not-prose absolute inset-0 w-full h-full object-cover" />
     </div>
   {{ end }}
   <div class="{{ $cardContentClasses }}">

--- a/layouts/partials/hero/background.html
+++ b/layouts/partials/hero/background.html
@@ -12,6 +12,9 @@
     {{ end }}
   {{ else }}
     {{ $featured = page.Resources.Get . }}
+    {{ if not $featured }}
+      {{ $featured = resources.Get . }}
+    {{ end }}
   {{ end }}
 {{ end }}
 
@@ -78,7 +81,7 @@
       decoding="async"
       fetchpriority="high"
       class="absolute inset-0 w-full h-full object-cover"
-      {{ if $style }}style="{{ $style | safeCSS }}"{{ end }}>
+      {{ if $style }}style="{{ $style | safeCSS }}"{{ end }} />
     <div
       class="absolute inset-0 bg-gradient-to-t from-neutral dark:from-neutral-800 to-transparent mix-blend-normal"></div>
     <div

--- a/layouts/partials/hero/basic.html
+++ b/layouts/partials/hero/basic.html
@@ -12,6 +12,9 @@
     {{ end }}
   {{ else }}
     {{ $featured = page.Resources.Get . }}
+    {{ if not $featured }}
+      {{ $featured = resources.Get . }}
+    {{ end }}
   {{ end }}
 {{ end }}
 
@@ -58,6 +61,6 @@
       decoding="async"
       fetchpriority="high"
       class="w-full h-full nozoom object-cover"
-      {{ if $style }}style="{{ $style | safeCSS }}"{{ end }}>
+      {{ if $style }}style="{{ $style | safeCSS }}"{{ end }} />
   </div>
 {{ end }}

--- a/layouts/partials/hero/big.html
+++ b/layouts/partials/hero/big.html
@@ -12,6 +12,9 @@
     {{ end }}
   {{ else }}
     {{ $featured = page.Resources.Get . }}
+    {{ if not $featured }}
+      {{ $featured = resources.Get . }}
+    {{ end }}
   {{ end }}
 {{ end }}
 
@@ -66,7 +69,7 @@
       decoding="async"
       fetchpriority="high"
       class="w-full rounded-lg single_hero_round nozoom"
-      {{ if $style }}style="{{ $style | safeCSS }}"{{ end }}>
+      {{ if $style }}style="{{ $style | safeCSS }}"{{ end }} />
     {{ if $caption }}
       <figcaption class="text-sm text-neutral-700 dark:text-neutral-400 hover:underline text-center">
         {{ $caption | markdownify }}

--- a/layouts/partials/hero/thumbAndBackground.html
+++ b/layouts/partials/hero/thumbAndBackground.html
@@ -46,6 +46,9 @@
     {{ end }}
   {{ else }}
     {{ $featured = page.Resources.Get . }}
+    {{ if not $featured }}
+      {{ $featured = resources.Get . }}
+    {{ end }}
   {{ end }}
 {{ end }}
 
@@ -94,7 +97,7 @@
       decoding="async"
       fetchpriority="high"
       class="w-full h-full nozoom object-cover"
-      {{ with $.Params.imagePositionFeature }}style="object-position: {{ . }};"{{ end }}>
+      {{ with $.Params.imagePositionFeature }}style="object-position: {{ . }};"{{ end }} />
   </div>
 {{ end }}
 
@@ -114,7 +117,7 @@
       decoding="async"
       fetchpriority="high"
       class="absolute inset-0 h-full w-full object-cover"
-      {{ if $style }}style="{{ $style | safeCSS }}"{{ end }}>
+      {{ if $style }}style="{{ $style | safeCSS }}"{{ end }} />
   {{ end }}
   <div
     class="from-neutral absolute inset-0 bg-gradient-to-t to-transparent mix-blend-normal dark:from-neutral-800"></div>

--- a/layouts/partials/term-link/card.html
+++ b/layouts/partials/term-link/card.html
@@ -5,11 +5,15 @@
 {{ $thumbnailAspectRatio := site.Params.thumbnailAspectRatio | default "1.5" }}
 {{ $thumbnailAspectRatio = replaceRE "[^0-9.]" "" $thumbnailAspectRatio }}
 {{ if eq $thumbnailAspectRatio "" }}{{ $thumbnailAspectRatio = "1.5" }}{{ end }}
+{{ $p := .Page }}
 {{ with .Page.Params.featureimage }}
   {{ if or (strings.HasPrefix . "http:") (strings.HasPrefix . "https:") }}
     {{ $featured = resources.GetRemote . }}
   {{ else }}
-    {{ $featured = page.Resources.Get . }}
+    {{ $featured = $p.Resources.Get . }}
+    {{ if not $featured }}
+      {{ $featured = resources.Get . }}
+    {{ end }}
   {{ end }}
 {{ end }}
 
@@ -31,14 +35,16 @@
 <div class="min-w-full">
   <div class="border-neutral-200 dark:border-neutral-700 border-2 rounded overflow-hidden shadow-2xl relative">
     {{ with $featuredURL }}
-      <figure class="not-prose flex-none relative overflow-hidden thumbnail_card" style="--thumbnail-aspect-ratio: {{ $thumbnailAspectRatio }}">
+      <figure
+        class="not-prose flex-none relative overflow-hidden thumbnail_card"
+        style="--thumbnail-aspect-ratio: {{ $thumbnailAspectRatio }}">
         <img
           src="{{ . }}"
           alt="{{ $.Page.Title }}"
           loading="lazy"
           decoding="async"
           fetchpriority="low"
-          class="not-prose absolute inset-0 w-full h-full object-cover">
+          class="not-prose absolute inset-0 w-full h-full object-cover" />
       </figure>
     {{ end }}
     {{ if site.Params.taxonomy.showTermCount | default true }}


### PR DESCRIPTION
Fix regression caused by #2978

The global resources match (`resources.Get`) should be a fallback instead of being replaced by local resources (`.Resources.Get`)