### PR TITLE
feat(header): add mobile submenu checked config

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -54,6 +54,7 @@ forgejoDefaultServer = "https://v11.next.forgejo.org"
 
 [header]
   layout = "basic" # valid options: basic, fixed, fixed-fill, fixed-gradient, fixed-fill-blur
+  # mobileSubmenuChecked = true # set to false to collapse nested mobile menu items by default
 
 [footer]
   showMenu = true

--- a/exampleSite/content/docs/configuration/index.de.md
+++ b/exampleSite/content/docs/configuration/index.de.md
@@ -118,6 +118,19 @@ Blowfish bietet eine große Anzahl von Konfigurationsparametern, die steuern, wi
 
 Viele der Artikel-Standardeinstellungen können auf Artikelebene überschrieben werden, indem sie im Front Matter angegeben werden. Weitere Details finden Sie im Abschnitt [Front Matter]({{< ref "front-matter" >}}).
 
+## Theme-Parameter
+
+Blowfish bietet eine große Anzahl von Konfigurationsparametern, die steuern, wie das Theme funktioniert. Die vollständige Liste aller verfügbaren Parameter finden Sie in der Datei `config/_default/params.toml`.
+
+Viele der Artikel-Standardeinstellungen können auf Artikelebene überschrieben werden, indem sie im Front Matter angegeben werden. Weitere Details finden Sie im Abschnitt [Front Matter]({{< ref "front-matter" >}}).
+
+### Header
+
+| Name | Standard | Beschreibung |
+| --- | --- | --- |
+| `header.layout` | `"basic"` | Definiert den Header für die gesamte Website. Unterstützte Werte sind `basic`, `fixed`, `fixed-fill` und `fixed-fill-blur`. |
+| `header.mobileSubmenuChecked` | `true` | Legt fest, ob verschachtelte Einträge im mobilen Menü standardmäßig aufgeklappt sind. Setze `false`, um sie standardmäßig einzuklappen. |
+
 ## Weitere Konfigurationsdateien
 
 Das Theme enthält auch eine `markup.toml`-Konfigurationsdatei. Diese Datei enthält einige wichtige Parameter, die sicherstellen, dass Hugo korrekt konfiguriert ist, um mit Blowfish erstellte Websites zu generieren.

--- a/exampleSite/content/docs/configuration/index.es.md
+++ b/exampleSite/content/docs/configuration/index.es.md
@@ -118,6 +118,19 @@ Blowfish proporciona un gran número de parámetros de configuración que contro
 
 Muchos de los valores predeterminados de artículos pueden sobrescribirse por artículo especificándolos en el front matter. Consulta la sección [Front Matter]({{< ref "front-matter" >}}) para más detalles.
 
+## Parámetros del tema
+
+Blowfish proporciona un gran número de parámetros de configuración que controlan cómo funciona el tema. La lista completa de todos los parámetros disponibles se encuentra en el archivo `config/_default/params.toml`.
+
+Muchos de los valores predeterminados de artículos pueden sobrescribirse por artículo especificándolos en el front matter. Consulta la sección [Front Matter]({{< ref "front-matter" >}}) para más detalles.
+
+### Cabecera
+
+| Nombre | Predeterminado | Descripción |
+| --- | --- | --- |
+| `header.layout` | `"basic"` | Define la cabecera de todo el sitio. Los valores admitidos son `basic`, `fixed`, `fixed-fill` y `fixed-fill-blur`. |
+| `header.mobileSubmenuChecked` | `true` | Indica si los elementos anidados del menú móvil se expanden de forma predeterminada. Establécelo en `false` para mantenerlos contraídos por defecto. |
+
 ## Otros archivos de configuración
 
 El tema también incluye un archivo de configuración `markup.toml`. Este archivo contiene algunos parámetros importantes que aseguran que Hugo esté correctamente configurado para generar sitios construidos con Blowfish.

--- a/exampleSite/content/docs/configuration/index.fr.md
+++ b/exampleSite/content/docs/configuration/index.fr.md
@@ -118,6 +118,19 @@ Blowfish fournit un grand nombre de paramètres de configuration qui contrôlent
 
 De nombreuses valeurs par défaut des articles peuvent être remplacées article par article en les spécifiant dans le front matter. Consultez la section [Front Matter]({{< ref "front-matter" >}}) pour plus de détails.
 
