### PR TITLE
🐛 Guard event.key before toLowerCase in search keydown handler

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -42,7 +42,7 @@ document.addEventListener("keydown", function (event) {
   }
 
   // Cmd+K (macOS) / Ctrl+K to toggle search wrapper
-  if (event.key.toLowerCase() == "k" && (event.metaKey || event.ctrlKey)) {
+  if (event.key && event.key.toLowerCase() == "k" && (event.metaKey || event.ctrlKey)) {
     event.preventDefault();
     if (searchVisible) {
       hideSearch();


### PR DESCRIPTION
## Describe your changes

The global `keydown` handler in `assets/js/search.js` calls `event.key.toLowerCase()` without first checking that `event.key` is defined. Some `keydown` events carry no `key` property — notably browser autofill, IME composition, and some mobile virtual-keyboard inputs — which throws `TypeError: Cannot read properties of undefined (reading 'toLowerCase')` and breaks the handler for that keystroke.

This adds a truthiness guard (`event.key && …`) before calling `toLowerCase()`, matching the defensive style already used by the other `event.key` comparisons in the same handler. No behavior change for real Cmd/Ctrl+K presses.

```diff
-  if (event.key.toLowerCase() == "k" && (event.metaKey || event.ctrlKey)) {
+  if (event.key && event.key.toLowerCase() == "k" && (event.metaKey || event.ctrlKey)) {
```

## Issue ticket number and link

_None — filing the fix directly. Happy to open an issue first if preferred._

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Will this be part of a product update? Fixes a crash in the search shortcut handler for keydown events without a `key` value (autofill / IME / mobile).