### PR TITLE
:bug: Fix smartTOC never highlighting on a page that can't scroll

### DIFF
--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -36,6 +36,21 @@
     let isJumpingToAnchor = false
 
     function getActiveAnchorId(anchors, offsetRatio) {
+      // On a page short enough that it never scrolls, scroll position can
+      // never change, so the loop below can never pick a different entry.
+      // Clicking a TOC entry still changes the hash, so fall back to that
+      // when scrolling can't answer the question at all - honoured only if
+      // it names an entry the TOC actually lists, so an unrelated hash
+      // doesn't fake a match. Pages that do scroll are unaffected.
+      const canScroll =
+        document.documentElement.scrollHeight > window.innerHeight + 1
+      if (!canScroll) {
+        const fromHash = decodeURIComponent(window.location.hash.substring(1))
+        const known = [...document.querySelectorAll('#TableOfContents a[href^="#"]')]
+          .map(link => decodeURIComponent(link.getAttribute('href').substring(1)))
+        if (fromHash && known.includes(fromHash)) return fromHash
+      }
+
       const threshold = window.scrollY + window.innerHeight * offsetRatio
       const tocLinks = [...document.querySelectorAll('#TableOfContents a[href^="#"]')]
       const tocIds = new Set(tocLinks.map(link => link.getAttribute('href').substring(1)))


### PR DESCRIPTION
Fixes #3087.

`getActiveAnchorId` derives the active entry from scroll position alone. On
a page short enough that `scrollHeight` never exceeds `innerHeight`, that
answer can never change — clicking a TOC entry still updates
`location.hash`, but nothing ever picks it up as active, so the menu reads
as permanently broken.

This is a different root cause than #2571 (closed stale): that one's about
a scrollable page whose last header never gets enough room below it to
cross the `offsetRatio` threshold. This one is a page that can't scroll at
all, so no threshold-based approach can ever fire regardless of tuning.

## What changed

`getActiveAnchorId` now falls back to `location.hash` when the document
can't scroll, honoured only if it names an entry the TOC actually lists —
so an unrelated hash on the page doesn't fake a match. Pages that do
scroll are completely unaffected; the new branch only runs when scroll
position genuinely can't answer the question.

## Testing

Manually verified against a short page (two headings, no scroll) with
`smartTOC = true`: before the fix, clicking either TOC entry left both
unhighlighted; after, the clicked entry highlights and stays highlighted.
A page long enough to scroll was unaffected before and after.

We've been carrying this as a local override on our own site
(`layouts/partials/toc.html`, shadowing the theme's copy) for a while and
it's held up fine there.