+## Paramètres du thème
+
+Blowfish fournit un grand nombre de paramètres de configuration qui contrôlent le fonctionnement du thème. La liste complète de tous les paramètres disponibles se trouve dans le fichier `config/_default/params.toml`.
+
+De nombreuses valeurs par défaut des articles peuvent être remplacées article par article en les spécifiant dans le front matter. Consultez la section [Front Matter]({{< ref "front-matter" >}}) pour plus de détails.
+
+### Header
+
+| Nom | Par défaut | Description |
+| --- | --- | --- |
+| `header.layout` | `"basic"` | Définit l'en-tête du site entier. Les valeurs prises en charge sont `basic`, `fixed`, `fixed-fill` et `fixed-fill-blur`. |
+| `header.mobileSubmenuChecked` | `true` | Indique si les sous-éléments du menu mobile sont ouverts par défaut. Définissez `false` pour les replier par défaut. |
+
 ## Autres fichiers de configuration
 
 Le thème inclut également un fichier de configuration `markup.toml`. Ce fichier contient des paramètres importants qui garantissent que Hugo est correctement configuré pour générer des sites construits avec Blowfish.

--- a/exampleSite/content/docs/configuration/index.it.md
+++ b/exampleSite/content/docs/configuration/index.it.md
@@ -198,6 +198,7 @@ Many of the article defaults here can be overridden on a per article basis by sp
 | Name | Default | Description |
 | --- | --- | --- |
 | `header.layout` | `"basic"` | Defines the header for the entire site, supported values are `basic`, `fixed`, `fixed-fill`, and `fixed-fill-blur`. |
+| `header.mobileSubmenuChecked` | `true` | Indica se le voci annidate del menu mobile sono espanse per impostazione predefinita. Imposta `false` per comprimerle di default. |
 
 ### Footer
 

--- a/exampleSite/content/docs/configuration/index.ja.md
+++ b/exampleSite/content/docs/configuration/index.ja.md
@@ -198,6 +198,7 @@ Blowfish は、テーマの機能を制御する多数の設定パラメータ�
 | 名前 | デフォルト | 説明 |
 | --- | --- | --- |
 | `header.layout` | `"basic"` | サイト全体のヘッダーを定義します。サポートされている値は、`basic`、`fixed`、`fixed-fill`、`fixed-fill-blur` です。 |
+| `header.mobileSubmenuChecked` | `true` | モバイルメニューのネストされた項目を既定で展開するかどうかを指定します。既定で折りたたむには `false` に設定します。 |
 
 ### フッター(Footer)
 

--- a/exampleSite/content/docs/configuration/index.md
+++ b/exampleSite/content/docs/configuration/index.md
@@ -227,6 +227,7 @@ Many of the article defaults here can be overridden on a per article basis by sp
 | Name | Default | Description |
 | --- | --- | --- |
 | `header.layout` | `"basic"` | Defines the header for the entire site, supported values are `basic`, `fixed`, `fixed-fill`, and `fixed-fill-blur`. |
+| `header.mobileSubmenuChecked` | `true` | Whether nested items in the mobile menu are expanded by default. Set to `false` to collapse them by default. |
 
 ### Footer
 

--- a/exampleSite/content/docs/configuration/index.pt-br.md
+++ b/exampleSite/content/docs/configuration/index.pt-br.md
@@ -118,6 +118,19 @@ O Blowfish fornece um grande número de parâmetros de configuração que contro
 
 Muitos dos padrões de artigos podem ser substituídos por artigo, especificando-os no front matter. Consulte a seção [Front Matter]({{< ref "front-matter" >}}) para mais detalhes.
 
+## Parâmetros do tema
+
+O Blowfish fornece um grande número de parâmetros de configuração que controlam como o tema funciona. A lista completa de todos os parâmetros disponíveis está no arquivo `config/_default/params.toml`.
+
+Muitos dos padrões de artigos podem ser substituídos por artigo, especificando-os no front matter. Consulte a seção [Front Matter]({{< ref "front-matter" >}}) para mais detalhes.
+
+### Cabeçalho
+
+| Nome | Padrão | Descrição |
+| --- | --- | --- |
+| `header.layout` | `"basic"` | Define o cabeçalho de todo o site. Os valores suportados são `basic`, `fixed`, `fixed-fill` e `fixed-fill-blur`. |
+| `header.mobileSubmenuChecked` | `true` | Define se os itens aninhados do menu mobile ficam expandidos por padrão. Defina `false` para recolhê-los por padrão. |
+
 ## Outros arquivos de configuração
 
 O tema também inclui um arquivo de configuração `markup.toml`. Este arquivo contém alguns parâmetros importantes que garantem que o Hugo esteja corretamente configurado para gerar sites construídos com o Blowfish.

