### PR TITLE
fix: katex not rendering

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -188,9 +188,7 @@
   {{ if .Site.Params.rtl | default false }}
     {{ $jsResources = $jsResources | append (resources.Get "js/rtl.js") }}
   {{ end }}
-  {{ if .Page.HasShortcode "katex" }}
-    {{ $jsResources = $jsResources | append (resources.Get "js/katex-render.js") }}
-  {{ end }}
+  {{ $jsResources = $jsResources | append (resources.Get "js/katex-render.js") }}
   {{ $jsResources = $jsResources | append (resources.Get "js/menu-a11y.js") }}
   {{ $jsResources = $jsResources | append (resources.Get "js/print-support.js") }}
   {{ $jsResources = $jsResources | append (resources.Get "js/email.js") }}


### PR DESCRIPTION
Close #3062

Conditionally loading a global JS on a per-page basis is the wrong approach.