### PR TITLE
fix: ignoreFiles in development config

### DIFF
--- a/exampleSite/config/development/hugo.toml
+++ b/exampleSite/config/development/hugo.toml
@@ -2,4 +2,4 @@
 # https://gohugo.io/quick-reference/glossary/#environment
 
 # Exclude folders containing large numbers of images
-ignoreFiles = ['content/guides', 'content/users']
+ignoreFiles = ['content/users']


### PR DESCRIPTION
Articles in `guides` are referenced now so remove them from `ignoreFiles`.
