### PR TITLE
♿️ Add header and main menu nav landmarks

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -60,6 +60,7 @@ list:
   no_articles: "There are no articles to list here yet."
 
 nav:
+  main_menu: "Main menu"
   scroll_to_top_title: "Scroll to top"
   skip_to_main: "Skip to main content"
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -19,12 +19,14 @@
         {{ i18n "nav.skip_to_main" }}
       </a>
     </div>
-    {{ $header := print "header/" site.Params.header.layout ".html" }}
-    {{ if templates.Exists ( printf "partials/%s" $header ) }}
-      {{ partial $header . }}
-    {{ else }}
-      {{ partial "header/basic.html" . }}
-    {{ end }}
+    <header>
+      {{ $header := print "header/" site.Params.header.layout ".html" }}
+      {{ if templates.Exists ( printf "partials/%s" $header ) }}
+        {{ partial $header . }}
+      {{ else }}
+        {{ partial "header/basic.html" . }}
+      {{ end }}
+    </header>
     <div class="relative flex flex-col grow">
       <main id="main-content" class="grow">
         {{ block "main" . }}{{ end }}

--- a/layouts/partials/header/basic.html
+++ b/layouts/partials/header/basic.html
@@ -37,30 +37,32 @@
 </div>
 
 {{ if .Site.Menus.subnavigation }}
-  <div
-    class="main-menu flex pb-3 flex-col items-end justify-between md:justify-start space-x-3 {{ if .Site.Params.Logo }}
-      -mt-[15px]
-    {{ end }}">
-    <div class="hidden md:flex items-center space-x-5">
-      {{ range .Site.Menus.subnavigation }}
-        <a
-          href="{{ .URL }}"
-          {{ if or (strings.HasPrefix .URL "http:" ) (strings.HasPrefix .URL "https:" ) }}
-            target="_blank"
-          {{ end }}
-          class="flex items-center bf-icon-color-hover">
-          {{ if .Pre }}
-            <span {{ if and .Pre .Name }}class="mr-1"{{ end }}>
-              {{ partial "icon.html" .Pre }}
+  <nav id="main-menu" aria-label="{{ i18n "nav.main_menu" }}">
+    <div
+      class="main-menu flex pb-3 flex-col items-end justify-between md:justify-start space-x-3 {{ if .Site.Params.Logo }}
+        -mt-[15px]
+      {{ end }}">
+      <div class="hidden md:flex items-center space-x-5">
+        {{ range .Site.Menus.subnavigation }}
+          <a
+            href="{{ .URL }}"
+            {{ if or (strings.HasPrefix .URL "http:" ) (strings.HasPrefix .URL "https:" ) }}
+              target="_blank"
+            {{ end }}
+            class="flex items-center bf-icon-color-hover">
+            {{ if .Pre }}
+              <span {{ if and .Pre .Name }}class="mr-1"{{ end }}>
+                {{ partial "icon.html" .Pre }}
+              </span>
+            {{ end }}
+            <span class="text-xs font-light" title="{{ .Title }}">
+              {{ .Name | markdownify }}
             </span>
-          {{ end }}
-          <span class="text-xs font-light" title="{{ .Title }}">
-            {{ .Name | markdownify }}
-          </span>
-        </a>
-      {{ end }}
+          </a>
+        {{ end }}
+      </div>
     </div>
-  </div>
+  </nav>
 {{ end }}
 
 {{ if .Site.Params.highlightCurrentMenuArea }}


### PR DESCRIPTION
Adopts #3032 by @Taffer (addresses #3023) with two small fixes on top:
- removed the duplicate `id="main-menu"` (it was on both the new `<nav>` and the inner `<div>`, which is invalid HTML) — kept on the `<nav>` only
- added `aria-label` to the nav via a new `nav.main_menu` i18n key (English; other languages fall back)

All four `fixed*` header layouts delegate to `basic.html`, so the nav landmark covers every header variant. No CSS or JS references the id — the `highlightCurrentMenuArea` script selects by `.main-menu` class, which is unchanged.

Verified with a Hugo build of the example site (with a temporary subnavigation menu): exactly one `id="main-menu"`, nav labelled, `<header>` wrapping the header partial.

Commit carries `Co-authored-by` credit to @Taffer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)