### PR TITLE
🐛 Balance the padding of the desktop dropdown menu

### DIFF
--- a/layouts/partials/header/components/desktop-menu.html
+++ b/layouts/partials/header/components/desktop-menu.html
@@ -77,7 +77,7 @@
         </a>
       </div>
       <div class="menuhide">
-        <div class="pt-2 p-5 mt-2 rounded-xl border border-neutral-200/80 bg-neutral/95 shadow-2xl shadow-neutral-900/20 dark:border-neutral-700/80 dark:bg-neutral-800/95">
+        <div class="p-5 mt-2 rounded-xl border border-neutral-200/80 bg-neutral/95 shadow-2xl shadow-neutral-900/20 dark:border-neutral-700/80 dark:bg-neutral-800/95">
           <div class="flex flex-col space-y-3">
             {{ range .Children }}
               <a


### PR DESCRIPTION

## Describe your changes

The desktop submenu panel in `layouts/partials/header/components/desktop-menu.html` carries both `pt-2` and `p-5`:

```html
<div class="pt-2 p-5 mt-2 rounded-xl border ...">
```

In the compiled stylesheet `.pt-2` comes after `.p-5`, so it wins the cascade and the panel renders with `padding-top: 0.5rem` against `1.25rem` on the other three sides. The first submenu entry sits closer to the top edge. 

This was invisible while the panel was translucent (`bg-neutral/25`). v3 made it opaque (`bg-neutral/95`) and added a border, which draws the edge and exposes the imbalance.

Removing `pt-2` gives the panel even padding on all four sides.

`pt-2` is still used by `article-link/_shortcode.html`, so removing it here does not drop the rule from the compiled stylesheet: I reran `npm run build` and the output is byte-identical to the committed `assets/css/compiled/main.css`.

## Verification

Measured with `getComputedStyle` on the example site (`npm run example`), hovering the nested `Examples` menu:

|        | `padding-top` | right / bottom / left | panel height |
| ------ | ------------- | --------------------- | ------------ |
| before | `8px`         | `20px`                | 114px        |
| after  | `20px`        | `20px`                | 126px        |


### Screenshots
Before:
<img width="700" height="260" alt="menu-before" src="https://github.com/user-attachments/assets/6b56bdad-f7eb-4810-bbbb-1f282d908c03" />

After:
<img width="700" height="260" alt="menu-after" src="https://github.com/user-attachments/assets/412f6bc4-fa8d-4cb3-8b22-dcaffd16ae8f" />

(The same `pt-N p-5` pattern appears in the `codeberg`, `forgejo`, `gitea`, `gitlab` and `ansible` shortcodes. Those cards read fine as they are, so I left them.)

## Issue ticket number and link

None. I searched open and closed issues and PRs and found nothing covering this.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Will this be part of a product update? If yes, please write one phrase about this update.

Desktop submenu panel (header bar) has now even padding on all four sides.