### PR TITLE
3.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hugo-blowfish-theme",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hugo-blowfish-theme",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hugo-blowfish-theme",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Blowfish theme for Hugo.",
   "scripts": {
     "postinstall": "vendor-copy",


### PR DESCRIPTION
## Summary

- bump Blowfish release version to 3.2.0
- keep npm package and lockfile metadata aligned

## Validation

- `node` package/lockfile version consistency check
- `git diff --check`