### PR TITLE
:bug: Fixed custom taxonomies not appearing as badges

### DIFF
--- a/layouts/partials/article-meta/basic.html
+++ b/layouts/partials/article-meta/basic.html
@@ -100,20 +100,26 @@
       {{ range $taxonomy, $terms := .Site.Taxonomies }}
         {{ if (gt (len ($context.GetTerms $taxonomy)) 0) }}
           {{ range $context.GetTerms $taxonomy }}
-            {{ if .Params.showCategories | default (.Site.Params.article.showCategories | default true) }}
-              {{ if (eq $taxonomy "categories") }}
+            {{ if (or (eq $taxonomy "authors") (eq $taxonomy "series"))}}
+              {{/* Ignore authors and series, since they are handled in other places */}}
+              {{ continue }}
+            {{ else if (eq $taxonomy "categories") }}
+              {{ if .Params.showCategories | default (.Site.Params.article.showCategories | default true) }}
                 <a class="relative mt-[0.5rem] me-2" href="{{ .RelPermalink }}">
                   {{ $useSecondaryColor := .Params.showCategoriesInSecondaryColor | default (.Site.Params.article.showCategoriesInSecondaryColor | default false) }}
                   {{ partial "badge.html" (dict "linkTitle" .LinkTitle "useSecondaryColor" $useSecondaryColor) }}
                 </a>
               {{ end }}
-            {{ end }}
-            {{ if .Params.showTags | default (.Site.Params.article.showTags | default true) }}
-              {{ if (eq $taxonomy "tags") }}
+            {{ else if (eq $taxonomy "tags") }}
+              {{ if .Params.showTags | default (.Site.Params.article.showTags | default true) }}
                 <a class="relative mt-[0.5rem] me-2" href="{{ .RelPermalink }}">
                   {{ partial "badge.html" .LinkTitle }}
                 </a>
               {{ end }}
+            {{ else }}
+              <a class="relative mt-[0.5rem] me-2" href="{{ .RelPermalink }}">
+                {{ partial "badge.html" .LinkTitle }}
+              </a>
             {{ end }}
           {{ end }}
         {{ end }}


### PR DESCRIPTION
After the PR https://github.com/nunocoracao/blowfish/pull/2852 I introduced a bug that caused that custom taxonomies would not appear as badges in an article. This was reported in issue https://github.com/nunocoracao/blowfish/issues/2959.

The proposed solution in the issue had another problem: `authors` and `series` taxonomies would appear duplicated because those are already handled in other places in the code.

I've implemented a fix that should fix all cases. The screenshot shows an article that has category, tags, authors, series and a custom taxonomy:

<img width="463" height="192" alt="image" src="https://github.com/user-attachments/assets/d32e010c-48a3-487b-b589-40302e91ac90" />

As seen, the authors taxonomies are not duplicated, series don't appear as badges, as it already appears in the series list below, and custom taxonomies are shown.

Also, custom taxonomies will show as long as the `showTaxonomies` parameter is true. There's some extra granularity for categories and tags with the `showCategories` and `showTags` parameters, but maybe it would be too much to have more parameters for any kind of taxonomy. For now, I just decided to leave it like this so the bug is fixed. At some other point it can be considered if it's necessary to add extra granularity for custom taxonomies.