### PR TITLE
feat: add llms.txt discovery link

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -54,6 +54,9 @@
       safeHTML
     }}
   {{ end }}
+  {{ with site.Home.OutputFormats.Get "LLMS" }}
+    <link rel="describedby" href="{{ .RelPermalink }}">
+  {{ end }}
 
   {{/* Me */}}
   {{ with .Site.Params.Author.name }}


### PR DESCRIPTION
Adds a guarded `rel="describedby"` link to the site's existing LLMS output.

The link is emitted only when the `LLMS` output format is enabled, so sites without `llms.txt` are unchanged.

Tested: `hugo --minify` against the full multilingual example site.