### PR TITLE
Address #3033 - suppress default author when using multi-author

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -109,29 +109,31 @@
     {{ $baseURL = delimit (slice $baseURL "/") "" }}
   {{ end }}
 
-  {{ if .Params.showAuthor | default (site.Params.article.showAuthor | default true) }}
-    {{ $showAuthor = 1 }}
-    {{ partial "author.html" . }}
-  {{ end }}
-
-  {{ range $author := .Page.Params.authors }}
-    {{ $authorData := index $authorsData $author }}
-    {{- if $authorData -}}
-      {{ range $taxonomyname, $taxonomy := $taxonomies }}
-        {{ if (eq $taxonomyname $author) }}
-          {{ $taxonomyLink = delimit (slice $baseURL "authors/" $author "/") "" }}
+  {{ if .Page.Params.authors }}
+    {{ range $author := .Page.Params.authors }}
+      {{ $authorData := index $authorsData $author }}
+      {{- if $authorData -}}
+        {{ range $taxonomyname, $taxonomy := $taxonomies }}
+          {{ if (eq $taxonomyname $author) }}
+            {{ $taxonomyLink = delimit (slice $baseURL "authors/" $author "/") "" }}
+          {{ end }}
         {{ end }}
-      {{ end }}
 
-      {{ $finalLink := $taxonomyLink }}
-      {{ $currentLang := site.Language.Name }}
-      {{ if eq site.LanguagePrefix "" }}
-        {{ $finalLink = printf "%sauthors/%s/" $baseURL $author }}
-      {{ else }}
-        {{ $finalLink = printf "%s%s/authors/%s/" $baseURL $currentLang $author }}
-      {{ end }}
-      {{ partial "author-extra.html" (dict "context" . "data" $authorData "link" $finalLink) }}
-    {{- end -}}
+        {{ $finalLink := $taxonomyLink }}
+        {{ $currentLang := site.Language.Name }}
+        {{ if eq site.LanguagePrefix "" }}
+          {{ $finalLink = printf "%sauthors/%s/" $baseURL $author }}
+        {{ else }}
+          {{ $finalLink = printf "%s%s/authors/%s/" $baseURL $currentLang $author }}
+        {{ end }}
+        {{ partial "author-extra.html" (dict "context" . "data" $authorData "link" $finalLink) }}
+      {{- end -}}
+    {{ end }}
+  {{ else }}
+    {{ if .Params.showAuthor | default (site.Params.article.showAuthor | default true) }}
+      {{ $showAuthor = 1 }}
+      {{ partial "author.html" . }}
+    {{ end }}
   {{ end }}
 
   {{ if or $taxonomyLink $showAuthor }}


### PR DESCRIPTION
If a page has `authors` set, use that instead of the site's `author` parameter, otherwise use the `author` parameter.

Without the whitespace:

```sh
blowfish on  multi-author-no-default [!] is 📦 v2.105.0 via 🐹 v1.26.5-X:nodwarf5 via  v26.5.0
🐟  chrish@moon ❯ git diff --ignore-all-space main
diff --git a/layouts/_default/single.html b/layouts/_default/single.html
index 95389091..843e0b0c 100644
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -109,11 +109,7 @@
     {{ $baseURL = delimit (slice $baseURL "/") "" }}
   {{ end }}

-  {{ if .Params.showAuthor | default (site.Params.article.showAuthor | default true) }}
-    {{ $showAuthor = 1 }}
-    {{ partial "author.html" . }}
-  {{ end }}
-
+  {{ if .Page.Params.authors }}
     {{ range $author := .Page.Params.authors }}
       {{ $authorData := index $authorsData $author }}
       {{- if $authorData -}}
@@ -133,6 +129,12 @@
         {{ partial "author-extra.html" (dict "context" . "data" $authorData "link" $finalLink) }}
       {{- end -}}
     {{ end }}
+  {{ else }}
+    {{ if .Params.showAuthor | default (site.Params.article.showAuthor | default true) }}
+      {{ $showAuthor = 1 }}
+      {{ partial "author.html" . }}
+    {{ end }}
+  {{ end }}

   {{ if or $taxonomyLink $showAuthor }}
     <div class="{{ cond $isAuthorBottom "mb-10" "mb-5" }}"></div>
```
