### PR TITLE
Fix KaTeX not rendering due to shared bundle cache collision

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -188,9 +188,7 @@
   {{ if .Site.Params.rtl | default false }}
     {{ $jsResources = $jsResources | append (resources.Get "js/rtl.js") }}
   {{ end }}
-  {{ if .Page.HasShortcode "katex" }}
-    {{ $jsResources = $jsResources | append (resources.Get "js/katex-render.js") }}
-  {{ end }}
+  {{ $jsResources = $jsResources | append (resources.Get "js/katex-render.js") }}
   {{ $jsResources = $jsResources | append (resources.Get "js/menu-a11y.js") }}
   {{ $jsResources = $jsResources | append (resources.Get "js/print-support.js") }}
   {{ $jsResources = $jsResources | append (resources.Get "js/email.js") }}


### PR DESCRIPTION
katex-render.js was the only per-page conditional input to the resources.Concat "js/main.bundle.js" target. Hugo caches Concat output by target path, so whichever page Hugo processes first for that path determines the bundle for every page on the site - silently dropping the katex render call on pages that need it whenever a non-katex page is built first.