### PR TITLE
🐛 Close the mobile dropdown menu when clicking outside it

### DIFF
--- a/assets/js/menu-a11y.js
+++ b/assets/js/menu-a11y.js
@@ -45,6 +45,19 @@
     });
   }
 
+  function setupMobileMenuOutsideClick() {
+    var toggle = document.getElementById("mobile-menu-toggle");
+    var dialog = document.getElementById("mobile-menu-dialog");
+    if (!toggle || !dialog) return;
+    document.addEventListener("click", function (event) {
+      if (!toggle.checked || event.target === toggle) return;
+      if (dialog.contains(event.target)) return;
+      if (event.target.closest('label[for="mobile-menu-toggle"]')) return;
+      toggle.checked = false;
+      syncCheckboxLabels(toggle);
+    });
+  }
+
   function setupDesktopDropdowns() {
     document.querySelectorAll(".nested-menu").forEach(function (menu) {
       var trigger = menu.querySelector("[aria-haspopup]");
@@ -78,6 +91,7 @@
   function init() {
     setupCheckboxLabels();
     setupMobileMenuEscape();
+    setupMobileMenuOutsideClick();
     setupDesktopDropdowns();
   }
 


### PR DESCRIPTION
## Describe your changes

With `header.mobileMenuStyle = "dropdown"`, the panel only closes through its own X button. `setupMobileMenuEscape()` already dismisses it with the keyboard, so the missing pointer equivalent leaves the panel sitting over the page after a stray tap.

This adds `setupMobileMenuOutsideClick()` next to the existing Escape handler in `assets/js/menu-a11y.js`. It closes the toggle on any click landing outside the panel and outside the labels that control it, then calls the existing `syncCheckboxLabels()` so `aria-expanded` stays correct.

The fullscreen panel needs no special case. It covers the viewport, so every click lands inside it and the handler stays inert.

## Verification

Checked by hand on `npm run example` in Chromium, viewport 390x780, with `mobileMenuStyle` set to each value in turn.

With `dropdown`:

1. Open the menu from the hamburger, then click anywhere on the page outside the panel. It closes, and `aria-expanded` goes back to `false`.
2. Open it again and click inside the panel. It stays open.
3. The X button and Escape still close it, and menu links still navigate.
4. Click the hamburger four times in a row. It still alternates open and closed.

With `fullscreen`, the same steps behave as they do on `main`. The panel covers the viewport, so every click lands inside it and the new handler never fires.

One file, no template or stylesheet change, and `prettier --check` passes on it.

## Issue ticket number and link

None.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Will this be part of a product update? If yes, please write one phrase about this update.

The mobile dropdown menu now closes when you click outside it.