--- a/exampleSite/content/docs/configuration/index.pt-pt.md
+++ b/exampleSite/content/docs/configuration/index.pt-pt.md
@@ -118,6 +118,19 @@ O Blowfish fornece um grande número de parâmetros de configuração que contro
 
 Muitas das predefinições de artigos podem ser substituídas por artigo, especificando-as no front matter. Consulte a secção [Front Matter]({{< ref "front-matter" >}}) para mais detalhes.
 
+## Parâmetros do tema
+
+O Blowfish fornece um grande número de parâmetros de configuração que controlam como o tema funciona. A lista completa de todos os parâmetros disponíveis está no ficheiro `config/_default/params.toml`.
+
+Muitas das predefinições de artigos podem ser substituídas por artigo, especificando-as no front matter. Consulte a secção [Front Matter]({{< ref "front-matter" >}}) para mais detalhes.
+
+### Cabeçalho
+
+| Nome | Predefinição | Descrição |
+| --- | --- | --- |
+| `header.layout` | `"basic"` | Define o cabeçalho de todo o site. Os valores suportados são `basic`, `fixed`, `fixed-fill` e `fixed-fill-blur`. |
+| `header.mobileSubmenuChecked` | `true` | Define se os itens aninhados do menu móvel ficam expandidos por predefinição. Defina `false` para os recolher por predefinição. |
+
 ## Outros ficheiros de configuração
 
 O tema também inclui um ficheiro de configuração `markup.toml`. Este ficheiro contém alguns parâmetros importantes que garantem que o Hugo está corretamente configurado para gerar sites construídos com o Blowfish.

--- a/exampleSite/content/docs/configuration/index.zh-cn.md
+++ b/exampleSite/content/docs/configuration/index.zh-cn.md
@@ -202,6 +202,7 @@ Blowfish 提供了大量控制主题功能的配置参数，下面的表格中�
 | 名称 | 默认值 | 描述 |
 | --- | --- | --- |
 | `header.layout` | `"basic"` | 定义整个站点的页头的布局，支持的参数有 `basic`、`fixed`、`fixed-fill`、and `fixed-fill-blur`. |
+| `header.mobileSubmenuChecked` | `true` | 定义移动端菜单中的嵌套项目是否默认展开。设置为 `false` 可让它们默认折叠。 |
 
 ### 页脚
 

--- a/layouts/partials/header/components/mobile-menu.html
+++ b/layouts/partials/header/components/mobile-menu.html
@@ -58,6 +58,7 @@
 {{ define "mobile-main-menu" }}
   {{ range .Site.Menus.main }}
     {{ $submenuId := printf "fullscreen-submenu-%s" (.Identifier | default .Name | anchorize) }}
+    {{ $submenuChecked := site.Params.header.mobileSubmenuChecked | default true }}
     <div class="px-2">
       <a
         href="{{ .URL }}"
@@ -84,7 +85,7 @@
       </a>
 
       {{ if .HasChildren }}
-        <input checked type="checkbox" id="{{ $submenuId }}" autocomplete="off" class="hidden peer/full">
+        <input {{ if $submenuChecked }}checked{{ end }} type="checkbox" id="{{ $submenuId }}" autocomplete="off" class="hidden peer/full">
 
         <div
           class="grid grid-rows-[0fr] transition-[grid-template-rows] duration-300 peer-checked/full:grid-rows-[1fr]">


### PR DESCRIPTION
This PR is a follow-up to #2980 and contains only the mobile menu changes requested during review.

Regarding the question about why it isn't collapsed by default, my reasoning was that, in some scenarios, the sub-items are not particularly important. Having them expanded by default can make the menu feel a bit cluttered.

## Summary

Set the default appearance of the mobile menu as shown in the image below.

<img width="500" height="661" alt="mobile-menu" src="https://github.com/user-attachments/assets/447b18fc-dc38-474e-bbd9-198c1106d405" />

## Changes

- Add a new parameter to `params.toml` to control whether nested menu items on mobile devices are expanded by default.
- Update the mobile menu behavior to respect the new configuration.
- Document the new parameter in the configuration docs.

## Notes

I'm not sure whether i should update the configuration docs or not, but I did anyway. 

Only the English and Simplified Chinese versions of the configuration docs have been reviewed. The other translations were generated using AI, and I cannot guarantee their grammatical or semantic accuracy.
