### PR TITLE
fix(a11y): add mastodon share labels

### DIFF
--- a/i18n/ar.yaml
+++ b/i18n/ar.yaml
@@ -73,6 +73,7 @@ sharing:
   pinterest: "النشر على بينترست"
   reddit: "النشر على ريديت"
   twitter: "النشر على تويتر"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "تم النشر مؤخرا"

--- a/i18n/bg.yaml
+++ b/i18n/bg.yaml
@@ -73,6 +73,7 @@ sharing:
   pinterest: "Закачи в Pinterest"
   reddit: "Добави на Reddit"
   twitter: "Сподели на Twitter"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Последни"

--- a/i18n/bn.yaml
+++ b/i18n/bn.yaml
@@ -69,6 +69,7 @@ sharing:
   pinterest: "পিন্টারেস্টে পিন করুন"
   reddit: "রেড্ডিটে জমা দিন"
   twitter: "ট্যুইট করুন"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "সাম্প্রতিক"

--- a/i18n/cs.yaml
+++ b/i18n/cs.yaml
@@ -73,6 +73,7 @@ sharing:
   pinterest: "Připnout na Pinterest"
   reddit: "Přidat na Reddit"
   twitter: "Tweet na Twitter"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Nedávné"

--- a/i18n/eo.yaml
+++ b/i18n/eo.yaml
@@ -77,6 +77,7 @@ sharing:
   reddit: "Sendi al Reddit"
   twitter: "Pepi per Twitter"
   bluesky: "Afiŝi en Bluesky"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Freŝaj"

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -72,6 +72,7 @@ sharing:
   pinterest: "Pinear en Pinterest"
   reddit: "Publicar en Reddit"
   twitter: "Tuitear en Twitter"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Reciente"

--- a/i18n/eu.yaml
+++ b/i18n/eu.yaml
@@ -72,6 +72,7 @@ sharing:
   pinterest: "Pin egin Pinteresten"
   reddit: "Argitaratu Redditen"
   twitter: "Tuitu Twitterren"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Azkenak"

--- a/i18n/fa.yaml
+++ b/i18n/fa.yaml
@@ -79,6 +79,7 @@ sharing:
   bluesky: "هم‌رسانی در بلواسکای"
   whatsapp: "هم‌رسانی در واتس‌اپ"
   telegram: "هم‌رسانی در تلگرام"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "مقاله‌های اخیر"

--- a/i18n/fi.yaml
+++ b/i18n/fi.yaml
@@ -67,6 +67,7 @@ sharing:
   pinterest: "Kiinnitä Pinterestiin"
   reddit: "Lähetä Reddittiin"
   twitter: "Twiittaa Twitterissä"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Viimeaikaiset"

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -70,6 +70,7 @@ sharing:
   pinterest: "Poster sur Pinterest"
   reddit: "Poster sur Reddit"
   twitter: "Tweeter"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Articles récents"

--- a/i18n/gl.yaml
+++ b/i18n/gl.yaml
@@ -79,6 +79,7 @@ sharing:
   bluesky: "Publicar en Bluesky"
   whatsapp: "Compartir vía WhatsApp"
   telegram: "Compartir vía Telegram"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Recente"

--- a/i18n/he.yaml
+++ b/i18n/he.yaml
@@ -67,6 +67,7 @@ sharing:
   pinterest: "שיתוף בפינטרסט"
   reddit: "שליחה לרדיט"
   twitter: "ציוץ בטוויטר"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "חדשים"

--- a/i18n/hr.yaml
+++ b/i18n/hr.yaml
@@ -69,6 +69,7 @@ sharing:
   pinterest: "Podijeli na Pinterest"
   reddit: "Objavi na Reddit"
   twitter: "Tweet na Twitter"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Nedavno"

--- a/i18n/hu.yaml
+++ b/i18n/hu.yaml
@@ -67,6 +67,7 @@ sharing:
   pinterest: "Megosztás a Pinteresten"
   reddit: "Megosztás a Redditen"
   twitter: "Megosztás a Twitteren"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Friss"

--- a/i18n/id.yaml
+++ b/i18n/id.yaml
@@ -73,6 +73,7 @@ sharing:
   pinterest: "Pin di Pinterest"
   reddit: "Kirim ke Reddit"
   twitter: "Tweet di Twitter"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Terbaru"

--- a/i18n/it.yaml
+++ b/i18n/it.yaml
@@ -67,6 +67,7 @@ sharing:
   pinterest: "Pinna su Pinterest"
   reddit: "Invia a Reddit"
   twitter: "Tweetta su Twitter"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Recenti"

--- a/i18n/ja.yaml
+++ b/i18n/ja.yaml
@@ -79,6 +79,7 @@ sharing:
   bluesky: "Blueskyに投稿する"
   whatsapp: "WhatsAppでシェアする"
   telegram: "Telegramでシェアする"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "最近の記事"

--- a/i18n/ko.yaml
+++ b/i18n/ko.yaml
@@ -73,6 +73,7 @@ sharing:
   pinterest: "Pinterest에 고정"
   reddit: "Reddit에 게시"
   twitter: "Twitter에 트윗"
+  mastodon: "Mastodon에 공유"
 
 shortcode:
   recent_articles: "최근 글"

--- a/i18n/nl.yaml
+++ b/i18n/nl.yaml
@@ -75,6 +75,7 @@ sharing:
   bluesky: "Delen op Bluesky"
   whatsapp: "Delen op WhatsApp"
   telegram: "Delen op Telegram"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Recente"

