### PR TITLE
🐛 Render HTML in series widget titles

### DIFF
--- a/layouts/partials/series/series_base.html
+++ b/layouts/partials/series/series_base.html
@@ -17,7 +17,7 @@
         class="py-1 border-dotted border-neutral-300 border-s-1 -ms-5 ps-5 dark:border-neutral-600">
         <a href="{{ $post.RelPermalink }}">
           {{ i18n "article.part" }} {{ $post.Params.series_order }}:
-          {{ $post.Params.title }}
+          {{ $post.Title | emojify }}
         </a>
       </div>
     {{ end }}


### PR DESCRIPTION
## Summary
The series widget printed `{{ $post.Params.title }}`, which Hugo HTML-escapes. Front-matter titles that include markup (for example `<br>` and `<small>` for a subtitle) showed as literal tags in the series list, while the article heading and prev/next links already used `{{ .Title | emojify }}` and rendered correctly.

## Change
Use `{{ $post.Title | emojify }}` in `layouts/partials/series/series_base.html` so series links match the rest of the theme.

## Test plan
- [x] Add HTML to a series post `title` in the example site (or any site using series)
- [x] Confirm the series widget renders the markup instead of showing raw tags
- [x] Confirm plain-text titles are unchanged
