### PR TITLE
feat: allow single pages without TOC to use full content width

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,5 +1,9 @@
 {{ define "main" }}
   {{ .Scratch.Set "scope" "single" }}
+  {{ $enableToc := site.Params.article.showTableOfContents | default false }}
+  {{ $enableToc = .Params.showTableOfContents | default $enableToc }}
+  {{ $showToc := and $enableToc (in .TableOfContents "<ul") }}
+  {{ $contentWidth := cond $showToc "max-w-prose" "max-w-full w-full" }}
   <article>
     {{/* Hero */}}
     {{ if .Params.showHero | default (site.Params.article.showHero | default false) }}
@@ -14,7 +18,7 @@
     {{ end }}
 
     {{/* Header */}}
-    <header id="single_header" class="mt-5 max-w-prose">
+    <header id="single_header" class="mt-5 {{ $contentWidth }}">
       {{ if .Params.showBreadcrumbs | default (site.Params.article.showBreadcrumbs | default false) }}
         {{ partial "breadcrumbs.html" . }}
       {{ end }}
@@ -31,9 +35,6 @@
 
     {{/* Body */}}
     <section class="flex flex-col max-w-full mt-0 prose dark:prose-invert lg:flex-row">
-      {{ $enableToc := site.Params.article.showTableOfContents | default false }}
-      {{ $enableToc = .Params.showTableOfContents | default $enableToc }}
-      {{ $showToc := and $enableToc (in .TableOfContents "<ul") }}
       {{ $topClass := cond (hasPrefix site.Params.header.layout "fixed") "lg:top-[140px]" "lg:top-10" }}
       {{ if $showToc }}
         <div class="order-first lg:ms-auto px-0 lg:order-last lg:ps-8 lg:max-w-2xs">
@@ -44,9 +45,9 @@
       {{ end }}
 
 
-      <div class="min-w-0 min-h-0 max-w-fit">
+      <div class="min-w-0 min-h-0 {{ cond $showToc "max-w-fit" "w-full max-w-full" }}">
         {{ partial "series/series.html" . }}
-        <div class="article-content max-w-prose mb-20">
+        <div class="article-content {{ $contentWidth }} mb-20">
           {{ .Content }}
           {{ $defaultReplyByEmail := site.Params.replyByEmail }}
           {{ $replyByEmail := default $defaultReplyByEmail .Params.replyByEmail }}
@@ -79,7 +80,7 @@
     </section>
 
     {{/* Footer */}}
-    <footer class="pt-8 max-w-prose print:hidden">
+    <footer class="pt-8 {{ $contentWidth }} print:hidden">
       {{ partial "article-pagination.html" . }}
       {{ if .Params.showComments | default (site.Params.article.showComments | default false) }}
         {{ if templates.Exists "partials/comments.html" }}


### PR DESCRIPTION
This PR updates the single article layout so pages without a visible table of contents can use the full available content width.

Currently, `single.html` always applies `max-w-prose` to the article header, content, and footer, and the main content wrapper always uses `max-w-fit`. That works well when a table of contents is displayed, but unnecessarily constrains pages where the TOC is disabled or not generated.

The change computes the TOC visibility once near the top of the template and reuses it to set the layout width:

- when the TOC is shown, the existing constrained `max-w-prose` / `max-w-fit` behavior is preserved;
- when the TOC is not shown, the header, article content, footer, and content wrapper can expand to `max-w-full w-full`.

This makes single pages without a TOC better suited for wider content such as custom shortcodes, media, embeds, tables, or layouts that should not be limited to prose width.

## Issue ticket number and link

No issue.

## Checklist before requesting a review

 - [x] I have performed a self-review of my code
 - [ ] Will this be part of a product update? If yes, please write one phrase about this update.
