### PR TITLE
Improve Largest Contentful Paint (LCP) performance for homepage profile images.

### DIFF
--- a/layouts/partials/home/background.html
+++ b/layouts/partials/home/background.html
@@ -62,6 +62,8 @@
                 width="144"
                 height="144"
                 alt="{{ $.Site.Params.Author.name | default `Author` }}"
+                loading="eager"
+                fetchpriority="high"
                 src="{{ $final.RelPermalink }}"
                 data-zoom-src="{{ $squareImage.RelPermalink }}">
             {{ end }}

--- a/layouts/partials/home/hero.html
+++ b/layouts/partials/home/hero.html
@@ -65,6 +65,8 @@
                 width="144"
                 height="144"
                 alt="{{ $.Site.Params.Author.name | default `Author` }}"
+                loading="eager"
+                fetchpriority="high"
                 src="{{ $final.RelPermalink }}"
                 data-zoom-src="{{ $squareImage.RelPermalink }}">
             {{ end }}

--- a/layouts/partials/home/profile.html
+++ b/layouts/partials/home/profile.html
@@ -24,6 +24,8 @@
           width="144"
           height="144"
           alt="{{ $.Site.Params.Author.name | default `Author` }}"
+          loading="eager"
+          fetchpriority="high"
           src="{{ $final.RelPermalink }}"
           data-zoom-src="{{ $squareImage.RelPermalink }}">
       {{ end }}


### PR DESCRIPTION
  - Set `loading="eager"` to prevent lazy loading.
  - Set `fetchpriority="high"` to prioritize the LCP resource.
  - Apply the optimization to the `profile`, `hero`, and `background` homepage layouts.