--- a/i18n/pl.yaml
+++ b/i18n/pl.yaml
@@ -74,6 +74,7 @@ sharing:
   pinterest: "Przypnij na Pinterest"
   reddit: "Prześlij na Reddita"
   twitter: "Tweetuj na Twitterze"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Ostatnie artykuły"

--- a/i18n/pt-BR.yaml
+++ b/i18n/pt-BR.yaml
@@ -70,6 +70,7 @@ sharing:
   pinterest: "Pin no Pinterest"
   reddit: "Postar no Reddit"
   twitter: "Tweet no Twitter"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Recente"

--- a/i18n/pt-PT.yaml
+++ b/i18n/pt-PT.yaml
@@ -70,6 +70,7 @@ sharing:
   pinterest: "Partilhar no Pinterest"
   reddit: "Partilhar no Reddit"
   twitter: "Partilhar no Twitter"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Recentes"

--- a/i18n/ro.yaml
+++ b/i18n/ro.yaml
@@ -67,6 +67,7 @@ sharing:
   pinterest: "Pune pe Pinterest"
   reddit: "Postează pe Reddit"
   twitter: "Scrie pe Twitter"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Cele mai noi"

--- a/i18n/ru.yaml
+++ b/i18n/ru.yaml
@@ -73,6 +73,7 @@ sharing:
   pinterest: "Добавить в Pinterest"
   reddit: "Отправить в Reddit"
   twitter: "Твитнуть в Twitter"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Недавние"

--- a/i18n/sv.yaml
+++ b/i18n/sv.yaml
@@ -67,6 +67,7 @@ sharing:
   pinterest: "Fäst på Pinterest"
   reddit: "Skicka till Reddit"
   twitter: "Twittra på Twitter"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Senaste"

--- a/i18n/th.yaml
+++ b/i18n/th.yaml
@@ -78,6 +78,7 @@ sharing:
   bluesky: "โพสต์บน Bluesky"
   whatsapp: "แชร์ทาง WhatsApp"
   telegram: "แชร์ทาง Telegram"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "บทความล่าสุด"

--- a/i18n/tr.yaml
+++ b/i18n/tr.yaml
@@ -62,6 +62,7 @@ sharing:
   pinterest: "Pinterest'te pinle"
   reddit: "Reddit'te gönder"
   twitter: "Twitter'da Tweetle"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Güncel"

--- a/i18n/uk.yaml
+++ b/i18n/uk.yaml
@@ -80,6 +80,7 @@ sharing:
   pinterest: "Зберегти на Pinterest"
   reddit: "Опублікувати на Reddit"
   twitter: "Поширити на Twitter"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Недавні дописи"

--- a/i18n/vi.yaml
+++ b/i18n/vi.yaml
@@ -76,6 +76,7 @@ sharing:
   pinterest: "Ghim lên Pinterest"
   reddit: "Gửi lên Reddit"
   twitter: "Tweet lên Twitter"
+  mastodon: "Share via Mastodon"
 
 shortcode:
   recent_articles: "Gần đây"

--- a/i18n/zh-CN.yaml
+++ b/i18n/zh-CN.yaml
@@ -79,6 +79,7 @@ sharing:
   bluesky: "发布到 Bluesky"
   whatsapp: "通过 WhatsApp 分享"
   telegram: "通过 Telegram 分享"
+  mastodon: "分享到 Mastodon"
 
 shortcode:
   recent_articles: "最近的文章"

--- a/i18n/zh-TW.yaml
+++ b/i18n/zh-TW.yaml
@@ -79,6 +79,7 @@ sharing:
   bluesky: "發布到 Bluesky"
   whatsapp: "以 WhatsApp 分享"
   telegram: "以 Telegram 分享"
+  mastodon: "分享到 Mastodon"
 
 shortcode:
   recent_articles: "最近的文章"

--- a/layouts/partials/sharing-links.html
+++ b/layouts/partials/sharing-links.html
@@ -3,12 +3,17 @@
   <section class="flex flex-row flex-wrap justify-center pt-4 text-xl">
     {{ range . }}
       {{ with index $links . }}
+        {{ $label := i18n .title }}
+        {{ if not $label }}
+          {{ $serviceName := replaceRE "^sharing\\." "" .title | title }}
+          {{ $label = printf "Share via %s" $serviceName }}
+        {{ end }}
         <a
           class="m-1 rounded bg-neutral-300 p-1.5 text-neutral-700 hover:bg-primary-500 hover:text-neutral dark:bg-neutral-700 dark:text-neutral-300 dark:hover:bg-primary-400 dark:hover:text-neutral-800"
           target="_blank"
           href="{{ printf .url $.Permalink $.Title | safeURL }}"
-          title="{{ i18n .title }}"
-          aria-label="{{ i18n .title }}">
+          title="{{ $label }}"
+          aria-label="{{ $label }}">
           {{ partial "icon.html" .icon }}
         </a>
       {{ end }}


### PR DESCRIPTION
## Summary

- Fixes an accessibility issue where sharing links lack a discernible name when translations are missing.
- Adds missing `sharing.mastodon` translations across all language files.

## Changes

- **`layouts/partials/sharing-links.html`**: Added a fallback generator formatted as "Share via [Service]" if the translation is missing.
- **`i18n/*.yaml`**: Added `sharing.mastodon` key-value pairs to 31 files.

## Validation

- Verified that all sharing links expose a discernible `aria-label` under a11y checks.