### PR TITLE
🚚 Move RussellChubb.com entry to keep users list in order

### DIFF
--- a/exampleSite/content/users/users.json
+++ b/exampleSite/content/users/users.json
@@ -8,14 +8,6 @@
       "Theme author"
     ]
   },
-    {
-    "title": "RussellChubb.com",
-    "url": "https://russellchubb.com",
-    "source": "n/a",
-    "tags": [
-      "Personal site"
-    ]
-  },
   {
     "title": "madoke.org",
     "url": "https://madoke.org/",
@@ -1113,6 +1105,14 @@
     "tags": [
       "Personal site",
       "Blog"
+    ]
+  },
+  {
+    "title": "RussellChubb.com",
+    "url": "https://russellchubb.com",
+    "source": "n/a",
+    "tags": [
+      "Personal site"
     ]
   },
   {


### PR DESCRIPTION
#3035 inserted the entry near the top of `users.json`, but the list is chronological (append at the end). This moves it to the end — before or1k.net (#3038), matching PR order — and fixes the off-indentation it introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)