### PR TITLE
Address #3023 - adds <header> and main menu <nav>

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -19,12 +19,14 @@
         {{ i18n "nav.skip_to_main" }}
       </a>
     </div>
-    {{ $header := print "header/" site.Params.header.layout ".html" }}
-    {{ if templates.Exists ( printf "partials/%s" $header ) }}
-      {{ partial $header . }}
-    {{ else }}
-      {{ partial "header/basic.html" . }}
-    {{ end }}
+    <header>
+      {{ $header := print "header/" site.Params.header.layout ".html" }}
+      {{ if templates.Exists ( printf "partials/%s" $header ) }}
+        {{ partial $header . }}
+      {{ else }}
+        {{ partial "header/basic.html" . }}
+      {{ end }}
+    </header>
     <div class="relative flex flex-col grow">
       <main id="main-content" class="grow">
         {{ block "main" . }}{{ end }}

--- a/layouts/partials/header/basic.html
+++ b/layouts/partials/header/basic.html
@@ -37,30 +37,33 @@
 </div>
 
 {{ if .Site.Menus.subnavigation }}
-  <div
-    class="main-menu flex pb-3 flex-col items-end justify-between md:justify-start space-x-3 {{ if .Site.Params.Logo }}
-      -mt-[15px]
-    {{ end }}">
-    <div class="hidden md:flex items-center space-x-5">
-      {{ range .Site.Menus.subnavigation }}
-        <a
-          href="{{ .URL }}"
-          {{ if or (strings.HasPrefix .URL "http:" ) (strings.HasPrefix .URL "https:" ) }}
-            target="_blank"
-          {{ end }}
-          class="flex items-center bf-icon-color-hover">
-          {{ if .Pre }}
-            <span {{ if and .Pre .Name }}class="mr-1"{{ end }}>
-              {{ partial "icon.html" .Pre }}
+  <nav id="main-menu">
+    <div
+      id="main-menu"
+      class="main-menu flex pb-3 flex-col items-end justify-between md:justify-start space-x-3 {{ if .Site.Params.Logo }}
+        -mt-[15px]
+      {{ end }}">
+      <div class="hidden md:flex items-center space-x-5">
+        {{ range .Site.Menus.subnavigation }}
+          <a
+            href="{{ .URL }}"
+            {{ if or (strings.HasPrefix .URL "http:" ) (strings.HasPrefix .URL "https:" ) }}
+              target="_blank"
+            {{ end }}
+            class="flex items-center bf-icon-color-hover">
+            {{ if .Pre }}
+              <span {{ if and .Pre .Name }}class="mr-1"{{ end }}>
+                {{ partial "icon.html" .Pre }}
+              </span>
+            {{ end }}
+            <span class="text-xs font-light" title="{{ .Title }}">
+              {{ .Name | markdownify }}
             </span>
-          {{ end }}
-          <span class="text-xs font-light" title="{{ .Title }}">
-            {{ .Name | markdownify }}
-          </span>
-        </a>
-      {{ end }}
+          </a>
+        {{ end }}
+      </div>
     </div>
-  </div>
+  </nav>
 {{ end }}
 
 {{ if .Site.Params.highlightCurrentMenuArea }}


### PR DESCRIPTION
Better (hopefully) version of PR https://github.com/nunocoracao/blowfish/pull/3025

Improve a11y by adding a `<header>` tag around the entire page header section, and a `<nav>` referencing the main menu section.

The diff without whitespace noise:

```sh
blowfish on  add-a11y-landmarks is 📦 v2.105.0 via 🐹 v1.26.5-X:nodwarf5 via  v26.5.0
🐟  chrish@moon ❯ git diff --ignore-all-space main
diff --git a/layouts/_default/baseof.html b/layouts/_default/baseof.html
index 8939fb31..4bbe6121 100644
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -19,12 +19,14 @@
         {{ i18n "nav.skip_to_main" }}
       </a>
     </div>
+    <header>
       {{ $header := print "header/" site.Params.header.layout ".html" }}
       {{ if templates.Exists ( printf "partials/%s" $header ) }}
         {{ partial $header . }}
       {{ else }}
         {{ partial "header/basic.html" . }}
       {{ end }}
+    </header>
     <div class="relative flex flex-col grow">
       <main id="main-content" class="grow">
         {{ block "main" . }}{{ end }}
diff --git a/layouts/partials/header/basic.html b/layouts/partials/header/basic.html
index 9c9c9f13..6e4c53ac 100644
--- a/layouts/partials/header/basic.html
+++ b/layouts/partials/header/basic.html
@@ -37,7 +37,9 @@
 </div>

 {{ if .Site.Menus.subnavigation }}
+  <nav id="main-menu">
     <div
+      id="main-menu"
       class="main-menu flex pb-3 flex-col items-end justify-between md:justify-start space-x-3 {{ if .Site.Params.Logo }}
         -mt-[15px]
       {{ end }}">
@@ -61,6 +63,7 @@
         {{ end }}
       </div>
     </div>
+  </nav>
 {{ end }}

 {{ if .Site.Params.highlightCurrentMenuArea }}
```
