### PR TITLE
fix: article shortcode build deadlock on mutually-referencing articles

### DIFF
--- a/layouts/partials/article-link/_shortcode.html
+++ b/layouts/partials/article-link/_shortcode.html
@@ -9,7 +9,9 @@
 */}}
 {{ $target := .target }}
 {{ $shortcodeShowSummary := .showSummary }}
+{{ $shortcodeShowSummarySet := .showSummarySet }}
 {{ $shortcodeCompactSummary := .compactSummary }}
+{{ $cyclic := .cyclic | default false }}
 {{ $constrainItemsWidth := site.Params.list.constrainItemsWidth | default false }}
 {{ $disableImageOptimization := site.Store.Get "disableImageOptimization" }}
 
@@ -120,10 +122,19 @@
         {{ partial "extend-article-link.html" $target }}
       {{ end }}
     </header>
+    {{ if not $cyclic }}
     <div class="text-sm text-neutral-500 dark:text-neutral-400">
       {{ partial "article-meta/basic.html" $target }}
     </div>
-    {{ if $shortcodeShowSummary | default $target.Params.showSummary | default site.Params.list.showSummary | default false }}
+    {{ end }}
+    {{/* Respect an explicit showSummary=false from the shortcode; only fall
+         back to target/site defaults when the shortcode did not set it. The
+         plain `default` chain treats false as zero and would override it. */}}
+    {{ $summaryEnabled := $shortcodeShowSummary }}
+    {{ if not $shortcodeShowSummarySet }}
+      {{ $summaryEnabled = $target.Params.showSummary | default site.Params.list.showSummary | default false }}
+    {{ end }}
+    {{ if $summaryEnabled }}
       {{ $compactSummary := $shortcodeCompactSummary | default $target.Params.compactSummary | default false }}
       <div
         class="article-link__summary prose dark:prose-invert max-w-fit mt-1 {{ if $compactSummary -}}

--- a/layouts/shortcodes/article.html
+++ b/layouts/shortcodes/article.html
@@ -1,5 +1,6 @@
 {{ $link := printf "%s%s" site.LanguagePrefix (.Get "link") }}
 {{ $showSummary := .Get "showSummary" }}
+{{ $showSummarySet := isset .Params "showSummary" }}
 {{ $compactSummary := .Get "compactSummary" | default false }}
 {{ $target := .Page }}
 {{ if ne $link .Page.RelPermalink }}
@@ -10,8 +11,21 @@
   {{ $target = index (first 1 (where $pages "RelPermalink" $link)) 0 }}
 {{ end }}
 {{ if $target }}
+  {{/* Guard against render deadlocks: requesting $target.Summary renders
+       $target.Content. When articles reference each other, this re-enters a
+       page whose Content is already being rendered, and Hugo deadlocks instead
+       of re-executing shortcodes. Mark the current page as rendering; if the
+       target is already marked it is on the render stack, so skip its summary
+       to break the cycle. Page-local Scratch keeps this free of global state. */}}
+  {{ .Page.Scratch.Set "article rendering" true }}
+  {{ $cyclic := false }}
+  {{ if $target.Scratch.Get "article rendering" }}
+    {{ $cyclic = true }}
+    {{ $showSummary = false }}
+  {{ end }}
   <section class="space-y-10 w-full">
-    {{ $context := dict "target" $target "showSummary" $showSummary "compactSummary" $compactSummary }}
+    {{ $context := dict "target" $target "showSummary" $showSummary "showSummarySet" $showSummarySet "compactSummary" $compactSummary "cyclic" $cyclic }}
     {{ partial "article-link/_shortcode.html" $context }}
   </section>
+  {{ .Page.Scratch.Set "article rendering" false }}
 {{ end }}


### PR DESCRIPTION
Fixes #2791

## Summary

This PR adds a theme-level mitigation for the circular `article` shortcode render deadlock described in #2791.

When two articles embed each other with the `article` shortcode and summaries are enabled, Hugo can hang during rendering. This change detects the circular render path and safely degrades only the inner cyclic reference, while preserving normal behavior for non-cyclic references.

## Reproduction

Two articles that reference each other:

```md
<!-- content/posts/a/index.md -->
{{< article link="/posts/b/" showSummary=true >}}

<!-- content/posts/b/index.md -->
{{< article link="/posts/a/" showSummary=true >}}
```

Without this change, rendering `$target.Summary` causes Hugo to render `$target.Content`, which executes nested shortcodes. In a mutual reference, this can attempt to render content that is already being rendered and cause the build to hang.

## Changes

### Add circular render detection

`layouts/shortcodes/article.html` now uses page-local `.Scratch` state to mark the page currently being rendered.

Before rendering an article card, the shortcode checks whether the target page is already marked as rendering. When a circular reference is detected, it passes a `cyclic` flag to the article-link partial and disables the summary for that inner reference.

### Skip content-dependent output on cyclic references

`layouts/partials/article-link/_shortcode.html` skips both the summary and metadata when `cyclic` is true.

Skipping metadata is necessary because `ReadingTime` and `WordCount` may also require Hugo to access the target page content, which can otherwise re-enter the same deadlocked render path.

The title, link, and feature image remain available on the cyclic article card.

### Respect explicit `showSummary=false`

The previous `default` chain treated `false` as an empty value. Therefore, an explicit shortcode option such as:

```md
{{< article link="/posts/b/" showSummary=false >}}
```

could be overridden by the page or site default.

This PR distinguishes between these cases:

- `showSummary` omitted: use the target page or site default;
- `showSummary=true`: show the summary;
- `showSummary=false`: explicitly disable the summary.

## Result

| Reference type | Summary | Metadata | Title / link / feature image |
| --- | --- | --- | --- |
| Non-cyclic reference | Preserved | Preserved | Preserved |
| Cyclic reference | Safely skipped for the inner reference | Safely skipped for the inner reference | Preserved |

## Verification

Tested with two articles that mutually reference each other through the `article` shortcode with `showSummary=true`.

- Before this change, the Hugo build timed out while rendering.
- After this change, the build completes successfully.
- Both generated pages contain the expected `article-link--shortcode` card.
- A shortcode with `showSummary` omitted still inherits the configured site default.
