### PR TITLE
fix: performance regression introduced in v3

### DIFF
--- a/assets/css/compiled/main.css
+++ b/assets/css/compiled/main.css
@@ -2071,6 +2071,9 @@
   .bg-white\/60 {
     background-color: color-mix(in oklab, #fff 60%, transparent);
   }
+  .bg-white\/85 {
+    background-color: color-mix(in oklab, #fff 85%, transparent);
+  }
   .bg-linear-60 {
     --tw-gradient-position: 60deg;
     @supports (background-image: linear-gradient(in lab, red, red)) {
@@ -3489,6 +3492,12 @@
     background-color: color-mix(in srgb, rgba(rgba(var(--color-neutral-900), 1), 1) 50%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
       background-color: color-mix(in oklab, rgba(var(--color-neutral-900), 1) 50%, transparent);
+    }
+  }
+  .dark\:bg-neutral-900\/80:is(.dark *) {
+    background-color: color-mix(in srgb, rgba(rgba(var(--color-neutral-900), 1), 1) 80%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, rgba(var(--color-neutral-900), 1) 80%, transparent);
     }
   }
   .dark\:bg-neutral-900\/99:is(.dark *) {

--- a/layouts/partials/article-link/card.html
+++ b/layouts/partials/article-link/card.html
@@ -67,7 +67,7 @@
 
 
 <article
-  class="article-link--card group relative min-h-full min-w-full overflow-hidden rounded-lg border border-neutral-300/80 bg-white/60 backdrop-blur-xl dark:border-neutral-600/80 dark:bg-neutral-900/50">
+  class="article-link--card group relative min-h-full min-w-full overflow-hidden rounded-lg border border-neutral-300/80 bg-white/85 dark:border-neutral-600/80 dark:bg-neutral-900/80">
   {{ with $featuredURL }}
     <div
       class="flex-none relative overflow-hidden thumbnail_card"


### PR DESCRIPTION
Related: #3086

This PR does NOT fix #3086

Overuse of backdrop-blur causes severe performance issues, since the blur is recalculated in real time for every affected area, causing stutter on an M1 Mac even when just scrolling.

The fix replaces backdrop-blur with a solid-color background to simulate the blur effect. This PR only fixes the regression in the card component. New components such as `stats` and `feature` shortcode have the same issue, but this PR does not address them.