### PR TITLE
Update Tech Trail Pulse entry and add Christian Living Ministries Books site built with Hugo and the Blowfish theme

### DIFF
--- a/exampleSite/content/users/users.json
+++ b/exampleSite/content/users/users.json
@@ -1096,11 +1096,24 @@
     ]
   },
   {
-    "title": "techtrailpulse.com",
+    "title": "Tech Trail Pulse",
     "url": "https://techtrailpulse.com",
     "source": "https://github.com/gregpuzzles1/blog",
     "tags": [
-      "Personal site"
+      "Personal site",
+      "Blog",
+      "Technology blog",
+      "Learning"
+    ]
+  },
+  {
+    "title": "Christian Living Ministries Books",
+    "url": "https://clmbooks.org",
+    "source": "https://github.com/gregpuzzles1/clmbooks",
+    "tags": [
+      "Books",
+      "PDF's",
+      "Christian devotionals"
     ]
   }
 ]


### PR DESCRIPTION
## Summary
- rename the Tech Trail Pulse site entry for clearer display
- add tags to the Tech Trail Pulse entry
- add the Christian Living Ministries Books site to the users list

## Testing
- validated exampleSite/content/users/users.json parses successfully as JSON