### PR TITLE
New Shortcode: Add stats for display of (number,label) tuples 

### DIFF
--- a/exampleSite/content/docs/shortcodes/index.md
+++ b/exampleSite/content/docs/shortcodes/index.md
@@ -926,6 +926,64 @@ You can see some additional Mermaid examples on the [diagrams and flowcharts sam
 
 <br/><br/><br/>
 
+## Stats
+
+`stats` creates a responsive grid of statistic cards, each displaying a prominent number alongside a short label. It relies on the `stat` shortcode to define each individual statistic.
+
+The `stats` shortcode accepts the following parameters.
+
+<!-- prettier-ignore-start -->
+| Parameter  | Description                                                       |
+| ---------- | ----------------------------------------------------------------- |
+| `colors`   | **Optional** Comma-separated list of theme colors to cycle through. |
+| `max-cols` | **Optional** [Integer] Maximum number of columns to display. Defaults to `3`.            |
+
+<!-- prettier-ignore-end -->
+
+Each `stat` item accepts the following parameters.
+
+<!-- prettier-ignore-start -->
+| Parameter | Description                              |
+| --------- | ---------------------------------------- |
+| `number`  | **Required** [String] The main statistic or value to display.  |
+| `label`   | **Required** [String] A short description for the statistic.   |
+
+<!-- prettier-ignore-end -->
+
+**Examples:**
+
+```md
+{{</* stats */>}}
+{{</* stat number="40" label="Shortcodes" */>}}
+{{</* stat number="50" label="Users" */>}}
+{{</* stat number="99" label="Amazing Options" */>}}
+{{</* /stats */>}}
+```
+
+{{< stats >}}
+{{< stat number="40" label="Shortcodes" >}}
+{{< stat number="50" label="Users" >}}
+{{< stat number="99" label="Amazing Options" >}}
+{{< /stats >}}
+
+```md
+{{</* stats colors="primary-500,secondary-500" max-cols="4" */>}}
+{{</* stat number="4" label="Columns" */>}}
+{{</* stat number="2" label="Colors" */>}}
+{{</* stat number="99" label="Amazing Options" */>}}
+{{</* stat number="50" label="Users" */>}}
+{{</* /stats */>}}
+```
+
+{{< stats colors="primary-500,secondary-500" max-cols="4" >}}
+{{< stat number="4" label="Columns" >}}
+{{< stat number="2" label="Colors" >}}
+{{< stat number="99" label="Amazing Options" >}}
+{{< stat number="50" label="Users" >}}
+{{< /stats >}}
+
+<br/><br/><br/>
+
 ## Tabs
 
 The `tabs` shortcode is commonly used to present different variants of a particular step. For example, it can be used to show how to install VS Code on different platforms.

--- a/layouts/shortcodes/stat.html
+++ b/layouts/shortcodes/stat.html
@@ -1,0 +1,5 @@
+{{ $number := .Get "number" }}
+{{ $label := .Get "label" }}
+
+{{ $items := .Page.Store.Get "stats" | default (slice) }}
+{{ .Page.Store.Set "stats" ($items | append (dict "number" $number "label" $label)) }}

--- a/layouts/shortcodes/stats.html
+++ b/layouts/shortcodes/stats.html
@@ -1,0 +1,73 @@
+{{ $noop := .Inner }}
+
+{{ $colorsParam := .Get "colors" | default "neutral-500,primary-500,secondary-500" }}
+{{ $colors := split $colorsParam "," }}
+{{ $items := .Page.Store.Get "stats" | default (slice) }}
+{{ $maxCols := .Get "max-cols" | default 3}}
+
+{{ if gt (len $items) 0 }}
+<div class="stats-wrapper">
+  <div class="stats-container">
+    {{ range $i, $item := $items }}
+    <div class="colorful-box"
+        style="--max-cols: {{ $maxCols }}; background-color: rgb(var(--color-{{ index $colors (mod $i (len $colors)) }}));">
+        <div class="text-container">
+          <span class="big-text">{{ $item.number }}</span>
+          <span class="small-text">{{ $item.label }}</span>
+        </div>
+      </div>
+    {{ end }}
+  </div>
+</div>
+{{ end }}
+
+<style>
+  .stats-wrapper {
+    padding: 1.5rem 0;
+    width: 100%;
+  }
+
+  .stats-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  .colorful-box {
+    flex: 1 1 calc(90% / var(--max-cols));
+    padding: 0.75rem 0.5rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border-radius: 0.375rem;
+    color: white;
+  }
+
+  .text-container {
+    display: flex;
+    flex-direction: row;
+    align-items: last baseline;
+    justify-content: center;
+    gap: 0.25rem;
+  }
+
+  .big-text {
+    margin: 0;
+    font-size: 3rem;
+    font-weight: 700;
+    line-height: 0.8;
+  }
+
+  .small-text {
+    margin: 0;
+    font-size: 0.75rem;
+    font-weight: 700;
+    line-height: 1;
+    text-align: left;
+    text-transform: uppercase;
+    max-width: 45%;
+  }
+
+</style>
+
+{{ .Page.Store.Delete "stats" }}


### PR DESCRIPTION
This PR adds a new stats shortcode with a nested stat sub-shortcode to render responsive statistic cards.

Features:
- Supports configurable grid columns via max-cols
- Supports cycling through custom theme colors via the colors parameter
- Allows each statistic to define a number and label

The color coding scheme seems suboptimal. Feedback on this would be appreciated.